### PR TITLE
fix(import): refresh sidebar message count after incremental import

### DIFF
--- a/apps/desktop/main/ipc/chat.ts
+++ b/apps/desktop/main/ipc/chat.ts
@@ -225,6 +225,8 @@ export function registerChatHandlers(ctx: IpcContext): void {
           console.error('[IpcMain] Failed to incrementally generate session index:', e)
         }
         worker.invalidateAnalysisCache(sessionId).catch(() => {})
+        // 通知渲染进程刷新会话列表（与 API 路由的 notifySessionListChanged 保持一致）
+        win.webContents.send('api:importCompleted')
       }
 
       return result

--- a/apps/desktop/main/worker/import/incrementalImport.ts
+++ b/apps/desktop/main/worker/import/incrementalImport.ts
@@ -11,6 +11,7 @@ import {
   BetterSqliteAdapter,
   analyzeIncrementalImport as sharedAnalyze,
   incrementalImport as sharedImport,
+  computeAndSetOverviewCache,
 } from '@openchatlab/node-runtime'
 import type {
   IncrementalImportDeps,
@@ -39,9 +40,8 @@ function buildDeps(requestId: string): IncrementalImportDeps {
     onProgress(progress) {
       sendProgress(requestId, progress)
     },
-    async postImportHook(_db, sessionId) {
+    postImportHook(_db, sessionId) {
       try {
-        const { computeAndSetOverviewCache } = await import('@openchatlab/node-runtime')
         const dbPath = getDbPath(sessionId)
         const rawDb = new Database(dbPath)
         computeAndSetOverviewCache(new BetterSqliteAdapter(rawDb), sessionId, getCacheDir())

--- a/apps/desktop/main/worker/import/streamImport.ts
+++ b/apps/desktop/main/worker/import/streamImport.ts
@@ -15,6 +15,7 @@ import {
   analyzeNewImport as sharedAnalyzeNewImport,
   streamParseFileInfo as sharedStreamParseFileInfo,
   TEMP_DB_SCHEMA,
+  computeAndSetOverviewCache,
 } from '@openchatlab/node-runtime'
 import type { StreamImportDeps, StreamImportResult, ImportLogger } from '@openchatlab/node-runtime'
 import { sendProgress, generateSessionId, getDbPath, createDatabaseWithoutIndexes } from './utils'
@@ -87,9 +88,8 @@ function buildStreamImportDeps(requestId: string): StreamImportDeps {
       sendProgress(requestId, progress)
     },
     logger: buildElectronLogger(),
-    async postImportHook(_db, sessionId) {
+    postImportHook(_db, sessionId) {
       try {
-        const { computeAndSetOverviewCache } = await import('@openchatlab/node-runtime')
         const dbPath = getDbPath(sessionId)
         const rawDb = new Database(dbPath)
         computeAndSetOverviewCache(new BetterSqliteAdapter(rawDb), sessionId, getCacheDir())

--- a/packages/node-runtime/src/import/incremental-importer.ts
+++ b/packages/node-runtime/src/import/incremental-importer.ts
@@ -64,7 +64,7 @@ export interface IncrementalImportDeps {
   openDatabase(sessionId: string, readonly?: boolean): DatabaseAdapter
   onProgress: ImportProgressCallback
   /** Optional hook after incremental import (e.g. update overview cache). */
-  postImportHook?: (db: DatabaseAdapter, sessionId: string) => void
+  postImportHook?: (db: DatabaseAdapter, sessionId: string) => void | Promise<void>
 }
 
 // ==================== Internal helpers ====================
@@ -383,7 +383,7 @@ export async function incrementalImport(
 
     // Post-import hook (e.g. overview cache)
     try {
-      deps.postImportHook?.(db, sessionId)
+      await deps.postImportHook?.(db, sessionId)
     } catch {
       /* non-fatal */
     }

--- a/packages/node-runtime/src/import/streaming-importer.ts
+++ b/packages/node-runtime/src/import/streaming-importer.ts
@@ -74,7 +74,7 @@ export interface StreamImportDeps {
   /** Optional perf/diagnostic logger */
   logger?: ImportLogger
   /** Optional hook after import completes (e.g. write overview cache) */
-  postImportHook?: (db: DatabaseAdapter, sessionId: string) => void
+  postImportHook?: (db: DatabaseAdapter, sessionId: string) => void | Promise<void>
   /** Generate a session ID. Defaults to timestamp + random. */
   generateSessionId?: () => string
 }
@@ -520,7 +520,7 @@ async function streamImportSingle(
 
     // Post-import hook (e.g. overview cache)
     try {
-      deps.postImportHook?.(db, sessionId)
+      await deps.postImportHook?.(db, sessionId)
       if (deps.postImportHook) logger?.perf('Post-import hook done', totalMessageCount)
     } catch {
       /* non-fatal */

--- a/src/pages/group-chat/index.vue
+++ b/src/pages/group-chat/index.vue
@@ -294,7 +294,12 @@ const filteredMemberCount = computed(() => {
       v-model="showIncrementalImportModal"
       :session-id="currentSessionId"
       :session-name="session.name"
-      @imported="loadData"
+      @imported="
+        () => {
+          loadData()
+          sessionStore.loadSessions()
+        }
+      "
     />
 
     <!-- 导出聊天记录弹窗 -->

--- a/src/pages/private-chat/index.vue
+++ b/src/pages/private-chat/index.vue
@@ -304,7 +304,12 @@ const otherMemberAvatar = computed(() => {
       v-model="showIncrementalImportModal"
       :session-id="currentSessionId"
       :session-name="session.name"
-      @imported="loadAnalysisData"
+      @imported="
+        () => {
+          loadAnalysisData()
+          sessionStore.loadSessions()
+        }
+      "
     />
 
     <!-- 导出聊天记录弹窗 -->


### PR DESCRIPTION
## Bug

After incremental import adds new chat records via the UI, the message count shown in the sidebar session list does not update — it stays stale until app restart.

## Root Cause

Three contributing gaps:

1. **IPC handler missing notification**: The `chat:incrementalImport` IPC handler did not send `api:importCompleted` to the renderer after a successful import. The API route handler correctly calls `notifySessionListChanged()`, but the IPC path omitted it. The Sidebar already listens for this event and calls `sessionStore.loadSessions()`.

2. **Race condition in `postImportHook`**: The worker adapter `postImportHook` was `async` (due to `await import(@openchatlab/node-runtime)`), but the caller in `incremental-importer.ts` / `streaming-importer.ts` did not `await` it. This meant `computeAndSetOverviewCache()` could execute *after* `loadSessions()` read the stale overview cache.

3. **Frontend `@imported` handlers incomplete**: The group-chat and private-chat pages only refreshed local analysis data on `@imported`, without calling `sessionStore.loadSessions()` to update the sidebar.

## Fix

| File | Change |
|------|--------|
| `apps/desktop/main/ipc/chat.ts` | Add `win.webContents.send("api:importCompleted")` after successful incremental import |
| `apps/desktop/main/worker/import/incrementalImport.ts` | Convert `postImportHook` from async dynamic import to sync static import |
| `apps/desktop/main/worker/import/streamImport.ts` | Same as above |
| `packages/node-runtime/src/import/incremental-importer.ts` | Update `postImportHook` type to `void \| Promise<void>`, add `await` at call site |
| `packages/node-runtime/src/import/streaming-importer.ts` | Same as above |
| `src/pages/group-chat/index.vue` | Add `sessionStore.loadSessions()` to `@imported` handler |
| `src/pages/private-chat/index.vue` | Same as above |

🤖 Generated with [Claude Code](https://claude.com/claude-code)