### PR TITLE
Fix AI message screenshot to capture only the assistant answer

### DIFF
--- a/src/components/AIChat/chat/ChatMessage.vue
+++ b/src/components/AIChat/chat/ChatMessage.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
+import type { ComponentPublicInstance } from 'vue'
 import { useI18n } from 'vue-i18n'
 import dayjs from 'dayjs'
 import MarkdownIt from 'markdown-it'
@@ -92,6 +93,25 @@ const visibleBlocks = computed(() => {
 const useBlocksRendering = computed(() => {
   return props.role === 'assistant' && visibleBlocks.value.length > 0
 })
+
+const answerCaptureElement = ref<HTMLElement | null>(null)
+
+const answerCaptureBlockIndex = computed(() => {
+  for (let i = visibleBlocks.value.length - 1; i >= 0; i--) {
+    if (visibleBlocks.value[i].type === 'text') return i
+  }
+  return -1
+})
+
+const canCaptureAnswer = computed(() => {
+  if (props.isStreaming || props.role !== 'assistant' || !props.showCaptureButton) return false
+  if (useBlocksRendering.value) return answerCaptureBlockIndex.value >= 0
+  return props.content.trim().length > 0
+})
+
+function setAnswerCaptureElement(el: Element | ComponentPublicInstance | null) {
+  answerCaptureElement.value = el instanceof HTMLElement ? el : null
+}
 
 function getToolDisplayName(tool: ToolBlockContent): string {
   return te(`ai.chat.message.tools.${tool.name}`) ? t(`ai.chat.message.tools.${tool.name}`) : tool.displayName
@@ -341,7 +361,11 @@ async function handleCopyMarkdown() {
         <div class="space-y-2">
           <template v-for="(block, idx) in visibleBlocks" :key="idx">
             <!-- 文本块 -->
-            <div v-if="block.type === 'text'" class="py-1 text-gray-900 dark:text-gray-100">
+            <div
+              v-if="block.type === 'text'"
+              :ref="idx === answerCaptureBlockIndex ? setAnswerCaptureElement : undefined"
+              class="py-1 text-gray-900 dark:text-gray-100"
+            >
               <div
                 class="prose prose-sm dark:prose-invert max-w-none leading-relaxed"
                 v-html="renderMarkdown(block.text)"
@@ -454,7 +478,7 @@ async function handleCopyMarkdown() {
 
       <!-- AI 消息：传统纯文本渲染（向后兼容） -->
       <template v-else>
-        <div class="py-1 text-gray-900 dark:text-gray-100">
+        <div :ref="setAnswerCaptureElement" class="py-1 text-gray-900 dark:text-gray-100">
           <div class="prose prose-sm dark:prose-invert max-w-none leading-relaxed" v-html="renderedContent" />
           <span
             v-if="isStreaming"
@@ -482,10 +506,11 @@ async function handleCopyMarkdown() {
         </UTooltip>
         <!-- 截屏按钮（仅 AI 回复显示） -->
         <CaptureButton
-          v-if="showCaptureButton && !isUser && !isStreaming"
+          v-if="canCaptureAnswer"
           size="xs"
           type="element"
-          target-selector=".qa-pair"
+          :target-element="answerCaptureElement"
+          :tooltip="t('ai.chat.message.captureAnswer')"
         />
       </div>
     </div>

--- a/src/components/common/CaptureButton.vue
+++ b/src/components/common/CaptureButton.vue
@@ -16,6 +16,8 @@ const props = withDefaults(
   defineProps<{
     /** 按钮显示文字（不传则只显示图标） */
     label?: string
+    /** 悬浮提示文字 */
+    tooltip?: string
     /** 按钮尺寸 */
     size?: 'xs' | 'sm' | 'md'
     /** 截屏类型：page=整页, element=指定元素 */
@@ -69,7 +71,7 @@ async function handleCapture(event: Event) {
 </script>
 
 <template>
-  <UTooltip :text="t('common.capture')" class="no-capture">
+  <UTooltip :text="tooltip || t('common.capture')" class="no-capture">
     <UButton
       :id="buttonId"
       icon="i-heroicons-camera"

--- a/src/i18n/locales/en-US/ai.json
+++ b/src/i18n/locales/en-US/ai.json
@@ -53,6 +53,7 @@
         "success": "Markdown copied to clipboard",
         "failed": "Failed to copy Markdown"
       },
+      "captureAnswer": "Capture answer",
       "tools": {
         "get_chat_overview": "Get Chat Overview",
         "search_messages": "Search Messages",

--- a/src/i18n/locales/ja-JP/ai.json
+++ b/src/i18n/locales/ja-JP/ai.json
@@ -53,6 +53,7 @@
         "success": "Markdown をクリップボードにコピーしました",
         "failed": "Markdown のコピーに失敗しました"
       },
+      "captureAnswer": "回答を画像保存",
       "tools": {
         "get_chat_overview": "チャット概要を取得",
         "search_messages": "チャット履歴を検索",

--- a/src/i18n/locales/zh-CN/ai.json
+++ b/src/i18n/locales/zh-CN/ai.json
@@ -53,6 +53,7 @@
         "success": "Markdown 已复制到剪贴板",
         "failed": "复制 Markdown 失败"
       },
+      "captureAnswer": "截屏回答",
       "tools": {
         "get_chat_overview": "获取聊天概览",
         "search_messages": "搜索聊天记录",

--- a/src/i18n/locales/zh-TW/ai.json
+++ b/src/i18n/locales/zh-TW/ai.json
@@ -53,6 +53,7 @@
         "success": "Markdown 已複製到剪貼簿",
         "failed": "複製 Markdown 失敗"
       },
+      "captureAnswer": "截圖回答",
       "tools": {
         "get_chat_overview": "取得聊天概覽",
         "search_messages": "搜尋聊天紀錄",


### PR DESCRIPTION
## Summary
- Capture only the assistant's final answer when using the per-message AI screenshot button
- Keep the existing full conversation screenshot behavior unchanged
- Add localized tooltip text for the answer-only screenshot action

## Testing
- Verified with a real AI chat response containing thinking/tool calls
- Ran `prettier --check`
- Ran `eslint`
- Ran `type-check:web` with Node.js v24.15.0