### PR TITLE
feat(ai): slash-activated chart runtime

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -361,7 +361,7 @@ jobs:
             echo ""
             echo "---"
             echo ""
-            echo "Full Changelog: [English](https://github.com/ChatLab/ChatLab/blob/main/changelogs/en.json) | [中文](https://github.com/ChatLab/ChatLab/blob/main/changelogs/cn.json) | [日本語](https://github.com/ChatLab/ChatLab/blob/main/changelogs/ja.json)"
+            echo "Full Changelog: [English](https://github.com/ChatLab/ChatLab/blob/main/changelogs/en.md) | [中文](https://github.com/ChatLab/ChatLab/blob/main/changelogs/cn.md) | [日本語](https://github.com/ChatLab/ChatLab/blob/main/changelogs/ja.md)"
             echo ""
             echo "---"
             echo ""

--- a/apps/cli/src/ai/agent-stream-runner.ts
+++ b/apps/cli/src/ai/agent-stream-runner.ts
@@ -5,7 +5,12 @@
 
 import type { DatabaseManager, AIConversationManager, AgentStreamChunk } from '@openchatlab/node-runtime'
 import { SkillManager, createActivateSkillTool } from '@openchatlab/node-runtime'
-import { getChatOverview } from '@openchatlab/core'
+import {
+  CHART_CAPABILITY_SKILL_ID,
+  getChartCapabilityAllowedBuiltinTools,
+  getChartCapabilitySkill,
+  getChatOverview,
+} from '@openchatlab/core'
 import type { DataSnapshot } from '@openchatlab/node-runtime'
 import type { AgentStreamRequest } from '@openchatlab/http-routes'
 import { AGENT_TOOL_REGISTRY } from '@openchatlab/tools'
@@ -46,11 +51,13 @@ export function createCliRunAgentStream(
     const aiDataDir = getAiDir(dbManager)
 
     let assistantSystemPrompt: string | undefined
+    let assistantAllowedTools: string[] | undefined
     if (assistantId) {
       const assistantConfig = loadAssistantConfig(aiDataDir, assistantId)
       if (assistantConfig?.systemPrompt) {
         assistantSystemPrompt = assistantConfig.systemPrompt
       }
+      assistantAllowedTools = assistantConfig?.allowedBuiltinTools
     }
 
     const llmConfig = getDefaultAssistantConfig(aiDataDir)
@@ -59,8 +66,18 @@ export function createCliRunAgentStream(
     const maxToolResultTokens = Math.floor(contextWindow * (maxToolResultPercent / 100))
 
     const db = (dbManager as any).open?.(sessionId)
+    const isChartCapability = skillId === CHART_CAPABILITY_SKILL_ID
+    const allowedToolSet = isChartCapability
+      ? new Set(getChartCapabilityAllowedBuiltinTools(assistantAllowedTools))
+      : assistantAllowedTools && assistantAllowedTools.length > 0
+        ? new Set(assistantAllowedTools)
+        : null
+    const availableToolDefs = allowedToolSet
+      ? AGENT_TOOL_REGISTRY.filter((tool) => tool.category !== 'analysis' || allowedToolSet.has(tool.name))
+      : AGENT_TOOL_REGISTRY
+
     const agentTools = db
-      ? adaptToolsForAgent(AGENT_TOOL_REGISTRY, () => ({ db, sessionId, locale }), { maxToolResultTokens })
+      ? adaptToolsForAgent(availableToolDefs, () => ({ db, sessionId, locale }), { maxToolResultTokens })
       : []
 
     const skillMgr = new SkillManager(aiDataDir)
@@ -69,7 +86,10 @@ export function createCliRunAgentStream(
 
     let resolvedSkillDef: { name: string; prompt: string } | undefined
     let resolvedSkillMenu: string | undefined
-    if (skillId) {
+    if (isChartCapability) {
+      const def = getChartCapabilitySkill(locale ?? 'zh-CN')
+      resolvedSkillDef = { name: def.name, prompt: def.prompt }
+    } else if (skillId) {
       const def = skillMgr.getSkillConfig(skillId)
       if (def) resolvedSkillDef = { name: def.name, prompt: def.prompt }
     } else if (enableAutoSkill) {

--- a/apps/cli/src/ai/tool-adapter.test.ts
+++ b/apps/cli/src/ai/tool-adapter.test.ts
@@ -1,0 +1,59 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { adaptToolsForAgent } from './tool-adapter'
+import type { ToolDefinition } from '@openchatlab/tools'
+import type { ChartPayload, DatabaseAdapter } from '@openchatlab/core'
+
+const chart: ChartPayload = {
+  version: 1,
+  spec: {
+    version: 1,
+    type: 'pie',
+    title: 'Selected members',
+    encoding: { label: 'name', value: 'message_count' },
+  },
+  dataset: {
+    columns: [
+      { name: 'name', type: 'category' },
+      { name: 'message_count', type: 'integer' },
+    ],
+    rows: [
+      { name: 'Alice', message_count: 4 },
+      { name: 'Bob', message_count: 3 },
+    ],
+  },
+  data: {
+    labels: ['Alice', 'Bob'],
+    values: [4, 3],
+  },
+  rowCount: 2,
+}
+
+describe('adaptToolsForAgent', () => {
+  it('preserves chart payloads in tool result details', async () => {
+    const tool: ToolDefinition = {
+      name: 'render_chart',
+      description: 'Render a chart',
+      inputSchema: { type: 'object', properties: {} },
+      async handler() {
+        return {
+          content: 'Generated chart.',
+          data: { rowCount: 2 },
+          chart,
+        }
+      },
+    }
+
+    const [agentTool] = adaptToolsForAgent([tool], () => ({
+      db: {} as DatabaseAdapter,
+      sessionId: 'session-1',
+      locale: 'en-US',
+    }))
+
+    assert.ok(agentTool)
+    const result = await agentTool.execute('call-1', {})
+
+    assert.deepEqual(result.content, [{ type: 'text', text: 'Generated chart.' }])
+    assert.deepEqual(result.details, { rowCount: 2, chart })
+  })
+})

--- a/apps/cli/src/ai/tool-adapter.ts
+++ b/apps/cli/src/ai/tool-adapter.ts
@@ -75,6 +75,13 @@ export function adaptToolsForAgent(
       }
       try {
         const result = await tool.handler(toolParams, execCtx)
+        const chartDetails =
+          result.chart || result.charts
+            ? {
+                ...(result.chart ? { chart: result.chart } : {}),
+                ...(result.charts ? { charts: result.charts } : {}),
+              }
+            : {}
 
         if (result.rawMessages && result.rawMessages.length > 0) {
           const pipelineResult = applyPreprocessingPipeline({
@@ -85,10 +92,23 @@ export function adaptToolsForAgent(
             extraDetails: (result.data ?? {}) as Record<string, unknown>,
             logger: getServerAiLogger() ?? undefined,
           })
-          return { content: [{ type: 'text', text: pipelineResult.text }], details: null }
+          return {
+            content: [{ type: 'text', text: pipelineResult.text }],
+            details: Object.keys(chartDetails).length > 0 ? chartDetails : null,
+          }
         }
 
-        return { content: [{ type: 'text', text: result.content }], details: null }
+        const baseDetails =
+          typeof result.data === 'object' && result.data !== null
+            ? (result.data as Record<string, unknown>)
+            : result.data === undefined
+              ? null
+              : { value: result.data }
+
+        return {
+          content: [{ type: 'text', text: result.content }],
+          details: Object.keys(chartDetails).length > 0 ? { ...(baseDetails ?? {}), ...chartDetails } : baseDetails,
+        }
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error)
         return { content: [{ type: 'text', text: `Error: ${msg}` }], details: null }

--- a/apps/desktop/main/ai/agent-stream-runner.ts
+++ b/apps/desktop/main/ai/agent-stream-runner.ts
@@ -15,6 +15,11 @@ import type { ToolContext } from './tools/types'
 import { getDefaultAssistantConfig, buildPiModel, findModelDefinition } from './llm'
 import type { AIServiceConfig } from './llm/types'
 import { getDefaultGeneralAssistantId } from './assistant/defaultGeneral'
+import {
+  CHART_CAPABILITY_SKILL_ID,
+  getChartCapabilityAllowedBuiltinTools,
+  getChartCapabilitySkill,
+} from '@openchatlab/core'
 import * as assistantManager from './assistant'
 import type { AssistantConfig } from './assistant/types'
 import * as skillManager from './skills'
@@ -147,7 +152,20 @@ export function createElectronRunAgentStream(): (
     }
 
     let skillCtx: SkillContext | undefined
-    if (skillId) {
+    const isChartCapability = skillId === CHART_CAPABILITY_SKILL_ID
+    if (isChartCapability) {
+      const chartSkill = getChartCapabilitySkill(locale ?? 'zh-CN')
+      skillCtx = { skillDef: { ...chartSkill, chatScope: 'all' } as SkillContext['skillDef'] }
+      assistantConfig = {
+        ...(assistantConfig ?? {
+          id: resolvedAssistantId,
+          name: resolvedAssistantId,
+          systemPrompt: '',
+          presetQuestions: [],
+        }),
+        allowedBuiltinTools: getChartCapabilityAllowedBuiltinTools(assistantConfig?.allowedBuiltinTools),
+      }
+    } else if (skillId) {
       const skillDef = skillManager.getSkillConfig(skillId) ?? undefined
       if (skillDef) {
         skillCtx = { skillDef }

--- a/apps/desktop/main/ai/tools/definitions/index.ts
+++ b/apps/desktop/main/ai/tools/definitions/index.ts
@@ -16,6 +16,7 @@ import {
   searchSessionsTool,
   getSessionMessagesTool,
   getMembersTool,
+  schemaTool,
   memberStatsTool,
   timeStatsTool,
   getMemberNameHistoryTool,
@@ -23,6 +24,7 @@ import {
   getSessionSummariesTool,
   responseTimeAnalysisTool,
   keywordFrequencyTool,
+  renderChartTool,
   SQL_TOOL_DEFS,
   createSqlToolDefinition,
 } from '@openchatlab/tools'
@@ -48,6 +50,7 @@ export const TOOL_REGISTRY: ToolRegistryEntry[] = [
   adaptSharedTool(searchSessionsTool, { category: 'core' }),
   adaptSharedTool(getSessionMessagesTool, { category: 'core', truncationStrategy: 'keep_last' }),
   adaptSharedTool(getMembersTool, { category: 'core' }),
+  adaptSharedTool(schemaTool, { category: 'core' }),
 
   // ==================== Analysis 工具（按需加载） ====================
   adaptSharedTool(memberStatsTool, { category: 'analysis' }),
@@ -57,6 +60,7 @@ export const TOOL_REGISTRY: ToolRegistryEntry[] = [
   adaptSharedTool(getSessionSummariesTool, { category: 'analysis' }),
   adaptSharedTool(responseTimeAnalysisTool, { category: 'analysis' }),
   adaptSharedTool(keywordFrequencyTool, { category: 'analysis' }),
+  adaptSharedTool(renderChartTool, { category: 'analysis' }),
 
   // ==================== SQL 分析工具 ====================
   ...sqlToolEntries,

--- a/apps/desktop/main/ai/tools/shared-tool-adapter.ts
+++ b/apps/desktop/main/ai/tools/shared-tool-adapter.ts
@@ -56,6 +56,13 @@ export function adaptSharedTool(tool: ToolDefinition, options: AdaptOptions): To
           const execCtx = buildExecutionContext(context)
           try {
             const result = await tool.handler(toolParams, execCtx)
+            const chartDetails =
+              result.chart || result.charts
+                ? {
+                    ...(result.chart ? { chart: result.chart } : {}),
+                    ...(result.charts ? { charts: result.charts } : {}),
+                  }
+                : {}
 
             if (result.rawMessages && result.rawMessages.length > 0) {
               const baseData = (typeof result.data === 'object' && result.data !== null ? result.data : {}) as Record<
@@ -64,13 +71,20 @@ export function adaptSharedTool(tool: ToolDefinition, options: AdaptOptions): To
               >
               return {
                 content: [{ type: 'text', text: result.content }],
-                details: { ...baseData, rawMessages: result.rawMessages },
+                details: { ...baseData, ...chartDetails, rawMessages: result.rawMessages },
               }
             }
 
+            const baseDetails =
+              typeof result.data === 'object' && result.data !== null
+                ? (result.data as Record<string, unknown>)
+                : result.data === undefined
+                  ? null
+                  : { value: result.data }
+
             return {
               content: [{ type: 'text', text: result.content }],
-              details: result.data ?? null,
+              details: Object.keys(chartDetails).length > 0 ? { ...(baseDetails ?? {}), ...chartDetails } : baseDetails,
             }
           } catch (error) {
             const msg = error instanceof Error ? error.message : String(error)

--- a/packages/core/src/ai/chart-capability.test.ts
+++ b/packages/core/src/ai/chart-capability.test.ts
@@ -1,0 +1,36 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  CHART_CAPABILITY_ANALYSIS_TOOLS,
+  CHART_CAPABILITY_SKILL_ID,
+  getChartCapabilityAllowedBuiltinTools,
+  getChartCapabilitySkill,
+} from './chart-capability'
+
+describe('chart capability skill', () => {
+  it('advertises render_chart and schema lookup tools', () => {
+    const skill = getChartCapabilitySkill('en-US')
+
+    assert.equal(skill.id, CHART_CAPABILITY_SKILL_ID)
+    assert.deepEqual(skill.tools, ['render_chart', 'get_schema'])
+    assert.match(skill.prompt, /render_chart/)
+    assert.match(skill.prompt, /get_schema/)
+  })
+
+  it('adds only chart analysis tools to assistant builtin tools', () => {
+    assert.deepEqual(CHART_CAPABILITY_ANALYSIS_TOOLS, ['render_chart'])
+    assert.deepEqual(getChartCapabilityAllowedBuiltinTools(), ['render_chart'])
+    assert.deepEqual(getChartCapabilityAllowedBuiltinTools(['keyword_frequency']), [
+      'keyword_frequency',
+      'render_chart',
+    ])
+  })
+
+  it('does not duplicate render_chart when it is already allowed', () => {
+    assert.deepEqual(getChartCapabilityAllowedBuiltinTools(['render_chart', 'time_stats']), [
+      'render_chart',
+      'time_stats',
+    ])
+  })
+})

--- a/packages/core/src/ai/chart-capability.ts
+++ b/packages/core/src/ai/chart-capability.ts
@@ -1,0 +1,81 @@
+export const CHART_CAPABILITY_SKILL_ID = 'chart_runtime'
+export const CHART_CAPABILITY_ANALYSIS_TOOLS = ['render_chart'] as const
+
+export function getChartCapabilityAllowedBuiltinTools(allowedTools?: readonly string[] | null): string[] {
+  return Array.from(new Set([...(allowedTools ?? []), ...CHART_CAPABILITY_ANALYSIS_TOOLS]))
+}
+
+export function getChartCapabilitySkill(locale: string = 'zh-CN'): {
+  id: string
+  name: string
+  description: string
+  tags: string[]
+  chatScope: 'all'
+  tools: string[]
+  prompt: string
+} {
+  const isZh = locale.startsWith('zh')
+  return {
+    id: CHART_CAPABILITY_SKILL_ID,
+    name: isZh ? '绘图助手' : 'Chart Assistant',
+    description: isZh ? '按本轮问题生成灵活的聊天数据图表' : 'Generate flexible charts for this chat question',
+    tags: [isZh ? '图表' : 'chart'],
+    chatScope: 'all',
+    tools: ['render_chart', 'get_schema'],
+    prompt: isZh ? ZH_PROMPT : EN_PROMPT,
+  }
+}
+
+const ZH_PROMPT = `你是 ChatLab 绘图助手。本轮用户希望你在回答里自然嵌入一张或多张图表。
+
+你必须通过 render_chart 工具生成图表。不要输出 HTML、JavaScript、SVG、Canvas、ECharts option 或任何渲染代码。
+
+工作流程：
+1. 如不确定表结构，先调用 get_schema。
+2. 根据用户要求确定统计对象、时间范围、维度、指标和图表类型。
+3. 调用 render_chart，提交只读 SQL 和 ChartSpec v1。
+4. 图表生成后，用简洁文字解释结论。用户要求多张图时，可以多次调用 render_chart。
+
+ChartSpec v1 支持：
+- bar: encoding.x + encoding.y
+- line: encoding.x + encoding.y，可选 encoding.series 表示每条线的含义
+- pie: encoding.label + encoding.value
+- heatmap: encoding.x + encoding.y + encoding.value
+
+ChartSpec 示例：
+{
+  "version": 1,
+  "type": "line",
+  "title": "最近 30 天成员发言趋势",
+  "encoding": { "x": "day", "y": "msg_count", "series": "member_name" },
+  "unit": "条"
+}
+
+用户明确要求图表时必须尝试生成。用户没有明确要求时，只有排名、趋势、分布、占比或二维密度明显更清楚时才主动生成，且默认最多一张。`
+
+const EN_PROMPT = `You are the ChatLab Chart Assistant. In this turn, the user wants one or more charts embedded naturally in the answer.
+
+You must generate charts through the render_chart tool. Do not output HTML, JavaScript, SVG, Canvas, ECharts options, or rendering code.
+
+Workflow:
+1. If the database schema is uncertain, call get_schema first.
+2. Derive the target members, time range, dimensions, metrics, and chart type from the user request.
+3. Call render_chart with read-only SQL and ChartSpec v1.
+4. After the chart is generated, explain the key finding briefly. If the user asks for multiple charts, call render_chart multiple times.
+
+ChartSpec v1 supports:
+- bar: encoding.x + encoding.y
+- line: encoding.x + encoding.y, optional encoding.series for the meaning of each line
+- pie: encoding.label + encoding.value
+- heatmap: encoding.x + encoding.y + encoding.value
+
+ChartSpec example:
+{
+  "version": 1,
+  "type": "line",
+  "title": "Member message trend in the last 30 days",
+  "encoding": { "x": "day", "y": "msg_count", "series": "member_name" },
+  "unit": "messages"
+}
+
+When the user explicitly asks for charts, you must try to generate them. If the user does not explicitly ask, add at most one chart only when ranking, trend, distribution, ratio, or two-dimensional density is clearly easier to understand visually.`

--- a/packages/core/src/ai/index.ts
+++ b/packages/core/src/ai/index.ts
@@ -5,6 +5,12 @@
 // 内置工具目录
 export type { ToolCategory, BuiltinToolCatalogEntry } from './tool-catalog'
 export { BUILTIN_TOOL_CATALOG } from './tool-catalog'
+export {
+  CHART_CAPABILITY_SKILL_ID,
+  CHART_CAPABILITY_ANALYSIS_TOOLS,
+  getChartCapabilityAllowedBuiltinTools,
+  getChartCapabilitySkill,
+} from './chart-capability'
 
 // LLM 模型系统类型
 export type {

--- a/packages/core/src/ai/tool-catalog.ts
+++ b/packages/core/src/ai/tool-catalog.ts
@@ -22,6 +22,7 @@ export const BUILTIN_TOOL_CATALOG: BuiltinToolCatalogEntry[] = [
   { name: 'search_sessions', category: 'core' },
   { name: 'get_session_messages', category: 'core' },
   { name: 'get_members', category: 'core' },
+  { name: 'get_schema', category: 'core' },
 
   // Analysis 工具
   { name: 'get_member_stats', category: 'analysis' },
@@ -31,6 +32,7 @@ export const BUILTIN_TOOL_CATALOG: BuiltinToolCatalogEntry[] = [
   { name: 'get_session_summaries', category: 'analysis' },
   { name: 'response_time_analysis', category: 'analysis' },
   { name: 'keyword_frequency', category: 'analysis' },
+  { name: 'render_chart', category: 'analysis' },
 
   // SQL Analysis 工具
   { name: 'message_type_breakdown', category: 'analysis' },

--- a/packages/core/src/chart/index.test.ts
+++ b/packages/core/src/chart/index.test.ts
@@ -1,0 +1,85 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { buildChartPayload, ChartValidationError } from './index'
+
+test('builds a pie chart from dynamic label/value fields', () => {
+  const chart = buildChartPayload(
+    [
+      { member_name: 'Alice', msg_count: 3 },
+      { member_name: 'Bob', msg_count: 5 },
+    ],
+    {
+      version: 1,
+      type: 'pie',
+      title: 'Selected members',
+      encoding: { label: 'member_name', value: 'msg_count' },
+    }
+  )
+
+  assert.equal(chart.spec.type, 'pie')
+  assert.deepEqual(chart.data, { labels: ['Alice', 'Bob'], values: [3, 5] })
+})
+
+test('builds line series when encoding.series is provided', () => {
+  const chart = buildChartPayload(
+    [
+      { day: '2026-06-01', member_name: 'Alice', msg_count: 2 },
+      { day: '2026-06-01', member_name: 'Bob', msg_count: 4 },
+      { day: '2026-06-02', member_name: 'Alice', msg_count: 1 },
+    ],
+    {
+      version: 1,
+      type: 'line',
+      title: 'Member trend',
+      encoding: { x: 'day', y: 'msg_count', series: 'member_name' },
+    }
+  )
+
+  assert.deepEqual(chart.data, {
+    labels: ['2026-06-01', '2026-06-02'],
+    values: [2, 1],
+    series: [
+      { name: 'Alice', values: [2, 1] },
+      { name: 'Bob', values: [4, 0] },
+    ],
+  })
+})
+
+test('builds heatmap indices from x/y/value fields', () => {
+  const chart = buildChartPayload(
+    [
+      { hour: 9, weekday: 'Mon', msg_count: 2 },
+      { hour: 10, weekday: 'Mon', msg_count: 3 },
+      { hour: 9, weekday: 'Tue', msg_count: 4 },
+    ],
+    {
+      version: 1,
+      type: 'heatmap',
+      title: 'Activity heatmap',
+      encoding: { x: 'hour', y: 'weekday', value: 'msg_count' },
+    }
+  )
+
+  assert.deepEqual(chart.data, {
+    xLabels: ['9', '10'],
+    yLabels: ['Mon', 'Tue'],
+    data: [
+      [0, 0, 2],
+      [1, 0, 3],
+      [0, 1, 4],
+    ],
+  })
+})
+
+test('rejects missing encoding fields', () => {
+  assert.throws(
+    () =>
+      buildChartPayload([{ label: 'Alice', count: 1 }], {
+        version: 1,
+        type: 'bar',
+        title: 'Broken chart',
+        encoding: { x: 'label', y: 'missing_count' },
+      }),
+    ChartValidationError
+  )
+})

--- a/packages/core/src/chart/index.ts
+++ b/packages/core/src/chart/index.ts
@@ -1,0 +1,336 @@
+export type ChartType = 'bar' | 'line' | 'pie' | 'heatmap'
+
+export type ChartFieldType = 'string' | 'number' | 'integer' | 'boolean' | 'date' | 'datetime' | 'category'
+
+export interface ChartField {
+  name: string
+  type: ChartFieldType
+  label?: string
+  unit?: string
+}
+
+export interface ChartEncoding {
+  x?: string
+  y?: string
+  value?: string
+  label?: string
+  series?: string
+  color?: string
+}
+
+export interface ChartSpec {
+  version: 1
+  type: ChartType
+  title: string
+  subtitle?: string
+  description?: string
+  encoding: ChartEncoding
+  fields?: ChartField[]
+  unit?: string
+  filters?: {
+    timeRange?: { startTs?: number; endTs?: number; label?: string }
+    members?: Array<{ id?: number; name: string }>
+    keywords?: string[]
+    messageTypes?: number[]
+    custom?: Record<string, unknown>
+  }
+  display?: {
+    horizontal?: boolean
+    stacked?: boolean
+    showLegend?: boolean
+    showDataZoom?: boolean
+    height?: number
+  }
+}
+
+export interface ChartDataset {
+  columns: ChartField[]
+  rows: Record<string, unknown>[]
+}
+
+export interface BarChartRenderData {
+  labels: string[]
+  values: number[]
+}
+
+export interface LineChartRenderData {
+  labels: string[]
+  values: number[]
+  series?: Array<{ name: string; values: number[] }>
+}
+
+export interface PieChartRenderData {
+  labels: string[]
+  values: number[]
+}
+
+export interface HeatmapChartRenderData {
+  xLabels: string[]
+  yLabels: string[]
+  data: Array<[number, number, number]>
+}
+
+export type ChartRenderData = BarChartRenderData | LineChartRenderData | PieChartRenderData | HeatmapChartRenderData
+
+export interface ChartPayload {
+  version: 1
+  spec: ChartSpec
+  dataset: ChartDataset
+  data: ChartRenderData
+  rowCount: number
+  truncated?: boolean
+}
+
+export class ChartValidationError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ChartValidationError'
+  }
+}
+
+const CHART_TYPES = new Set<ChartType>(['bar', 'line', 'pie', 'heatmap'])
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function asFieldName(value: unknown, label: string): string {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new ChartValidationError(`${label} must be a non-empty field name`)
+  }
+  return value
+}
+
+function assertFieldExists(rows: Record<string, unknown>[], field: string): void {
+  if (rows.length === 0) return
+  if (!Object.prototype.hasOwnProperty.call(rows[0], field)) {
+    throw new ChartValidationError(`Field "${field}" does not exist in SQL result`)
+  }
+}
+
+function toLabel(value: unknown): string {
+  if (value === null || value === undefined || value === '') return '(empty)'
+  return String(value)
+}
+
+function toNumber(value: unknown, field: string): number {
+  const num = typeof value === 'number' ? value : Number(value)
+  if (!Number.isFinite(num)) {
+    throw new ChartValidationError(`Field "${field}" contains non-numeric value "${String(value)}"`)
+  }
+  return num
+}
+
+function inferFieldType(values: unknown[]): ChartFieldType {
+  const present = values.filter((v) => v !== null && v !== undefined)
+  if (present.length === 0) return 'string'
+  if (present.every((v) => typeof v === 'number' && Number.isInteger(v))) return 'integer'
+  if (
+    present.every(
+      (v) => typeof v === 'number' || (typeof v === 'string' && v.trim() !== '' && !Number.isNaN(Number(v)))
+    )
+  ) {
+    return 'number'
+  }
+  if (present.every((v) => typeof v === 'boolean')) return 'boolean'
+  return 'category'
+}
+
+export function normalizeChartSpec(raw: unknown): ChartSpec {
+  if (!isRecord(raw)) throw new ChartValidationError('chartSpec must be an object')
+  if (raw.version !== 1) throw new ChartValidationError('chartSpec.version must be 1')
+  if (typeof raw.type !== 'string' || !CHART_TYPES.has(raw.type as ChartType)) {
+    throw new ChartValidationError('chartSpec.type must be one of: bar, line, pie, heatmap')
+  }
+  if (typeof raw.title !== 'string' || raw.title.trim().length === 0) {
+    throw new ChartValidationError('chartSpec.title must be a non-empty string')
+  }
+  if (!isRecord(raw.encoding)) throw new ChartValidationError('chartSpec.encoding must be an object')
+
+  const spec = raw as unknown as ChartSpec
+  switch (spec.type) {
+    case 'bar':
+    case 'line':
+      asFieldName(spec.encoding.x, 'encoding.x')
+      asFieldName(spec.encoding.y, 'encoding.y')
+      break
+    case 'pie':
+      asFieldName(spec.encoding.label, 'encoding.label')
+      asFieldName(spec.encoding.value, 'encoding.value')
+      break
+    case 'heatmap':
+      asFieldName(spec.encoding.x, 'encoding.x')
+      asFieldName(spec.encoding.y, 'encoding.y')
+      asFieldName(spec.encoding.value, 'encoding.value')
+      break
+  }
+
+  return {
+    ...spec,
+    title: spec.title.trim(),
+  }
+}
+
+export function inferChartDataset(rows: Record<string, unknown>[], declaredFields?: ChartField[]): ChartDataset {
+  const declared = new Map((declaredFields ?? []).map((field) => [field.name, field]))
+  const columnNames = rows.length > 0 ? Object.keys(rows[0]) : [...declared.keys()]
+  const columns = columnNames.map((name) => {
+    const declaredField = declared.get(name)
+    if (declaredField) return declaredField
+    return {
+      name,
+      type: inferFieldType(rows.map((row) => row[name])),
+    }
+  })
+
+  return { columns, rows }
+}
+
+function aggregateByLabel(
+  rows: Record<string, unknown>[],
+  labelField: string,
+  valueField: string
+): {
+  labels: string[]
+  values: number[]
+} {
+  const labels: string[] = []
+  const indexByLabel = new Map<string, number>()
+  const values: number[] = []
+
+  for (const row of rows) {
+    const label = toLabel(row[labelField])
+    let index = indexByLabel.get(label)
+    if (index === undefined) {
+      index = labels.length
+      indexByLabel.set(label, index)
+      labels.push(label)
+      values.push(0)
+    }
+    values[index] += toNumber(row[valueField], valueField)
+  }
+
+  return { labels, values }
+}
+
+function buildLineData(rows: Record<string, unknown>[], spec: ChartSpec): LineChartRenderData {
+  const xField = spec.encoding.x!
+  const yField = spec.encoding.y!
+  const seriesField = spec.encoding.series
+
+  if (!seriesField) return aggregateByLabel(rows, xField, yField)
+
+  assertFieldExists(rows, seriesField)
+  const labels: string[] = []
+  const labelIndex = new Map<string, number>()
+  const seriesNames: string[] = []
+  const seriesIndex = new Map<string, number>()
+  const matrix: number[][] = []
+
+  for (const row of rows) {
+    const label = toLabel(row[xField])
+    const seriesName = toLabel(row[seriesField])
+    let xIndex = labelIndex.get(label)
+    if (xIndex === undefined) {
+      xIndex = labels.length
+      labelIndex.set(label, xIndex)
+      labels.push(label)
+      for (const values of matrix) values.push(0)
+    }
+
+    let sIndex = seriesIndex.get(seriesName)
+    if (sIndex === undefined) {
+      sIndex = seriesNames.length
+      seriesIndex.set(seriesName, sIndex)
+      seriesNames.push(seriesName)
+      matrix.push(Array(labels.length).fill(0))
+    }
+
+    matrix[sIndex][xIndex] += toNumber(row[yField], yField)
+  }
+
+  const series = seriesNames.map((name, index) => ({ name, values: matrix[index] }))
+  return {
+    labels,
+    values: series[0]?.values ?? [],
+    series,
+  }
+}
+
+function buildHeatmapData(rows: Record<string, unknown>[], spec: ChartSpec): HeatmapChartRenderData {
+  const xField = spec.encoding.x!
+  const yField = spec.encoding.y!
+  const valueField = spec.encoding.value!
+  const xLabels: string[] = []
+  const yLabels: string[] = []
+  const xIndex = new Map<string, number>()
+  const yIndex = new Map<string, number>()
+  const values = new Map<string, number>()
+
+  for (const row of rows) {
+    const xLabel = toLabel(row[xField])
+    const yLabel = toLabel(row[yField])
+    let xi = xIndex.get(xLabel)
+    if (xi === undefined) {
+      xi = xLabels.length
+      xIndex.set(xLabel, xi)
+      xLabels.push(xLabel)
+    }
+    let yi = yIndex.get(yLabel)
+    if (yi === undefined) {
+      yi = yLabels.length
+      yIndex.set(yLabel, yi)
+      yLabels.push(yLabel)
+    }
+    const key = `${xi}:${yi}`
+    values.set(key, (values.get(key) ?? 0) + toNumber(row[valueField], valueField))
+  }
+
+  const data: Array<[number, number, number]> = []
+  for (const [key, value] of values.entries()) {
+    const [x, y] = key.split(':').map(Number)
+    data.push([x, y, value])
+  }
+
+  return { xLabels, yLabels, data }
+}
+
+export function buildChartPayload(
+  rows: Record<string, unknown>[],
+  rawSpec: unknown,
+  options?: { truncated?: boolean }
+): ChartPayload {
+  const spec = normalizeChartSpec(rawSpec)
+  const dataset = inferChartDataset(rows, spec.fields)
+
+  const requiredFields = new Set<string>()
+  for (const field of Object.values(spec.encoding)) {
+    if (typeof field === 'string' && field) requiredFields.add(field)
+  }
+  for (const field of requiredFields) assertFieldExists(rows, field)
+
+  let data: ChartRenderData
+  switch (spec.type) {
+    case 'bar':
+      data = aggregateByLabel(rows, spec.encoding.x!, spec.encoding.y!)
+      break
+    case 'line':
+      data = buildLineData(rows, spec)
+      break
+    case 'pie':
+      data = aggregateByLabel(rows, spec.encoding.label!, spec.encoding.value!)
+      break
+    case 'heatmap':
+      data = buildHeatmapData(rows, spec)
+      break
+  }
+
+  return {
+    version: 1,
+    spec,
+    dataset,
+    data,
+    rowCount: rows.length,
+    truncated: options?.truncated,
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -180,6 +180,23 @@ export type {
   TableSchema,
 } from './query'
 
+// Chart runtime
+export { ChartValidationError, normalizeChartSpec, inferChartDataset, buildChartPayload } from './chart'
+export type {
+  ChartType,
+  ChartFieldType,
+  ChartField,
+  ChartEncoding,
+  ChartSpec,
+  ChartDataset,
+  ChartPayload,
+  ChartRenderData,
+  BarChartRenderData,
+  LineChartRenderData,
+  PieChartRenderData,
+  HeatmapChartRenderData,
+} from './chart'
+
 // NLP（平台无关的类型、数据和工具函数）
 export {
   POS_TAG_DEFINITIONS,
@@ -225,6 +242,10 @@ export {
   BUILTIN_MODELS,
   getBuiltinModelsByProvider,
   getBuiltinModelById,
+  CHART_CAPABILITY_SKILL_ID,
+  CHART_CAPABILITY_ANALYSIS_TOOLS,
+  getChartCapabilityAllowedBuiltinTools,
+  getChartCapabilitySkill,
   THINK_TAGS,
   extractThinkingContent,
   stripToolCallTags,

--- a/packages/node-runtime/src/ai/__tests__/conversations.test.ts
+++ b/packages/node-runtime/src/ai/__tests__/conversations.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import Database from 'better-sqlite3'
 import { AIConversationManager } from '../conversations'
+import type { ChartPayload } from '@openchatlab/core'
 
 const sqliteNativeBinding = process.env.CHATLAB_TEST_SQLITE_NATIVE_BINDING
 
@@ -279,6 +280,56 @@ describe('AIConversationManager message editing', () => {
       )
       assert.equal(inserted.parentId, userMsg.id)
       manager.close()
+    } finally {
+      cleanup(dir)
+    }
+  })
+})
+
+describe('AIConversationManager chart content blocks', () => {
+  it('persists normalized chart payloads for stable replay', () => {
+    const dir = createTempDir()
+    try {
+      const chart: ChartPayload = {
+        version: 1,
+        spec: {
+          version: 1,
+          type: 'bar',
+          title: 'Messages by member',
+          encoding: { x: 'name', y: 'message_count' },
+        },
+        dataset: {
+          columns: [
+            { name: 'name', type: 'category' },
+            { name: 'message_count', type: 'integer' },
+          ],
+          rows: [
+            { name: 'Alice', message_count: 4 },
+            { name: 'Bob', message_count: 3 },
+          ],
+        },
+        data: {
+          labels: ['Alice', 'Bob'],
+          values: [4, 3],
+        },
+        rowCount: 2,
+      }
+
+      const manager = createManager(dir)
+      const conv = manager.createConversation('s1', 'Chart Replay', 'general_cn')
+      manager.addMessage(conv.id, 'user', 'draw a chart')
+      manager.addMessage(conv.id, 'assistant', 'Here is the chart.', undefined, undefined, [{ type: 'chart', chart }])
+      manager.close()
+
+      const reloaded = createManager(dir)
+      const messages = reloaded.getMessages(conv.id)
+      const block = messages[1]?.contentBlocks?.[0]
+
+      if (!block || block.type !== 'chart') {
+        assert.fail('Expected a chart content block')
+      }
+      assert.deepEqual(block?.chart, chart)
+      reloaded.close()
     } finally {
       cleanup(dir)
     }

--- a/packages/node-runtime/src/ai/agent/__tests__/event-handler.test.ts
+++ b/packages/node-runtime/src/ai/agent/__tests__/event-handler.test.ts
@@ -97,4 +97,31 @@ describe('AgentEventHandler', () => {
     assert.equal(contentChunks.length, 1)
     assert.equal(contentChunks[0].content, 'Hello')
   })
+
+  it('passes chart tool results through unchanged', () => {
+    const chunks: AgentStreamChunk[] = []
+    const handler = new AgentEventHandler({
+      onChunk: (c) => chunks.push(c),
+      context: {},
+      systemPrompt: 'test',
+    })
+    const toolResult = {
+      content: 'Chart generated.',
+      details: {
+        chart: {
+          version: 1,
+          type: 'pie',
+          title: 'Selected members',
+          data: [{ label: 'Alice', value: 3 }],
+          source: { rowCount: 1, truncated: false },
+        },
+      },
+    }
+
+    handler.handleCoreEvent({ type: 'tool_end', toolName: 'render_chart', toolResult }, [])
+
+    const resultChunk = chunks.find((c) => c.type === 'tool_result')
+    assert.equal(resultChunk?.toolName, 'render_chart')
+    assert.deepEqual(resultChunk?.toolResult, toolResult)
+  })
 })

--- a/packages/node-runtime/src/ai/conversations.ts
+++ b/packages/node-runtime/src/ai/conversations.ts
@@ -8,6 +8,7 @@
 import Database from 'better-sqlite3'
 import * as fs from 'fs'
 import * as path from 'path'
+import type { ChartPayload } from '@openchatlab/core'
 
 const DEFAULT_GENERAL_ID = 'general_cn'
 
@@ -26,6 +27,7 @@ export interface AIConversation {
 export type ContentBlock =
   | { type: 'text'; text: string }
   | { type: 'think'; tag: string; text: string; durationMs?: number }
+  | { type: 'chart'; chart: ChartPayload }
   | {
       type: 'tool'
       tool: {

--- a/packages/node-runtime/src/ai/i18n/locales/en-US.ts
+++ b/packages/node-runtime/src/ai/i18n/locales/en-US.ts
@@ -252,6 +252,19 @@ Returned summaries are brief descriptions of each session, helping quickly locat
           top_n: 'Number of top keywords to return',
         },
       },
+      get_schema: {
+        desc: 'Inspect the chat database schema. Use it before charting or custom SQL when table or field names are uncertain.',
+        params: {},
+      },
+      render_chart: {
+        desc: 'Generate a native ChatLab chart from read-only SQL and ChartSpec v1. Supports bar, line, pie, and heatmap. Do not output HTML, JavaScript, SVG, ECharts options, or rendering code.',
+        params: {
+          sql: 'Read-only SELECT or WITH SELECT SQL. It must return fields referenced by ChartSpec encoding.',
+          params: 'Named SQL parameters. Use an empty object when no parameters are needed.',
+          chartSpec: 'ChartSpec v1 with version, type, title, and encoding.',
+          maxRows: 'Maximum chart query rows. Default 1000.',
+        },
+      },
     },
 
     // ===== AI Agent system prompts =====

--- a/packages/node-runtime/src/ai/i18n/locales/ja-JP.ts
+++ b/packages/node-runtime/src/ai/i18n/locales/ja-JP.ts
@@ -252,6 +252,19 @@ export default {
           top_n: '上位何個のキーワードを返却するか',
         },
       },
+      get_schema: {
+        desc: 'チャットデータベースのスキーマを確認します。チャート作成やカスタム SQL の前にテーブル名とフィールド名を確認してください。',
+        params: {},
+      },
+      render_chart: {
+        desc: '読み取り専用 SQL と ChartSpec v1 から ChatLab ネイティブチャートを生成します。bar、line、pie、heatmap をサポートします。HTML、JavaScript、SVG、ECharts option、描画コードは出力しないでください。',
+        params: {
+          sql: '読み取り専用の SELECT または WITH SELECT SQL。ChartSpec encoding で参照するフィールドを返す必要があります。',
+          params: 'SQL の名前付きパラメータ。不要な場合は空オブジェクトを渡します。',
+          chartSpec: 'version、type、title、encoding を含む ChartSpec v1。',
+          maxRows: 'チャートクエリの最大行数。デフォルトは 1000。',
+        },
+      },
     },
 
     agent: {

--- a/packages/node-runtime/src/ai/i18n/locales/zh-CN.ts
+++ b/packages/node-runtime/src/ai/i18n/locales/zh-CN.ts
@@ -243,6 +243,19 @@ export default {
           top_n: '返回前多少个关键词',
         },
       },
+      get_schema: {
+        desc: '查看聊天数据库表结构。绘图或自定义 SQL 前应先用它确认表名和字段名。',
+        params: {},
+      },
+      render_chart: {
+        desc: '根据只读 SQL 和 ChartSpec v1 生成 ChatLab 原生图表。支持 bar、line、pie、heatmap。禁止输出 HTML、JavaScript、SVG、ECharts option 或渲染代码。',
+        params: {
+          sql: '只读 SELECT 或 WITH SELECT SQL。必须返回 ChartSpec encoding 中引用的字段。',
+          params: 'SQL 命名参数对象；不需要参数时传空对象。',
+          chartSpec: 'ChartSpec v1，包含 version、type、title、encoding。',
+          maxRows: '图表查询最大行数，默认 1000。',
+        },
+      },
     },
 
     agent: {

--- a/packages/node-runtime/src/ai/i18n/locales/zh-TW.ts
+++ b/packages/node-runtime/src/ai/i18n/locales/zh-TW.ts
@@ -243,6 +243,19 @@ export default {
           top_n: '回傳前多少個關鍵詞',
         },
       },
+      get_schema: {
+        desc: '查看聊天資料庫表結構。繪圖或自訂 SQL 前應先用它確認表名和欄位名。',
+        params: {},
+      },
+      render_chart: {
+        desc: '根據唯讀 SQL 和 ChartSpec v1 生成 ChatLab 原生圖表。支援 bar、line、pie、heatmap。禁止輸出 HTML、JavaScript、SVG、ECharts option 或渲染程式碼。',
+        params: {
+          sql: '唯讀 SELECT 或 WITH SELECT SQL。必須返回 ChartSpec encoding 中引用的欄位。',
+          params: 'SQL 命名參數物件；不需要參數時傳空物件。',
+          chartSpec: 'ChartSpec v1，包含 version、type、title、encoding。',
+          maxRows: '圖表查詢最大行數，預設 1000。',
+        },
+      },
     },
 
     agent: {

--- a/packages/tools/src/definitions/render-chart.test.ts
+++ b/packages/tools/src/definitions/render-chart.test.ts
@@ -1,0 +1,148 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { renderChartTool } from './render-chart'
+import type { ToolDataProvider, ToolExecutionContext } from '../types'
+
+const barSpec = {
+  version: 1,
+  type: 'bar',
+  title: 'Messages by member',
+  encoding: { x: 'name', y: 'message_count' },
+} as const
+
+function createContext(
+  rows: Record<string, unknown>[],
+  calls: Array<{ query: string; params: Record<string, unknown> }>
+): ToolExecutionContext {
+  const dataProvider = {
+    async executeParameterizedSql(query: string, params: Record<string, unknown>) {
+      calls.push({ query, params })
+      return rows
+    },
+  } as Partial<ToolDataProvider> as ToolDataProvider
+
+  return {
+    sessionId: 'session-1',
+    locale: 'en-US',
+    dataProvider,
+  }
+}
+
+describe('renderChartTool', () => {
+  it('runs parameterized read-only SQL and returns a normalized chart payload', async () => {
+    const calls: Array<{ query: string; params: Record<string, unknown> }> = []
+    const context = createContext(
+      [
+        { name: 'Alice', message_count: 4 },
+        { name: 'Bob', message_count: 3 },
+      ],
+      calls
+    )
+
+    const result = await renderChartTool.handler(
+      {
+        sql: 'SELECT name, message_count FROM member_stats WHERE days = @days',
+        params: { days: 7 },
+        chartSpec: barSpec,
+        maxRows: 2,
+      },
+      context
+    )
+
+    assert.equal(calls.length, 1)
+    assert.equal(
+      calls[0]?.query,
+      'SELECT * FROM (\nSELECT name, message_count FROM member_stats WHERE days = @days\n) AS chart_query LIMIT 3'
+    )
+    assert.deepEqual(calls[0]?.params, { days: 7 })
+    assert.equal(result.chart?.spec.type, 'bar')
+    assert.deepEqual(result.chart?.data, { labels: ['Alice', 'Bob'], values: [4, 3] })
+    assert.deepEqual(result.chart?.dataset.rows, [
+      { name: 'Alice', message_count: 4 },
+      { name: 'Bob', message_count: 3 },
+    ])
+  })
+
+  it('truncates rows after fetching one more than maxRows', async () => {
+    const calls: Array<{ query: string; params: Record<string, unknown> }> = []
+    const context = createContext(
+      [
+        { name: 'Alice', message_count: 4 },
+        { name: 'Bob', message_count: 3 },
+        { name: 'Cara', message_count: 2 },
+      ],
+      calls
+    )
+
+    const result = await renderChartTool.handler(
+      {
+        sql: 'WITH ranked AS (SELECT name, message_count FROM member_stats) SELECT name, message_count FROM ranked',
+        chartSpec: barSpec,
+        maxRows: 2,
+      },
+      context
+    )
+
+    assert.equal(
+      calls[0]?.query,
+      'SELECT * FROM (\nWITH ranked AS (SELECT name, message_count FROM member_stats) SELECT name, message_count FROM ranked\n) AS chart_query LIMIT 3'
+    )
+    assert.equal(result.chart?.rowCount, 2)
+    assert.equal(result.chart?.truncated, true)
+    assert.deepEqual(result.chart?.data, { labels: ['Alice', 'Bob'], values: [4, 3] })
+  })
+
+  it('rejects direct write statements before reaching the data provider', async () => {
+    const calls: Array<{ query: string; params: Record<string, unknown> }> = []
+    const context = createContext([], calls)
+
+    await assert.rejects(async () => {
+      await renderChartTool.handler(
+        {
+          sql: 'DELETE FROM message',
+          chartSpec: barSpec,
+        },
+        context
+      )
+    }, /only accepts SELECT or WITH SELECT SQL/)
+    assert.equal(calls.length, 0)
+  })
+
+  it('enforces an outer row limit even when SQL already has a LIMIT', async () => {
+    const calls: Array<{ query: string; params: Record<string, unknown> }> = []
+    const context = createContext([{ name: 'Alice', message_count: 4 }], calls)
+
+    await renderChartTool.handler(
+      {
+        sql: 'SELECT name, message_count FROM member_stats LIMIT 100000',
+        chartSpec: barSpec,
+        maxRows: 2,
+      },
+      context
+    )
+
+    assert.equal(
+      calls[0]?.query,
+      'SELECT * FROM (\nSELECT name, message_count FROM member_stats LIMIT 100000\n) AS chart_query LIMIT 3'
+    )
+  })
+
+  it('does not let a trailing line comment swallow the enforced row limit', async () => {
+    const calls: Array<{ query: string; params: Record<string, unknown> }> = []
+    const context = createContext([{ name: 'Alice', message_count: 4 }], calls)
+
+    await renderChartTool.handler(
+      {
+        sql: 'SELECT name, message_count FROM member_stats -- model note',
+        chartSpec: barSpec,
+        maxRows: 2,
+      },
+      context
+    )
+
+    assert.equal(
+      calls[0]?.query,
+      'SELECT * FROM (\nSELECT name, message_count FROM member_stats -- model note\n) AS chart_query LIMIT 3'
+    )
+  })
+})

--- a/packages/tools/src/definitions/render-chart.ts
+++ b/packages/tools/src/definitions/render-chart.ts
@@ -1,0 +1,110 @@
+/**
+ * Dynamic chart rendering tool.
+ *
+ * The model provides read-only SQL plus a ChartSpec. ChatLab executes and
+ * validates the result before producing a chart payload for the chat UI.
+ */
+
+import { buildChartPayload } from '@openchatlab/core'
+import type { ToolDefinition, ToolExecutionContext, ToolResult, JsonSchema } from '../types'
+
+const DEFAULT_MAX_ROWS = 1000
+
+const inputSchema: JsonSchema = {
+  type: 'object',
+  properties: {
+    sql: {
+      type: 'string',
+      description: 'Read-only SELECT or WITH SELECT SQL used to produce chart rows.',
+    },
+    params: {
+      type: 'object',
+      description: 'Named SQL parameters. Use an empty object when no parameters are needed.',
+      additionalProperties: true,
+      default: {},
+    },
+    chartSpec: {
+      type: 'object',
+      description:
+        'ChartSpec v1. Required fields: version, type, title, encoding. Supported types: bar, line, pie, heatmap.',
+      additionalProperties: true,
+    },
+    maxRows: {
+      type: 'number',
+      description: 'Maximum rows to fetch before chart normalization.',
+      default: DEFAULT_MAX_ROWS,
+      minimum: 1,
+      maximum: 5000,
+    },
+  },
+  required: ['sql', 'chartSpec'],
+}
+
+function normalizeSql(sql: unknown, maxRows: number): string {
+  if (typeof sql !== 'string' || sql.trim().length === 0) {
+    throw new Error('sql must be a non-empty string')
+  }
+
+  const trimmed = sql.trim().replace(/;+\s*$/, '')
+  if (trimmed.includes(';')) {
+    throw new Error('Only a single read-only SQL statement is allowed')
+  }
+
+  const statementStart = trimmed.replace(/^(\s|--[^\n]*(\n|$)|\/\*[\s\S]*?\*\/)*/, '')
+  if (!/^(SELECT|WITH)\b/i.test(statementStart)) {
+    throw new Error('render_chart only accepts SELECT or WITH SELECT SQL')
+  }
+
+  return `SELECT * FROM (\n${trimmed}\n) AS chart_query LIMIT ${maxRows + 1}`
+}
+
+function normalizeParams(raw: unknown): Record<string, unknown> {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return {}
+  return raw as Record<string, unknown>
+}
+
+function normalizeMaxRows(raw: unknown): number {
+  const value = typeof raw === 'number' ? raw : DEFAULT_MAX_ROWS
+  if (!Number.isFinite(value)) return DEFAULT_MAX_ROWS
+  return Math.min(5000, Math.max(1, Math.floor(value)))
+}
+
+function summarizeChart(type: string, title: string, rowCount: number, truncated: boolean, locale?: string): string {
+  if (locale?.startsWith('zh')) {
+    return `已生成图表「${title}」（${type}，${rowCount} 行数据${truncated ? '，已截断' : ''}）。`
+  }
+  return `Generated chart "${title}" (${type}, ${rowCount} rows${truncated ? ', truncated' : ''}).`
+}
+
+async function handler(params: Record<string, unknown>, context: ToolExecutionContext): Promise<ToolResult> {
+  if (!context.dataProvider) throw new Error('render_chart requires a data provider')
+
+  const maxRows = normalizeMaxRows(params.maxRows)
+  const sql = normalizeSql(params.sql, maxRows)
+  const sqlParams = normalizeParams(params.params)
+
+  const fetchedRows = await context.dataProvider.executeParameterizedSql<Record<string, unknown>>(sql, sqlParams)
+  const truncated = fetchedRows.length > maxRows
+  const rows = truncated ? fetchedRows.slice(0, maxRows) : fetchedRows
+  const chart = buildChartPayload(rows, params.chartSpec, { truncated })
+
+  return {
+    content: summarizeChart(chart.spec.type, chart.spec.title, rows.length, truncated, context.locale),
+    data: {
+      rowCount: rows.length,
+      truncated,
+      chartType: chart.spec.type,
+      title: chart.spec.title,
+    },
+    chart,
+  }
+}
+
+export const renderChartTool: ToolDefinition = {
+  name: 'render_chart',
+  description:
+    'Generate a native ChatLab chart from read-only SQL plus ChartSpec v1. Use this for flexible bar, line, pie, and heatmap charts. Never output HTML, JavaScript, SVG, ECharts options, or rendering code.',
+  inputSchema,
+  handler,
+  category: 'analysis',
+}

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -29,6 +29,7 @@ export { getConversationBetweenTool } from './definitions/get-conversation-betwe
 export { getSessionSummariesTool } from './definitions/get-session-summaries'
 export { responseTimeAnalysisTool } from './definitions/response-time-analysis'
 export { keywordFrequencyTool } from './definitions/keyword-frequency'
+export { renderChartTool } from './definitions/render-chart'
 
 // === SQL Tools ===
 export { SQL_TOOL_DEFS, createSqlToolDefinition, createAllSqlToolDefinitions } from './sql'

--- a/packages/tools/src/registry.ts
+++ b/packages/tools/src/registry.ts
@@ -11,6 +11,7 @@
 import type { ToolDefinition } from './types'
 
 import { sqlQueryTool, schemaTool } from './definitions/sql-query'
+import { renderChartTool } from './definitions/render-chart'
 import { sessionInfoTool } from './definitions/session-info'
 import { sessionsListTool } from './definitions/sessions'
 import { chatOverviewTool } from './definitions/chat-overview'
@@ -44,6 +45,7 @@ const SHARED_TOOLS: ToolDefinition[] = [
   searchSessionsTool,
   getSessionMessagesTool,
   getMembersTool,
+  schemaTool,
 
   // Analysis
   memberStatsTool,
@@ -53,6 +55,7 @@ const SHARED_TOOLS: ToolDefinition[] = [
   getSessionSummariesTool,
   responseTimeAnalysisTool,
   keywordFrequencyTool,
+  renderChartTool,
 
   // Raw SQL
   sqlQueryTool,
@@ -75,7 +78,6 @@ export const MCP_TOOL_REGISTRY: ToolDefinition[] = [
   // MCP-specific: session discovery & schema
   sessionsListTool,
   sessionInfoTool,
-  schemaTool,
   // Shared core + analysis + raw SQL
   ...SHARED_TOOLS,
 ]

--- a/packages/tools/src/types.ts
+++ b/packages/tools/src/types.ts
@@ -4,7 +4,7 @@
  * 平台无关的工具注册表类型，同时服务于 MCP Server、HTTP API 和 Electron Agent。
  */
 
-import type { DatabaseAdapter } from '@openchatlab/core'
+import type { ChartPayload, DatabaseAdapter } from '@openchatlab/core'
 
 // ==================== Schema ====================
 
@@ -19,6 +19,8 @@ export interface JsonSchema {
       type: string
       description?: string
       items?: { type: string }
+      properties?: Record<string, unknown>
+      additionalProperties?: boolean | Record<string, unknown>
       default?: unknown
       enum?: unknown[]
       minimum?: number
@@ -268,6 +270,8 @@ export interface RawMessage {
 export interface ToolResult {
   content: string
   data?: unknown
+  chart?: ChartPayload
+  charts?: ChartPayload[]
   /** 消息类工具可透传原始消息数据，供预处理管道消费 */
   rawMessages?: RawMessage[]
 }

--- a/project document/README.md
+++ b/project document/README.md
@@ -1,0 +1,46 @@
+# Project Document
+
+This folder is the handoff space for the ChatLab AI chart runtime work.
+
+Use it when the current AI context is exhausted and another AI or engineer needs to continue without re-reading the whole conversation.
+
+## Documents
+
+- `ai-chart-runtime.md` records the final product goal, MVP architecture, and implementation plan.
+- `handoff-log.md` records what each conversation has completed and what remains.
+
+## Current Status
+
+As of 2026-06-04, the first implementation slice and targeted hardening tests have been added but are not yet committed.
+
+The active development branch is:
+
+```text
+codex/new-feature
+```
+
+The feature is implemented as a slash-activated chart capability inside the AI chat experience.
+
+Current code covers:
+
+- shared `ChartSpec` validation and chart data normalization
+- stricter `render_chart` SQL entry validation before data-provider execution
+- enforced outer SQL row limit wrapping for every `render_chart` query
+- real SQLite chat-data integration coverage for flexible `render_chart` SQL + ChartSpec payloads
+- real SQLite safety regression coverage for CTE-prefixed write attempts through `render_chart`
+- `render_chart` tool registration for Electron and CLI Web paths
+- chart payload transport through tool results
+- frontend `chart` content blocks and inline chart rendering
+- frontend chart payload extraction helpers and smoke-build harness coverage
+- headless Edge screenshot smoke coverage for the chart renderer harness
+- slash menu activation through a synthetic chart capability
+- shared chart-capability tool allowlist wiring for Electron and CLI Web
+- Agent event-handler preservation of chart-bearing tool results
+- offline Agent-level chart flow coverage from natural-language prompt to `render_chart` tool result and final answer
+- offline Agent-level multi-chart flow coverage when the user asks for two charts in one answer
+- opt-in real external LLM E2E harness for model-generated SQL + ChartSpec over real temporary chat data
+- frontend skill-store coverage for the slash menu chart capability and single-message toggle API
+- visible error-block handling for render-only chart tool failures
+- normalized chart payload persistence through existing `content_blocks` JSON storage
+
+Known remaining work is tracked in `handoff-log.md`.

--- a/project document/ai-chart-runtime.md
+++ b/project document/ai-chart-runtime.md
@@ -1,0 +1,143 @@
+# AI Chart Runtime Goal
+
+## Final Goal
+
+Build a slash-activated, AI-driven chart capability for ChatLab.
+
+The feature is not a fixed report system. Users should be able to ask for flexible visual analysis in natural language, including:
+
+- who to analyze: all members, selected members, or excluded members
+- what to measure: message count, word count, image count, reply count, ratio, average length, or other SQL-computable metrics
+- time range: recent N days, a month, custom range, or the current chat context
+- grouping dimensions: member, date, hour, message type, keyword, or custom SQL-derived fields
+- chart type: bar, line, pie, or heatmap for the first version
+- chart encoding: the meaning of x, y, value, color, and series must follow the user's request
+
+The intended flow is:
+
+```text
+User selects chart assistant with /
+-> User asks a chart question
+-> AI generates read-only SQL + ChartSpec
+-> ChatLab validates SQL, fields, and chart schema
+-> ChatLab executes the query and normalizes data
+-> AI response embeds one or more chart content blocks naturally among text
+```
+
+## Product Behavior
+
+- The chart capability is activated per message from the chat input slash menu.
+- The selection is single-use: after sending, it clears automatically.
+- When activated, the AI may call chart tools and return charts in the answer.
+- Chart count follows the user's request. If the user asks for two charts, return two charts. If the user asks for one chart, return one chart.
+- If the user did not explicitly request charts, AI may be conservative and add at most one chart only when it clearly improves ranking, trend, distribution, ratio, or density analysis.
+- Charts should feel native inside the AI answer, like Markdown content blocks, not like a separate report page.
+- The `render_chart` tool call should not show a normal tool capsule by default; the visible output should be the chart block. Errors may still appear as error blocks.
+
+## Engineering Shape
+
+First version should add:
+
+- `ChartSpec` and chart dataset types.
+- A `render_chart` analysis tool.
+- A `chart` content block type in frontend and node-runtime conversation types.
+- Stream support for chart payloads from tool results.
+- A `ChartBlockRenderer` that uses existing chart components.
+- Persistence of normalized chart rendering data so historical conversations do not need to re-run SQL.
+
+First version chart types:
+
+```text
+bar
+line
+pie
+heatmap
+```
+
+The AI must not output or execute:
+
+```text
+HTML
+JavaScript
+SVG
+Canvas code
+ECharts option
+arbitrary frontend component code
+```
+
+ChatLab owns rendering through built-in chart components.
+
+## Key Implementation Notes
+
+- Existing slash skill selection already works as a single-message activation model. Reuse that interaction pattern for the chart capability.
+- Existing analysis tools are opt-in through assistant/tool filtering. The chart capability should temporarily expose the required chart tools for the current request.
+- Existing readonly SQL safety exists in `packages/core/src/query`. `render_chart` should reuse that safety boundary.
+- Current `ToolResult` does not include chart payloads. The implementation must add a structured way to pass chart payloads through Electron and CLI Web.
+- Current `ContentBlock` does not include `chart`. Add it consistently to both frontend store types and node-runtime conversation types.
+- Current `ChatMessage.vue` only renders text, think, skill, tool, and error blocks. Add chart rendering through a dedicated renderer component.
+
+## MVP Plan
+
+1. Define chart schema and normalized data model.
+2. Implement chart validation and row-to-component-data normalization.
+3. Add `render_chart` as an opt-in analysis tool.
+4. Add chart payload transport through tool results and stream chunks.
+5. Add frontend chart content block rendering.
+6. Add slash menu entry for the chart assistant/capability.
+7. Add tests for schema validation, SQL safety, normalization, adapters, and frontend type coverage.
+
+## Implemented First Slice
+
+As of 2026-06-03, the first vertical slice is implemented:
+
+- `ChartSpec` and `ChartPayload` live in shared core code.
+- Bar, line, pie, and heatmap payload normalization is covered by core tests.
+- `render_chart` is registered as an analysis tool in shared, Electron, and CLI Web paths.
+- `get_schema` is available as a shared core tool so chart prompts can inspect database shape.
+- Tool adapters preserve structured chart payloads in tool result details.
+- AI chat messages can append chart content blocks from `render_chart` results.
+- The chat UI renders chart blocks inline using existing chart components.
+- Slash menu exposes a synthetic chart capability with per-message activation.
+
+## Implemented Hardening
+
+As of 2026-06-03, targeted hardening has also been added:
+
+- `render_chart` now rejects non-`SELECT` / non-`WITH` SQL before calling the data provider.
+- `render_chart` wraps every accepted query as a subquery with an outer `LIMIT maxRows + 1`, so model-provided large `LIMIT` clauses or trailing line comments cannot bypass ChatLab's fetch cap.
+- `render_chart` tests cover parameterized SQL, enforced outer row limits, row truncation, normalized chart payload output, direct write-statement rejection, existing inner `LIMIT`, and trailing line comments.
+- `tests/chart-runtime/render-chart.integration.test.ts` uses a real temporary ChatLab SQLite chat database, `CoreDataProvider`, real readonly SQL, and dynamic ChartSpec payloads to verify selected-member pie, multi-series line, and heatmap generation from chat tables.
+- The same real SQLite integration test now verifies that a `WITH`-prefixed `DELETE` attempt is rejected and does not mutate chat data.
+- CLI Web adapter tests cover preservation of `chart` payloads in agent tool result details.
+- Conversation manager tests cover `chart` content block persistence and reload from the existing `content_blocks` JSON field.
+- Current evidence indicates no explicit database migration is needed for chart history replay because `content_blocks` already stores arbitrary JSON blocks and now includes the `chart` union type.
+- Frontend chart helper tests cover extraction of `chart` / `charts` payloads from agent tool result details and conversion into chart content blocks.
+- `ChartBlockRenderer` imports only the four chart components it renders, avoiding accidental dependency on the full chart barrel.
+- `tests/chart-smoke` provides a repeatable Vite build harness for `ChartBlockRenderer` with bar, line, pie, and heatmap payloads.
+- A headless Microsoft Edge screenshot smoke test verified that `tests/chart-smoke` renders visible bar, line, pie, and heatmap chart output. Pixel analysis result: `size=1024x1600`, `non_bg=73423`, `colored=39133`, `bands=[5382, 33748, 4354, 29939]`.
+- Chart capability analysis-tool allowlist logic is shared in core and used by both Electron and CLI Web runners. Activating the chart capability adds `render_chart` without duplicating it, while `get_schema` remains available through the core tool path.
+- Agent event-handler regression coverage proves chart-bearing `render_chart` tool results are streamed through unchanged for frontend extraction.
+- `tests/chart-runtime/agent-chart-flow.test.ts` now provides an offline Agent-level flow: a natural-language prompt enters `runAgentCore`, a fake model stream emits a `render_chart` tool call, the real chart tool normalizes rows into a line chart payload, and a final answer is streamed after the tool result.
+- The same offline Agent-level test file now covers a user asking for two charts in one answer: the fake model emits pie and heatmap `render_chart` calls in one tool round, both calls use parameterized readonly CTE SQL plus ChartSpec, and both chart payloads are preserved in `tool_end` details.
+- `tests/chart-runtime/real-llm-chart-flow.e2e.test.ts` now provides an opt-in real external LLM E2E harness. It creates a temporary real ChatLab SQLite database, exposes `get_schema` and `render_chart`, asks the configured model for exactly two charts, and verifies pie plus heatmap payloads when `CHATLAB_RUN_REAL_LLM_CHART_E2E=1` is set.
+- `src/stores/skill.test.ts` now covers the slash-menu-facing chart capability: it appears as a compatible skill without import, activates with localized metadata, exposes `render_chart` / `get_schema`, and can be cleared through the same single-message toggle API.
+- Render-only chart tool failures now become visible error content blocks instead of disappearing silently when no chart payload is returned.
+
+## Still Pending
+
+- Run the opt-in real external LLM E2E harness with a live API key to verify model SQL generation quality, chart count, x/y/series semantics, and inline placement without a fake stream. The harness exists, but the external API call has not been executed in this thread.
+- Add stricter SQL/schema validation if future QA finds gaps around CTE shape, field references, or max row limits.
+- Full in-app Electron UI smoke test with real chat data.
+
+## Completed After Initial Implementation
+
+- Fixed EChart.vue initialization timing bug (2026-06-04): ECharts was reading container width before layout completed, resulting in narrow canvases. Deferred `initChart()` to `nextTick` in `onMounted`.
+- Browser smoke test verified: all 4 chart types render at full width without manual resize.
+
+## Out Of Scope For MVP
+
+- Full plugin marketplace support.
+- Long-lived global chart module toggle.
+- User-editable chart builder UI.
+- Dataset references between tool calls.
+- Graph, calendar, wordcloud, or custom ECharts option support.

--- a/project document/codexRecord.md
+++ b/project document/codexRecord.md
@@ -1,0 +1,2240 @@
+# 拉取main并创建功能分支
+
+> 拉取一下main分支的最新的代码，然后就是基于main分支，创建一个分支，我要开发一个新的功能，然后PR的时候PR到main
+
+<details><summary>7 previous messages</summary>
+
+> 我先按仓库规则看一下项目文档和当前 git 状态，然后拉取 `main` 并从最新 `main` 切新开发分支。
+>
+> `.docs/README.md` 在当前工作树里不存在，我会先确认是否是文档目录改名或缺失。当前分支有一些未跟踪文件，我会保留它们，不会清理或覆盖。
+>
+> 我看到仓库里实际是 `docs/README.md`，不是 `.docs/README.md`；我会按这个读。远端里 `upstream/main` 比 `origin/main` 更新，所以“最新 main”我会以 `upstream/main` 为准，再从它切开发分支。
+>
+> 接下来会执行真正的 git 操作：先抓取远端更新，切到 `main`，快进到最新 `upstream/main`，然后创建 `codex/new-feature`。未跟踪文件会保持原样。
+>
+> 远端已更新，`upstream/main` 又前进到了新的提交 `2f5d0398`。现在我会把本地 `main` 快进到这个提交再切分支。
+>
+> 本地 `main` 已经快进到最新的 `upstream/main`，这一步改动很大但都是上游内容。现在切出开发分支。
+>
+> 分支已经创建并切换好了。我再做一次状态确认，确保它确实基于最新 `main`。
+> </details>
+
+已完成：
+
+本地 `main` 已拉到最新的 `upstream/main`，当前最新提交是 `2f5d0398 ci(release): link markdown changelog`。我已经基于这个 `main` 创建并切换到新分支：
+
+`codex/new-feature`
+
+当前仍有这些未跟踪文件，我没有动它们：`.dev-home/`、`CLAUDE.md`、`chartDesign.md`、`newPlan.md`、`taskAssignment.md`。
+
+之后你在这个分支上开发，PR 目标分支选 `main` 就行。
+
+> 这是原先的计划，但是由于原作者对代码进行了大范围的重构，该计划可能已经失效。anyway，请你再阅读一下这份计划，理解我的目的
+>
+> User context
+>
+> Attachments:
+> - newPlan.md: `~/Desktop/newPlan.md`
+
+<details><summary>6 previous messages</summary>
+
+> 我先把仓库文档入口和你这份 `newPlan.md` 读一遍，重点不是立刻改代码，而是先还原你的目标和原计划的假设。
+>
+> 我已经读完计划主体。为了判断哪些目标仍然成立、哪些路径可能被重构冲掉，我再快速对照当前代码里的 `ChartHint`、工具适配器和聊天渲染链路。
+>
+> 刚才一个 `rg` 的引号在 PowerShell 里被吃掉了，我换成拆开的搜索。现在已经确认项目是 `0.24.0` 的 monorepo 形态，计划里说的大重构方向确实已经发生：桌面端、CLI、node-runtime、tools 都被拆开了。
+>
+> 对照结果比计划里更“干净”：当前 `packages/tools` 的公共 `ToolResult` 已经没有 `chartHint` 字段，`ChatMessage.vue` 目前也只渲染 text/think/skill/tool/error，不渲染 chart block。所以原计划里“已有 chartHint 链路”的部分在最新 main 上已经失效，或者被重构移除了。
+>
+> 我还看了两个 adapter：桌面端和 CLI Web 现在都只把工具结果转成文本，桌面端会保留部分 `details`，CLI Web 甚至直接丢掉普通工具的 `data/details`。这意味着如果要恢复/新增图表能力，第一步不只是补图表组件，而是要重新定义工具结果协议和跨端透传方式。
+>
+> 还有一个关键点：`ContentBlock` 类型定义目前分散在前端 store 和 node-runtime conversation 里，且都没有 chart 类型。后面如果要做这件事，应该先把 chart block 变成一等内容块，否则持久化和重放都会不稳。
+> </details>
+
+我读完了 [newPlan.md](~/Desktop/newPlan.md)，也快速对照了当前 `main` 的代码。你的核心目的我理解是：
+
+你不是想做几个写死的“报表图表”，而是想给 ChatLab 增加一套安全、可扩展的 AI 图表运行时。
+
+关键方向是：
+
+- 用户明确要求画图，或者 AI 判断图表更适合表达时，可以进入图表能力。
+- AI / Skill / Tool 只负责提出 `SQL + ChartSpec`，不能直接输出 HTML、JS、SVG、ECharts option。
+- ChatLab runtime 负责只读 SQL 校验、字段校验、schema 校验、执行查询、标准化数据。
+- 前端只用内置图表组件渲染，比如 bar、line、pie、heatmap。
+- 这套能力要能沉淀到 tools / skills 里，而不是核心里写死一堆 `if 用户说热力图 -> 跑某个固定函数`。
+- Electron 和 CLI Web 要走同一套共享协议，避免一端能画图另一端只能文本。
+
+但当前重构后的代码确实让原计划部分失效了：现在 `packages/tools/src/types.ts` 的 `ToolResult` 已经没有 `chartHint`，桌面和 CLI 的 tool adapter 也都只输出文本，`ContentBlock` 里没有 `chart` 类型，`ChatMessage.vue` 也没有 chart block 渲染逻辑。`activity_heatmap` 仍然只是声明式 SQL 文本工具。
+
+所以后续如果要落地，我会把计划重新基于当前代码收敛成新的 MVP，而不是照旧方案硬套。大概第一步会是：重新定义 `ChartSpec/ChartHint` 与 `chart` content block，再接 `render_chart` 工具和前端渲染闭环。当前有利条件是只读 SQL 安全基础还在，`activity_heatmap` 这种 SQL 工具也已经是很好的第一个验证场景。
+
+> 有以下这个方案：
+> 开发成技能的形式，用户在导入或每次对话选择该技能以后，AI聊天区就可以返回相对应的图表
+> 你如何评价？请从实现难度，实用性、可维护性、可拓展性等角度进行分析
+
+这个方案方向是对的，但要拆成两层来看：
+
+“开发成技能”适合解决 **AI 什么时候该画图、该怎么理解图表任务、该用什么 SQL/工具**。
+
+但它不适合单独承担 **图表协议、SQL 安全校验、图表渲染、跨端持久化** 这些硬能力。
+
+所以我的评价是：**技能可以作为入口和说明书，但不能作为唯一实现层。最佳形态是：技能触发 + runtime 执行。**
+
+**实现难度**
+
+中等偏高，但比“写死图表 planner”更健康。
+
+如果只是做成一个 skill prompt，难度很低：写一个 `chart_runtime` 技能，告诉 AI 用户要图表时调用某些工具。但这只能提升模型行为，不能保证真的能画图。
+
+真正可用需要补这些基础设施：
+
+- `ToolResult` 支持结构化图表结果。
+- `ContentBlock` 增加 `chart` 类型。
+- Electron / CLI Web adapter 都透传 chart block。
+- 前端 `ChatMessage.vue` 渲染 chart block。
+- 后端提供 `render_chart` 或图表型工具。
+- runtime 校验 SQL 只读、字段匹配、ChartSpec 合法。
+
+所以如果是“技能 + 现有系统自然就能返回图表”，目前做不到。当前代码里 skill 只能影响 AI 行为，不能让聊天区凭空支持图表块。
+
+**实用性**
+
+实用性很强，尤其符合 ChatLab 的产品形态。
+
+用户导入某个技能，比如“活跃度分析”“成员排行分析”“互动关系分析”，然后 AI 聊天区可以自然返回图表，这个体验很好。它比让用户手动去图表页找功能更符合 AI Agent 的使用方式。
+
+但有一个前提：技能不能只是“提示 AI 画图”。它应该明确告诉 AI：
+
+- 哪类问题适合画图。
+- 优先调用哪些原生工具。
+- 动态需求何时调用 `render_chart`。
+- 支持哪些图表类型。
+- SQL 和 ChartSpec 的格式是什么。
+- 用户指定热力图时不能偷偷改成柱状图。
+
+这样技能才像“分析能力包”，而不是一段容易失效的 prompt。
+
+**可维护性**
+
+单独靠技能，可维护性一般，甚至有风险。
+
+风险在于 schema 如果只写在技能里，会漂移。比如代码里支持 `version: 2`，技能里还教 AI 写 `version: 1`，就会大量失败。或者某个图表字段改名了，多个技能都复制了一份旧说明，也会炸。
+
+更可维护的方式是：
+
+- 代码里有唯一真实的 `ChartSpec` 类型和 validator。
+- 技能里只放 AI 可读的使用说明和少量 recipes。
+- 每个业务技能只描述自己的分析场景，不复制完整图表协议。
+- 有一个内置基础技能，比如 `chart_runtime`，统一讲图表 schema 和禁用行为。
+
+也就是说：
+
+```text
+chart_runtime 技能：通用图表协议说明
+业务技能：活跃时间、成员排行、消息类型分布等分析方法
+代码 runtime：真正校验、执行、渲染
+```
+
+这样维护成本最低。
+
+**可拓展性**
+
+这个方案的可拓展性很好，前提仍然是不要把能力只放在 skill prompt 里。
+
+如果架构做对，后续可以自然扩展：
+
+- 新增一个 skill，就能新增一种分析方法。
+- 新增一个 tool，就能提供更稳定的数据口径。
+- 新增一个图表类型，只需要扩展 ChartSpec validator 和前端 renderer。
+- Electron / CLI Web / MCP 可以共享同一套 tools 和 chart schema。
+- AI 可以处理动态组合需求，不需要核心代码为每种统计写死逻辑。
+
+比如未来可以有：
+
+```text
+activity_chart_skill
+member_ranking_skill
+message_type_distribution_skill
+relationship_graph_skill
+keyword_trend_skill
+```
+
+它们都不直接画图，而是指导 AI 调用统一的 `render_chart` 或图表型 tools。
+
+**我的结论**
+
+这个方案值得做，但不要理解成“把图表功能开发成一个技能就完事”。
+
+我建议的最终判断是：
+
+```text
+技能负责触发和分析策略；
+Tool 负责稳定数据能力；
+Chart runtime 负责安全执行和 schema 校验；
+前端负责内置组件渲染。
+```
+
+第一版 MVP 可以这样收敛：
+
+1. 先做内置 `chart_runtime` 技能。
+2. 加 `render_chart` 工具。
+3. 支持 `bar / line / pie / heatmap`。
+4. 给 `activity_heatmap` 作为第一个业务验证场景。
+5. 让聊天区支持 `chart` content block。
+6. Electron 和 CLI Web adapter 都透传图表结果。
+
+这样它既是“技能形式”的用户体验，又不会把安全性和可维护性压在 prompt 上。
+
+> 我这里所说的技能不是广义的skill.md，而是说作为一个开关，一个拓展的性能，独立去开发，然后作为插件或者模块独立导入，用户可以自行打开或关闭这个技能
+
+明白，你说的“技能”更像 **可插拔功能模块 / capability toggle**，不是 prompt 型 `SKILL.md`。
+
+这个方案我评价会更高：**作为产品形态是合理的，甚至比单纯 prompt skill 更适合图表能力**。但它最好被设计成“模块化能力包”，而不是只是在 UI 上加一个开关。
+
+核心判断：
+
+```text
+图表能力适合做成可启用/禁用的独立模块；
+但模块内部仍然需要 runtime、tool、schema、前端 renderer 共同组成。
+```
+
+**实现难度**
+
+中高。
+
+如果只是加一个“启用图表分析”的开关，难度不高。但如果要做到用户启用后，AI 聊天区能稳定返回对应图表，就需要这几个部分一起接入：
+
+- 功能开关：用户可启用/禁用图表模块。
+- 工具注册：启用后，Agent 才能看到 `render_chart` 或图表分析 tools。
+- 系统提示/能力描述：启用后，AI 才知道什么时候该使用图表。
+- 结果协议：工具需要返回结构化 `chart` block。
+- 前端渲染：聊天区要支持图表内容块。
+- 持久化：历史 AI 消息里的图表要能保存和重放。
+- 跨端适配：Electron 和 CLI Web 的行为要一致。
+
+所以它不是一个小功能开关，而是一个 **capability module**。实现上建议把它做成独立模块，但底层协议要进入共享层。
+
+**实用性**
+
+很强。
+
+这个形态对用户很自然：
+
+- 不想让 AI 聊天变复杂的用户，可以关闭。
+- 喜欢数据分析的用户，可以打开。
+- 不同场景可以启用不同能力，比如“基础图表”“社群活跃分析”“互动关系分析”。
+- 后续也可以做成插件市场或内置扩展能力。
+
+尤其 ChatLab 本身是聊天记录分析工具，图表不是所有用户每次都需要，但一旦需要，它非常有价值。所以“默认可控、按需启用”比强行内置到所有 AI 对话里更好。
+
+**可维护性**
+
+取决于模块边界。
+
+好的设计应该是：
+
+```text
+chart capability module
+  - 注册 tools
+  - 注册 AI capability prompt
+  - 注册 chart schema 版本
+  - 注册前端可渲染 block 类型
+  - 注册 i18n 文案
+  - 注册权限/安全策略
+```
+
+但有些东西不应该散落在插件里，比如：
+
+- SQL 只读校验
+- ChartSpec validator
+- chart content block 基础类型
+- 前端图表 renderer 容器
+- 持久化格式
+
+这些应该是核心平台能力。否则每个插件都自己定义图表协议，后面一定会混乱。
+
+所以维护性最好的边界是：
+
+```text
+核心平台提供图表运行时和协议；
+图表模块提供具体能力、工具、提示词和业务 recipes。
+```
+
+**可拓展性**
+
+很好，而且比“核心写死图表 planner”强很多。
+
+未来可以自然扩展成：
+
+- `chart-basic`：柱状图、折线图、饼图、热力图。
+- `chart-social`：成员排行、互动关系、活跃时段。
+- `chart-keyword`：词频、关键词趋势。
+- `chart-calendar`：日历热力图。
+- `chart-graph`：关系网络图。
+
+每个模块启用后，只注册自己的工具和能力描述。AI 根据当前启用模块决定是否调用。
+
+这会让 ChatLab 从“有几个固定图表功能”变成“有一个可扩展的数据分析能力系统”。
+
+**风险**
+
+最大风险是：模块开关只控制 prompt，不控制工具和 runtime。
+
+如果用户关闭了图表模块，但 AI 仍能调用图表工具，或者历史消息里出现无法渲染的 chart block，体验会不一致。
+
+另一个风险是模块版本。比如历史消息保存的是 `ChartSpec v1`，后来模块升级到 `v2`，前端仍然需要兼容旧图表。
+
+所以建议一开始就加版本字段：
+
+```ts
+{
+  type: "chart",
+  version: 1,
+  chartType: "heatmap",
+  spec: {...},
+  dataset: {...}
+}
+```
+
+**我建议的最终架构**
+
+可以这样分层：
+
+```text
+Core
+- ContentBlock 支持 chart
+- ChartSpec 类型和 validator
+- SQL readonly 安全执行
+- 图表数据标准化
+- 前端 ChartBlockRenderer
+- 持久化兼容
+
+Chart Module
+- 用户开关
+- 注册 render_chart tool
+- 注册图表相关 system prompt/capability description
+- 注册内置分析 tools，比如 activity_heatmap
+- 注册图表类型支持列表
+- 注册 i18n 文案
+```
+
+**结论**
+
+这个方案我认为是正确方向，产品上也更优雅。
+
+但它应该叫“可插拔图表能力模块”，而不是单纯“技能”。用户层面可以叫“技能”，工程层面最好按 capability/plugin module 设计。
+
+一句话：
+
+```text
+把图表做成用户可开关的独立能力模块是对的；
+但图表协议、安全执行、内容块渲染必须进入核心共享层，
+否则这个模块会变成一组不稳定的 prompt 和工具补丁。
+```
+
+> 而且我的最终目的是要这个图表非常灵活，横轴纵轴的坐标含义，热力图、折线图的每根线的含义都要符合用户的自定义需求，而不是说这个饼图只能实现所有成员的统计，而要是用户说统计哪些人，这个饼图就统计哪些人，你理解了吗
+
+理解了，而且这是这个功能的关键边界。
+
+你的目标不是“内置几个固定图表”，也不是“某个饼图组件默认统计全体成员”。你要的是 **AI 聊天里的灵活数据可视化能力**：
+
+用户可以自然语言指定：
+
+- 统计对象：所有人、某几个人、某个群体、排除某些人
+- 统计范围：最近 7 天、某个月、某段聊天、某个会话
+- 统计口径：消息数、字数、图片数、回复次数、活跃天数、平均长度
+- 横轴含义：日期、小时、成员、消息类型、关键词、月份
+- 纵轴含义：消息数、人数、比例、平均值
+- 系列含义：每个人一条线、每种消息类型一条线、不同时间段对比
+- 图表类型：饼图、柱状图、折线图、热力图等
+
+所以正确的能力形态应该是：
+
+```text
+用户自定义分析需求
+-> AI 理解统计口径
+-> AI 生成 SQL / 查询计划
+-> AI 生成 ChartSpec
+-> Runtime 校验 SQL 和字段映射
+-> 前端按 ChartSpec 渲染内置图表
+```
+
+也就是说，图表不是固定报表，而是一个 **动态映射系统**。
+
+比如用户说：
+
+> 只统计张三、李四、王五最近 30 天的发言占比，画饼图
+
+就不应该调用一个“全体成员占比”的固定饼图，而应该生成类似：
+
+```text
+SQL:
+查询 sender_id in 张三、李四、王五，按成员 group by，统计 count
+
+ChartSpec:
+type: pie
+label: member_name
+value: message_count
+filters: members = 张三、李四、王五
+```
+
+用户说：
+
+> 画最近一个月张三和李四每天发言趋势，每个人一条线
+
+就应该是：
+
+```text
+SQL:
+按 day + member 分组统计
+
+ChartSpec:
+type: line
+x: day
+y: message_count
+series: member_name
+```
+
+用户说：
+
+> 看工作日晚上 8 点到 12 点谁最活跃，用柱状图
+
+就是：
+
+```text
+SQL:
+WHERE weekday in 1..5 AND hour between 20 and 23
+GROUP BY member
+
+ChartSpec:
+type: bar
+x: member_name
+y: message_count
+```
+
+这也说明为什么不能只靠固定 tools。固定 tools 可以作为稳定模板，但核心必须支持：
+
+```text
+动态 SQL + 动态 ChartSpec
+```
+
+我会把你的需求总结成一句更准确的话：
+
+```text
+用户不是在请求某个固定图表功能，而是在请求一个可通过自然语言配置维度、指标、筛选、分组和图表编码的数据可视化运行时。
+```
+
+因此，后续设计里最重要的不是“加饼图/折线图组件”，而是这几个东西：
+
+- `filters`：用户指定统计谁、什么时间、什么消息类型。
+- `metrics`：统计消息数、比例、平均长度等。
+- `dimensions`：按成员、日期、小时、类型、关键词分组。
+- `encoding`：哪个字段映射到 x/y/value/series/color。
+- `series`：折线图每条线代表什么。
+- `validation`：确保用户说的图表类型和实际字段匹配。
+- `fallback`：如果无法满足用户指定，不要偷偷换图，要说明原因。
+
+所以我完全理解：你要的是灵活可组合的图表能力，而不是固定图表入口。
+
+> 所以，综合以上这些需求，请你言简意赅的重新总结一下我的需求以及项目的简单规划
+
+你的需求可以总结为：
+
+你想给 ChatLab 做一个 **可开关、可扩展、由 AI 驱动的灵活图表能力模块**。
+
+它不是固定报表，不是“饼图只能统计全员”“热力图只能画星期×小时”，而是用户可以用自然语言自定义：
+
+- 统计谁：全员、指定成员、排除成员
+- 统计什么：消息数、字数、图片数、回复数、占比、平均值
+- 统计范围：最近 N 天、某个月、某段时间、某个会话
+- 怎么分组：按成员、日期、小时、消息类型、关键词
+- 怎么画：饼图、柱状图、折线图、热力图
+- 坐标含义：x/y/value/series 都由需求动态决定
+
+核心目标：
+
+```text
+用户问题
+-> AI 理解分析意图
+-> 生成只读 SQL + ChartSpec
+-> ChatLab 校验安全性和字段映射
+-> 执行查询并标准化数据
+-> 前端用内置图表组件渲染
+```
+
+简单规划：
+
+1. **核心协议**
+   定义 `ChartSpec`：图表类型、字段映射、筛选条件、统计口径、series 含义、标题、单位、版本号。
+
+2. **安全运行时**
+   提供 `render_chart` 能力，只允许只读 SQL，校验 SQL、返回字段、图表类型和 encoding 是否匹配。
+
+3. **内容块支持**
+   给 AI 聊天消息增加 `chart` content block，支持持久化、历史重放、Electron / CLI Web 透传。
+
+4. **前端渲染**
+   新增统一 `ChartBlockRenderer`，第一阶段支持 `bar / line / pie / heatmap`，只渲染内置组件，不接受 AI 生成的渲染代码。
+
+5. **可开关模块**
+   把图表能力做成用户可启用/禁用的独立 capability module。开启后，AI 才能看到图表工具和图表规则。
+
+6. **AI 指导层**
+   模块内提供简洁能力说明：什么时候画图、如何写 SQL、如何写 ChartSpec、禁止输出 HTML/JS/ECharts option。
+
+7. **MVP 范围**
+   先跑通“用户自定义筛选 + 动态 SQL + 动态 ChartSpec + 聊天区出图”的闭环，再逐步扩展更多图表类型和分析模板。
+
+一句话版本：
+
+```text
+把图表做成 ChatLab 的可插拔数据可视化运行时：AI 负责理解需求和生成 SQL + ChartSpec，ChatLab 负责安全校验、执行查询和内置渲染，让用户能自由定义图表的统计对象、维度、指标和坐标含义。
+```
+
+> 最终这个图表应该毫无违和感的嵌入AI输出的文本里，图表数量按照用户需求
+
+补充后的最终需求是：
+
+你要做的是 **AI 回复里的原生图表能力**，不是独立报表页。
+
+图表应该像 Markdown、工具调用结果、引用消息一样，毫无违和感地嵌入 AI 输出文本流中：
+
+```text
+AI 解释一段结论
+-> 插入一张图表
+-> 再解释图表发现
+-> 根据需要继续插入第二张图表
+```
+
+并且图表数量由用户需求决定：
+
+- 用户只要一个趋势图，就返回一张。
+- 用户要求“分别画成员占比和每日趋势”，就返回多张。
+- 用户要求对比多个维度，可以在同一轮回复里插入多个图表。
+- AI 主动出图时应克制，但用户明确要求多张时必须支持。
+
+因此最终规划里要补两点：
+
+1. **图表是 AI 内容块的一种**
+   新增 `chart` content block，和 `text / think / tool / skill / error` 一样按顺序保存在 `contentBlocks` 里，支持流式插入、持久化和历史重放。
+
+2. **支持一轮多图**
+   `render_chart` 可以被调用多次，或一次返回多个 chart blocks。前端按内容块顺序自然渲染，不把图表集中到单独区域。
+
+一句话修正版：
+
+```text
+把图表做成 AI 回复文本流中的原生内容块：AI 可按用户需求生成一张或多张由 SQL + ChartSpec 驱动的图表，并自然穿插在文字解释中，由 ChatLab 安全执行、校验和内置渲染。
+```
+
+> 开始计划吧
+
+<details><summary>7 previous messages</summary>
+
+> 我会先做一轮只读探查，把“可开关能力模块”在当前代码里该挂到哪里摸清楚：工具注册、助手配置、技能/能力开关、流式 content block、前端渲染这几条线都要对齐。
+>
+> 我看到了当前项目已有“助手选择工具”和 Markdown skill 导入系统，但你这次要的是 capability 开关。现在我继续定位：Agent 实际工具列表如何过滤、前端流如何把 tool result 变成 contentBlocks，以及 SQL 工具的安全边界。
+>
+> 目前事实比较清楚：analysis 工具本来就是 opt-in，助手配置里已有 allowed tools 的白名单，这和“打开/关闭图表能力”很契合。需要再确认 CLI Web 是否复用同一个白名单和工具 registry，避免计划只照顾桌面端。
+>
+> 我已经能把当前代码里的落点串起来了。还有几个不是代码能回答的产品取舍，会直接决定计划边界：模块开关是全局还是跟助手绑定、第一版做到什么深度、以及图表数量/主动出图的默认策略。
+>
+> 好的，这个答案很关键：图表不是“常驻助手配置”，而是每轮对话用户可以用 `/` 临时唤醒的绘图助手。那我把规划方向改成“slash 激活的临时 chart capability”，同时保留 AI 克制主动出图的基础规则。
+>
+> 现有 `/` 选择的技能已经是“单次消息生效，发送后清空”，这正好贴合你的交互设想。现在的计划可以复用这个交互模型，但把它从纯 prompt skill 升级成会临时开放 `render_chart` 工具的绘图 capability。
+>
+> Plan
+>
+> # Slash 激活的动态图表能力 MVP
+>
+> ## Summary
+>
+> - 做一个一次性生效的“绘图助手”能力：用户在聊天框输入 `/` 选择后，本轮 AI 可以返回一张或多张图表，发送后自动关闭。
+> - 图表不是固定报表，而是由 AI 根据用户需求生成 `只读 SQL + ChartSpec`，支持自定义统计对象、范围、维度、指标、x/y/value/series 含义。
+> - 图表作为 AI 回复的原生 `chart` content block 插入文本流中；默认不显示 `render_chart` 工具胶囊，只显示自然的图表卡片。
+> - 第一版支持 `bar / line / pie / heatmap`，保存渲染所需的标准化数据，历史消息不重新查库。
+>
+> ## Key Changes
+>
+> - 新增图表协议：
+>   - `ChartSpec`：`version`、`type`、`title`、`encoding`、`unit`、`filters`、`display`。
+>   - `ChartDataset`：字段定义 + rows。
+>   - `ChartContentBlock`：保存 `spec`、标准化后的 component data、必要 metadata。
+> - 新增 `render_chart` analysis 工具：
+>   - 输入：`sql`、`params`、`chartSpec`、可选 `maxRows`。
+>   - 执行：复用现有只读 SQL 安全检查，校验 SQL 返回字段与 `encoding` 匹配。
+>   - 输出：文本摘要给模型，结构化 chart payload 给前端。
+> - 新增 slash 绘图助手：
+>   - 在 `/` 菜单中出现“绘图助手”。
+>   - 选中后只对当前消息生效。
+>   - 本轮临时开放 `render_chart` 和 `get_schema`。
+>   - Prompt 明确禁止 HTML / JS / SVG / ECharts option。
+>   - 用户明确要求多图时允许多次调用 `render_chart`；未明确要求多图时默认最多主动 1 张。
+> - 更新流式和持久化链路：
+>   - `AgentStreamChunk` 支持 chart payload，或在 `tool_result` 中携带 chart payload。
+>   - 前端收到 `render_chart` 结果后追加 `chart` block，而不是追加普通工具胶囊。
+>   - `ContentBlock` 类型在前端和 node-runtime 中增加 `chart`。
+> - 前端新增统一 `ChartBlockRenderer`：
+>   - 根据 `ChartSpec.type` 调用现有图表组件。
+>   - 图表卡片显示标题、口径/筛选摘要、空数据/错误状态。
+>   - 支持多张图按 contentBlocks 顺序自然嵌入 AI 文本之间。
+>
+> ## Test Plan
+>
+> - 单元测试：
+>   - `ChartSpec` 校验：缺字段、字段不存在、类型不匹配、unsupported chart type。
+>   - `render_chart`：只读 SQL 成功、写入 SQL 被拒绝、空数据、截断数据。
+>   - bar/line/pie/heatmap 标准化结果正确。
+> - 适配器测试：
+>   - Electron 和 CLI Web 都能把 chart payload 透传成 `chart` block。
+>   - 普通工具调用行为不回归。
+> - 前端验证：
+>   - `/绘图助手` 本轮生效，发送后自动关闭。
+>   - AI 回复中可插入单张或多张图。
+>   - 历史会话重新打开后图表仍可显示，不重新查询数据库。
+> - 质量检查：
+>   - 对修改文件执行 type-check、lint、format。
+>   - 若检查暴露无关报错，按项目规则一并修复。
+>
+> ## Assumptions
+>
+> - 第一版只做 slash 单轮激活，不做全局插件市场或长期模块管理。
+> - 未选择 `/绘图助手` 时，不主动开放 `render_chart`。
+> - 图表历史消息保存标准化渲染数据，不保存完整 SQL 执行上下文作为重放来源。
+> - 第一版不开放 AI 生成 ECharts option，只允许内置组件渲染。
+> </details>
+
+我还需要锁一个展示层取舍：图表如果像普通工具一样旁边出现“调用了 render_chart”的工具胶囊，会更透明但稍微破坏阅读流；如果只显示图表卡片，体验更自然但工具过程更隐性。这个决定会影响前端 content block 设计。
+
+> 我希望在项目文件夹中添加一个project document文件夹，内部放置最终的实现目标、每轮对话实现了什么，什么有待实现，确保codex限额到顶以后，其他的AI也能够无缝衔接。
+
+<details><summary>4 previous messages</summary>
+
+> 我会按你说的做成一个可交接的项目文档区。因为这是“给其他 AI 无缝衔接”的收尾/记忆整理场景，我会使用 `neat-freak` 的方式，先最小范围整理出清晰的目标、已完成对话成果和待办。
+>
+> 我会新建 `project document/`，里面放一个入口 README、一份图表能力目标文档、一份交接日志。内容会记录“当前只是完成需求澄清和规划，还没有实现代码”，避免下个 AI 误判进度。
+>
+> <details><summary>Created 3 files</summary>
+>
+> - Wrote `./project document/README.md` (+26 -0)
+> - Wrote `./project document/ai-chart-runtime.md` (+114 -0)
+> - Wrote `./project document/handoff-log.md` (+54 -0)
+>
+> </details>
+>
+> 文档已经创建好了。我会对这几个 Markdown 文件跑一次 Prettier 格式化检查/格式化，再确认 git 状态；这类文档没有 TypeScript 类型检查或 ESLint 目标。
+> </details>
+
+已添加交接文档文件夹：
+
+- [project document/README.md](<./project document/README.md>)：入口说明和当前状态
+- [project document/ai-chart-runtime.md](<./project document/ai-chart-runtime.md>)：最终实现目标、产品行为、MVP 规划
+- [project document/handoff-log.md](<./project document/handoff-log.md>)：每轮对话已完成内容、未实现项、下一步建议
+
+我也对这 3 个 Markdown 文件跑了 `prettier --write`。这次只新增文档，没有 TypeScript/ESLint 适用文件，所以没有跑类型检查或 ESLint。当前新增的 `project document/` 还是未跟踪状态，其他原本未跟踪文件我没有动。
+
+> 为codex的目标功能写一个目标
+
+可以写成这个：
+
+**目标：**
+在 ChatLab 的 `codex/new-feature` 分支上，实现一个通过聊天框 `/` 临时激活的 AI 动态绘图能力。用户可用自然语言自定义统计对象、时间范围、维度、指标和图表类型，AI 生成只读 SQL + ChartSpec，ChatLab 负责安全校验、执行查询、标准化数据，并将一张或多张图表作为原生内容块自然嵌入 AI 回复中。第一版支持 `bar / line / pie / heatmap`，并保存标准化渲染数据以支持历史消息稳定重放。
+
+<details><summary>65 previous messages</summary>
+
+> 我会先对当前工作树做一次真实状态检查，然后开始做第一个可运行的竖切：`ChartSpec`/`render_chart`/流式 chart block/前端渲染这条线。这个目标比较大，我会分阶段推进，并且每轮结束前同步 `project document`。
+>
+> 我会优先做“能跑通传输和渲染”的基础设施，而不是一开始就堆很多图表模板。这样每个后续图表类型都只是扩展 schema/normalizer，而不是重做链路。
+>
+> 我会开始编辑共享层。先把图表协议放进 `@openchatlab/core`，因为 tools、node-runtime 和前端都能依赖它；这比把类型散落在前后端各写一份更稳。
+>
+> 接下来我会做比较多文件的改动：核心 chart schema、`render_chart` 工具、两个 adapter 的 chart 透传、前端 content block 类型和 renderer、以及 `/绘图助手` 入口。中间我会尽量保持每一步都是当前架构里的最小自然扩展。
+>
+> <details><summary>Created 1 file, edited 2 files</summary>
+>
+> - Wrote `./packages/core/src/ai/tool-catalog.ts` (+5 -3)
+> - Wrote `./packages/core/src/chart/index.ts` (+332 -0)
+> - Wrote `./packages/core/src/index.ts` (+20 -3)
+>
+> </details>
+>
+> 核心层已经有了第一版 chart schema 和 normalizer。下一步接入工具层：`render_chart` 会作为 analysis tool 返回结构化 chart payload，同时把 `get_schema` 纳入 Agent 工具集，方便绘图助手先看表结构。
+>
+> 刚才工具层补丁因为目标文件上下文不一致没有应用，我会拆成更小的补丁逐个接上。
+>
+> <details><summary>Created 1 file, edited 2 files</summary>
+>
+> - Wrote `./packages/tools/src/definitions/render-chart.ts` (+105 -0)
+> - Wrote `./packages/tools/src/index.ts` (+3 -2)
+> - Wrote `./packages/tools/src/types.ts` (+16 -12)
+>
+> </details>
+>
+> `render_chart` 工具定义已经加入 tools 包。现在我把它接进 CLI/桌面共用的工具注册表，并让 `get_schema` 也能在 Agent 里使用。
+>
+> <details><summary>Edited 2 files</summary>
+>
+> - Wrote `./apps/desktop/main/ai/tools/definitions/index.ts` (+14 -10)
+> - Wrote `./packages/tools/src/registry.ts` (+11 -8)
+>
+> </details>
+>
+> 接下来是传输层：工具返回 chart payload 后，Electron 和 CLI Web 都要把它放进 `details`，这样前端在 `tool_result` 事件里能抽出 chart block。
+>
+> 这个补丁同样被 registry 的注释上下文卡住了，我继续拆开处理。
+>
+> <details><summary>Edited 3 files</summary>
+>
+> - Wrote `./apps/cli/src/ai/tool-adapter.ts` (+34 -14)
+> - Wrote `./apps/desktop/main/ai/tools/shared-tool-adapter.ts` (+35 -21)
+> - Wrote `./packages/tools/src/registry.ts` (+7 -8)
+>
+> </details>
+>
+> 现在接前端和持久化类型：把 `chart` 变成正式 content block。这样历史对话保存时会自然带上图表渲染数据。
+>
+> <details><summary>Edited 2 files</summary>
+>
+> - Wrote `./packages/node-runtime/src/ai/conversations.ts` (+10 -8)
+> - Wrote `./src/stores/aiChat.ts` (+9 -7)
+>
+> </details>
+>
+> 我会让图表卡片保持 ChatLab 现有聊天界面的克制风格：轻量边框、标题/口径、小尺寸内嵌图表，不做独立报表页的重装饰。折线图同时补上多 series 支持。
+>
+> <details><summary>Created 1 file, edited 1 file</summary>
+>
+> - Wrote `./src/components/AIChat/chat/ChartBlockRenderer.vue` (+74 -0)
+> - Wrote `./src/components/charts/EChartLine.vue` (+81 -54)
+>
+> </details>
+>
+> 图表渲染组件和多线折线图支持已接上。接下来把 `ChatMessage` 按 content block 顺序渲染 chart。
+>
+> <details><summary>Edited 1 file</summary>
+>
+> - Wrote `./src/components/AIChat/chat/ChatMessage.vue` (+24 -16)
+>
+> </details>
+>
+> 现在我会让前端流处理识别 `render_chart` 的结果：它不会生成普通工具胶囊，而会把 payload 追加为一个或多个 chart blocks。
+>
+> <details><summary>Edited 1 file</summary>
+>
+> - Wrote `./src/stores/aiChat.ts` (+57 -12)
+>
+> </details>
+>
+> 同一套流处理逻辑在“正常发送”和“编辑后重生成”里各有一份，我会两边一起接 chart block，避免只有首次发送能出图。
+>
+> <details><summary>Edited 1 file</summary>
+>
+> - Wrote `./src/stores/aiChat.ts` (+61 -37)
+>
+> </details>
+>
+> 现在接 `/绘图助手` 的单轮激活。我会把它做成内置的 synthetic skill：前端 slash 菜单能选中，后端识别这个特殊 id 后注入绘图 prompt 并临时开放 `render_chart`。
+>
+> 我会把绘图助手的 id 和 prompt 放在 core 的静态 AI 区域，前端和两个后端入口都引用同一个常量，避免特殊 id 写散。
+>
+> <details><summary>Created 1 file, edited 1 file</summary>
+>
+> - Wrote `./packages/core/src/ai/chart-capability.ts` (+78 -0)
+> - Wrote `./packages/core/src/ai/index.ts` (+2 -1)
+>
+> </details>
+>
+> 绘图助手常量和 prompt 已经放进 core。现在我把它暴露到 `@openchatlab/core` 顶层，再接前端 slash 菜单。
+>
+> <details><summary>Edited 2 files</summary>
+>
+> - Wrote `./packages/core/src/index.ts` (+9 -7)
+> - Wrote `./src/stores/skill.ts` (+28 -14)
+>
+> </details>
+>
+> 前端现在能把“绘图助手”当作单轮 slash 技能展示。接下来接后端：当 `skillId=chart_runtime` 时，注入绘图 prompt，并确保本轮工具列表包含 `render_chart`。
+>
+> <details><summary>Edited 2 files</summary>
+>
+> - Wrote `./apps/cli/src/ai/agent-stream-runner.ts` (+26 -12)
+> - Wrote `./apps/desktop/main/ai/agent-stream-runner.ts` (+22 -7)
+>
+> </details>
+>
+> 后端已经识别 `chart_runtime`。我会检查一下类型定义，避免刚才为了复用 prompt 做的对象形状和现有 SkillContext 不一致。
+>
+> 核心交互已经有骨架了。接下来我要补工具目录和文案，否则助手配置/工具市场里会出现未翻译的 `render_chart`/`get_schema`。
+>
+> 我会补齐中英日繁四套前端工具名，以及 node-runtime 的工具描述。运行时工具描述属于非 UI 文本，按现有 locale 机制做多语言。
+>
+> 日文/繁中现有文案和我预想的略不同，我拆开按实际内容补。
+>
+> 我会对四个 JSON 做精确插入，只加工具名，不碰其他翻译。
+>
+> <details><summary>Edited 4 files</summary>
+>
+> - Wrote `./src/i18n/locales/en-US/ai.json` (+9 -7)
+> - Wrote `./src/i18n/locales/ja-JP/ai.json` (+9 -7)
+> - Wrote `./src/i18n/locales/zh-CN/ai.json` (+9 -7)
+> - Wrote `./src/i18n/locales/zh-TW/ai.json` (+9 -7)
+>
+> </details>
+>
+> 接着补模型看到的工具描述，否则 Function Calling 描述会退回英文硬编码，中文模型表现会差一点。
+>
+> 繁中的句子略有差异，我先补简中和英文，再按实际上下文补另外两套。
+>
+> <details><summary>Edited 2 files</summary>
+>
+> - Wrote `./packages/node-runtime/src/ai/i18n/locales/en-US.ts` (+21 -8)
+> - Wrote `./packages/node-runtime/src/ai/i18n/locales/zh-CN.ts` (+21 -8)
+>
+> </details>
+>
+> 实际上下文找到了，我把繁中和日文补上。
+>
+> <details><summary>Edited 2 files</summary>
+>
+> - Wrote `./packages/node-runtime/src/ai/i18n/locales/ja-JP.ts` (+21 -8)
+> - Wrote `./packages/node-runtime/src/ai/i18n/locales/zh-TW.ts` (+21 -8)
+>
+> </details>
+>
+> 我发现服务层也有一份 `ContentBlock` 类型，用于持久化 API；这里也要同步加 chart，否则类型会在保存/加载时断开。
+>
+> <details><summary>Edited 1 file</summary>
+>
+> - Wrote `./src/services/ai/types.ts` (+7 -5)
+>
+> </details>
+>
+> 我会给核心 chart normalizer 加单元测试，先把字段校验、多线折线、热力图聚合这些关键行为锁住。
+>
+> <details><summary>Created 1 file</summary>
+>
+> - Wrote `./packages/core/src/chart/index.test.ts` (+85 -0)
+>
+> </details>
+>
+> 还有聊天里的工具状态名称也有一组独立文案；虽然 `render_chart` 默认隐藏，但 `get_schema` 会显示，所以我一并补齐。
+>
+> 按实际文案补工具状态名。
+>
+> <details><summary>Edited 4 files</summary>
+>
+> - Wrote `./src/i18n/locales/en-US/ai.json` (+9 -7)
+> - Wrote `./src/i18n/locales/ja-JP/ai.json` (+9 -7)
+> - Wrote `./src/i18n/locales/zh-CN/ai.json` (+9 -7)
+> - Wrote `./src/i18n/locales/zh-TW/ai.json` (+9 -7)
+>
+> </details>
+>
+> 到这里，第一条竖切的主要代码已经铺好了：schema、tool、slash 激活、payload 透传、content block 渲染都有了。接下来我会跑格式化和针对性测试/类型检查，修掉实际暴露的问题。
+>
+> 格式化完成。我先跑新加的 chart 单元测试，再跑相关 TypeScript 检查；如果类型检查牵出本次无关问题，也会按项目规则一起处理。
+>
+> 单测和 node/web 类型检查都通过了。现在按项目要求对本次修改文件跑 ESLint 自动修复。
+>
+> ESLint 没有报错。为了确认自动修复没有影响格式，我会再跑一次针对性格式化和类型/单测快检。
+>
+> 快检全部通过。现在我会做一次 diff 审阅，确认没有把无关文件搅进去，也确认实现和目标一致。
+>
+> 代码级检查通过了。因为这次改到了聊天区前端渲染，我按本地浏览器验证流程找一下可用的 in-app Browser 工具；如果能快速打开本地页面，我会做一次基础渲染检查。
+>
+> 浏览器工具这轮没有暴露出来，所以我无法做 in-app 页面截图验证；我已经用单测、node/web 类型检查、ESLint、格式化和 diff 检查覆盖这一轮。现在按你的要求更新 `project document` 交接记录。
+>
+> Context compaction
+>
+> Source: automatic
+> Status: completed
+>
+> 我继续把这轮收尾补齐：先确认当前目标和文档状态，然后把 `project document` 更新成可交接版本，再跑一次轻量校验。
+>
+> 文档还停留在“规划未实现”的状态，和当前代码已经完成的首个纵向切片不一致。我现在把交接文档改成真实状态，方便后续任何 AI 接手时不会重新走弯路。
+>
+> <details><summary>Edited 1 file</summary>
+>
+> - Wrote `./project document/README.md` (+12 -2)
+>
+> </details>
+>
+> README 已经对齐到“首个实现切片已完成但未提交”。接下来我把目标文档里的 MVP 计划从纯待办改成“已完成 / 待补强”的状态。
+>
+> <details><summary>Edited 1 file</summary>
+>
+> - Wrote `./project document/ai-chart-runtime.md` (+21 -0)
+>
+> </details>
+>
+> 目标文档已经记录了实现边界和剩余风险。我再更新 handoff log，把这轮实际做过的代码、验证结果、未验证项写进去。
+>
+> <details><summary>Edited 1 file</summary>
+>
+> - Wrote `./project document/handoff-log.md` (+34 -10)
+>
+> </details>
+>
+> 文档补齐了。现在只对刚改的文档跑格式化，再做一次 diff 空白检查；代码侧的类型检查、lint 和核心测试在文档前已经通过。
+>
+> 校验结果干净，只有 Git 提示 Windows 换行会在下次触碰时转换，这不是 diff 错误。我最后确认一下分支和改动摘要，然后给你一个清晰收口。
+> </details>
+
+已为 Codex 建立并推进这个目标：
+
+> 在 `codex/new-feature` 分支实现一个 slash 临时激活的 AI 动态绘图能力：用户用自然语言定义统计对象、范围、维度、指标和图表类型；AI 生成只读 SQL + `ChartSpec`；ChatLab 校验、执行、标准化数据，并把一张或多张图表作为原生内容块自然嵌入 AI 回复。第一版支持 `bar / line / pie / heatmap`，并保留标准化渲染数据用于历史消息稳定重放。
+
+本轮已完成首个纵向切片：`ChartSpec`、`render_chart` 工具、Electron/CLI Web 工具传输、AI 回复里的 `chart` content block、前端内嵌图表渲染、slash 菜单临时激活，以及 `project document` 交接文档更新。
+
+验证已通过：`prettier`、核心 chart 测试、`type-check:node`、`type-check:web`、`eslint --fix`、`git diff --check`。未完成的是浏览器 UI smoke test，因为当前线程没有暴露 Browser 工具；后续硬化项已写进 [handoff-log.md](<./project document/handoff-log.md:1>)。
+
+<details><summary>41 previous messages</summary>
+
+> 我会继续沿着真实目标往前推，不先假设上一轮已经完整达标。现在重点审一下两个容易漏的硬需求：只读 SQL 安全边界、以及 chart content block 是否真的能被历史消息持久化/重放。
+>
+> 先按仓库约定看文档入口和相关代码流；如果发现上一轮实现已经有缺口，我会直接补，不停在评估层。
+>
+> 目前看到 `render_chart` 只做了单语句和 LIMIT 处理，这还不能证明“只读 SQL”这个硬需求。我要去看仓库已有 query 安全工具和 dataProvider 约束，决定是复用现有边界还是补上缺失校验。
+>
+> 持久化这边初步证据不错：`content_blocks` 是 TEXT JSON，`chart` block 会随 message 保存，历史加载直接 JSON 反序列化回来。安全侧需要继续确认执行层是不是只读打开，以及 `render_chart` 是否会把非 SELECT/写语句拦住。
+>
+> 这里基本确认了一个真实缺口：CLI/core 路径可能依赖 `executeParameterizedSql`，Electron 通过 worker 的 `pluginQuery`。我需要分别看这两个底层函数，避免一个平台安全、另一个平台没拦住。
+>
+> 底层有 `stmt.readonly` 检查，方向是对的；但 `render_chart` 自己没有明确限制 SQL 起始语义，CTE + 写语句、PRAGMA 等边界要用测试钉住。我先读统一 SQL 执行器，再决定补什么。
+>
+> 刚才 Powershell 的 `Select-Object -Index 314..390` 语法踩了个小坑，我换成标准的 skip/first 继续读同一段。
+>
+> 下一个高价值动作很明确：补回归测试来证明两件事，而不是只靠类型：`render_chart` 会保存规范化后的图表 payload，`AIConversationManager` 能把 chart block 原样存取，历史消息重放不需要重跑 SQL。
+>
+> 我要做三个小而硬的改动：给 `render_chart` 增加明确的 SELECT/WITH 入口校验；给它补单测证明 LIMIT、参数、payload 和拒绝写语句；再给 conversation manager 补 chart block 持久化测试。这样目标里的“安全执行”和“历史稳定重放”会有更直接证据。
+>
+> <details><summary>Created 1 file, edited 1 file</summary>
+>
+> - Wrote `./packages/tools/src/definitions/render-chart.ts` (+6 -0)
+> - Wrote `./packages/tools/src/definitions/render-chart.test.ts` (+109 -0)
+>
+> </details>
+>
+> `render_chart` 的测试已经补上，覆盖正常参数化查询、WITH 查询、截断、以及写语句拒绝。现在补历史消息持久化测试，验证 chart block 存的是完整 normalized payload。
+>
+> <details><summary>Edited 1 file</summary>
+>
+> - Wrote `./packages/node-runtime/src/ai/__tests__/conversations.test.ts` (+56 -7)
+>
+> </details>
+>
+> 我注意到测试里 TypeScript 对 union narrowing 会比较挑剔，顺手把断言写成它能明确收窄的形式，免得类型检查时因为测试代码本身卡住。
+>
+> <details><summary>Edited 1 file</summary>
+>
+> - Wrote `./packages/node-runtime/src/ai/__tests__/conversations.test.ts` (+3 -1)
+>
+> </details>
+>
+> 代码改动先到这里。我现在跑格式化和针对性测试，先看新增测试是否能稳住，再决定是否继续补适配器层测试。
+>
+> 新增工具测试过了。conversation 测试不是代码逻辑失败，而是本机 `better-sqlite3` 原生模块版本和当前 Node ABI 不匹配：模块是 `NODE_MODULE_VERSION 133`，当前 Node 要 `137`。我先确认有没有现成匹配的 native binding，优先用现有依赖路径，不急着动依赖安装。
+>
+> 仓库里除了 pnpm 的 native 模块，还有 `apps/cli/native/better_sqlite3.node`。我测试一下这个 binding 是否匹配当前 Node；如果匹配，就用测试环境变量跑持久化测试，不需要重装依赖。
+>
+> 现成的 CLI native binding 可以加载，太好了。现在用 `CHATLAB_TEST_SQLITE_NATIVE_BINDING` 指向它重跑 conversation 测试，这样验证的是同一套代码，不需要改依赖树。
+>
+> 核心和持久化测试都通过了。再补一个很小的 CLI Web adapter 回归测试，专门钉住“工具结果 details 里不能丢 chart payload”，这正好覆盖前端收到 chart block 的上游证据。
+>
+> <details><summary>Created 1 file</summary>
+>
+> - Wrote `./apps/cli/src/ai/tool-adapter.test.ts` (+60 -0)
+>
+> </details>
+>
+> 测试里我刚多写了一个不属于 `ToolDefinition` 的 `label` 字段，虽然 cast 能绕过，但没必要留下噪音。我把它去掉，保持测试也像生产代码一样干净。
+>
+> <details><summary>Edited 1 file</summary>
+>
+> - Wrote `./apps/cli/src/ai/tool-adapter.test.ts` (+0 -1)
+> - Wrote `./apps/cli/src/ai/tool-adapter.test.ts` (+1 -1)
+>
+> </details>
+>
+> 适配器测试补好了。现在跑它和格式化，看看是否有隐藏依赖问题。
+>
+> 新增测试已经过了。现在进入质量门：先对本轮触碰的文件跑 lint/format，再跑 node/web 类型检查和相关测试，避免测试文件或安全校验引入旁路问题。
+>
+> lint 和格式化没有留下改动。接下来跑完整 node/web 类型检查，以及本轮相关的四组测试，确认整条链仍然稳。
+>
+> 类型检查抓到一个测试签名问题：`assert.rejects` 要求回调明确返回 Promise，而工具 handler 类型允许同步或异步。生产代码没问题，我把测试回调包成 `async`，再重跑质量门。
+>
+> <details><summary>Edited 1 file</summary>
+>
+> - Wrote `./packages/tools/src/definitions/render-chart.test.ts` (+4 -3)
+>
+> </details>
+>
+> 测试类型已经修正。现在重新跑格式化、lint、类型检查和相关测试；这次如果绿了，就进入文档更新。
+>
+> 格式和 lint 通过。继续跑完整类型检查和相关测试集合。
+>
+> 质量门已经绿了。按你的交接要求，我现在使用 `neat-freak` 做收尾文档同步，把本轮新增的安全校验、测试和验证命令写进 `project document`。
+>
+> `neat-freak` 的全量文档审查会很重；这次变更是内部开发交接，不是 public docs/API 文档，所以我会把同步范围收敛到 `project document/`，并确认根目录/公开 docs 没有需要跟进的产品文档入口。
+>
+> 交接文档里还有“待加 adapter 测试 / 待确认持久化”的旧状态。现在这两项已经有证据了，我把它们从 pending 移到已完成，并保留真正还没验证的 UI/E2E 项。
+>
+> <details><summary>Edited 1 file</summary>
+>
+> - Wrote `./project document/README.md` (+3 -1)
+>
+> </details>
+>
+> README 已经反映本轮硬化结果。继续更新目标文档，把“已实现首切片”和“待办”改成当前事实。
+>
+> <details><summary>Edited 1 file</summary>
+>
+> - Wrote `./project document/ai-chart-runtime.md` (+12 -3)
+>
+> </details>
+>
+> 目标文档已更新。最后更新 handoff log，写明本轮具体文件、测试命令和 native binding 注意事项。
+>
+> <details><summary>Edited 1 file</summary>
+>
+> - Wrote `./project document/handoff-log.md` (+30 -0)
+>
+> </details>
+>
+> 文档也同步完了。现在对交接文档跑格式化和 diff 检查，确认收尾没有空白问题。
+>
+> `git diff --check` 干净，只有 Windows 换行提示。最后我看一下当前分支和改动摘要，准备把本轮结果收口给你。
+>
+> 还有一个目标级缺口是 UI smoke test。之前 Browser 工具没暴露；我再搜索一次可用浏览器工具，如果这轮仍不可用，就把它作为明确未验证项保留。
+>
+> 工具搜索仍然没有暴露 in-app Browser，只返回了自动化/子线程相关工具；所以 UI smoke test 这轮仍不能做。这个状态已经写入 handoff，目标继续保持 active。
+> </details>
+
+本轮继续把目标往“可验证”方向推进了，没有标记 goal 完成，因为 UI smoke test 和真实 AI E2E 还没做。
+
+我补了 `render_chart` 的 SQL 入口安全校验：非 `SELECT` / `WITH` 语句会在进入 data provider 前被拒绝，见 [render-chart.ts](<./packages/tools/src/definitions/render-chart.ts:1>)。同时新增/扩展了测试：`render_chart` 参数化查询、LIMIT 截断、写语句拒绝；CLI Web adapter 保留 chart payload；conversation manager 持久化并重载 chart content block，见 [render-chart.test.ts](<./packages/tools/src/definitions/render-chart.test.ts:1>)、[tool-adapter.test.ts](<./apps/cli/src/ai/tool-adapter.test.ts:1>)、[conversations.test.ts](<./packages/node-runtime/src/ai/__tests__/conversations.test.ts:1>)。
+
+验证已通过：
+
+- `pnpm run type-check:node`
+- `pnpm run type-check:web`
+- chart/tool/adapter tests：8 passed
+- conversation tests：13 passed
+- `git diff --check`
+
+注意：conversation 测试需要用 `CHATLAB_TEST_SQLITE_NATIVE_BINDING=apps/cli/native/better_sqlite3.node`，因为当前 pnpm 的 `better-sqlite3` native module 和 Node ABI 不匹配。这个也已经写进 [handoff-log.md](<./project document/handoff-log.md:1>)。
+
+`project document` 已更新；仍待做的是 in-app Browser UI smoke test、真实聊天数据 E2E、前端 chart block 组件/store 回归测试。
+
+<details><summary>46 previous messages</summary>
+
+> 我会继续补目标里还没被强证据覆盖的部分：先看前端 chart block 的实现细节，再补一个可跑的回归测试；如果能用 Playwright 兜底做本地渲染冒烟，也顺手把 UI 验证补上。
+>
+> 先读前端相关文件和测试工具配置，确认最小可维护的测试切入点。这里我会尽量避免引入新测试框架，优先用仓库已有的 `tsx --test`/类型检查路径。
+>
+> 当前前端没有 Vue 组件测试框架，但 store 里有一段纯逻辑最关键：从 agent tool result 里提取 `chart/charts` payload。我要把这段纯函数导出并加就近 `tsx --test`，这样不引入新框架，也能钉住前端接收 chart block 的关键入口。
+>
+> 我会把 chart payload 解析从大 store 里拆成一个小的纯模块；这不是重构炫技，而是为了让前端接收链路能被稳定测试，同时让 `aiChat.ts` 更少依赖隐式内部函数。
+>
+> <details><summary>Created 1 file</summary>
+>
+> - Wrote `./src/stores/aiChatChartBlocks.ts` (+34 -0)
+>
+> </details>
+>
+> 纯模块已加。现在把 `aiChat.ts` 接到这个模块上，移除原来的内联解析函数，行为保持一样但可测试。
+>
+> <details><summary>Edited 1 file</summary>
+>
+> - Wrote `./src/stores/aiChat.ts` (+2 -30)
+>
+> </details>
+>
+> 现在加就近测试，覆盖单 chart、多 chart、invalid 过滤和 render-only 工具判断。这会把前端从 tool result 到 chart block 的关键逻辑固定下来。
+>
+> <details><summary>Created 1 file</summary>
+>
+> - Wrote `./src/stores/aiChatChartBlocks.test.ts` (+80 -0)
+>
+> </details>
+>
+> 前端 store 侧测试已加。接下来跑格式化、lint 和这个测试，先把新增模块稳定下来。
+>
+> 前端 helper 测试已经通过。接下来尝试 UI 渲染验证：先看本机是否有可用 Playwright/浏览器依赖；如果有，我会开一个临时 Vite harness 做实际 chart render 截图检查。
+>
+> Playwright 在 Codex runtime 里可用，仓库本身没带。为了不污染业务路由，我会创建一个 `tmp/chart-smoke` 临时 Vite harness，直接挂载 `ChartBlockRenderer.vue` 和真实 chart 组件，再用 Playwright 检查页面有 canvas 且非空。
+>
+> 我会把 harness 放到 `tmp/`，它不是产品代码；结束后保留一小段验证脚本路径在文档里，方便后续复查，也不会影响打包入口。
+>
+> <details><summary>Created 4 files</summary>
+>
+> - Wrote `./tmp/chart-smoke/index.html` (+12 -0)
+> - Wrote `./tmp/chart-smoke/src/main.ts` (+122 -0)
+> - Wrote `./tmp/chart-smoke/src/style.css` (+28 -0)
+> - Wrote `./tmp/chart-smoke/vite.config.mts` (+23 -0)
+>
+> </details>
+>
+> 临时 harness 已创建，使用真实 `ChartBlockRenderer`。现在先让 Vite 对这个 harness 做一次生产构建，确认所有 Vue/ECharts import 能被打包。
+>
+> harness 构建暴露了一个真实前端问题：`ChartBlockRenderer` 通过 charts barrel import，会把一堆无关图表/组件也带进临时构建，最终碰到 `@nuxt/ui` 的 `#imports` 解析。这里改成按文件直连四个图表组件，更符合这个组件的实际依赖。
+>
+> <details><summary>Edited 1 file</summary>
+>
+> - Wrote `./src/components/AIChat/chat/ChartBlockRenderer.vue` (+4 -1)
+>
+> </details>
+>
+> 依赖入口已经收窄。现在重跑格式化和 harness build，看它是否能真正打包过。
+>
+> 构建通过了。现在启动临时 Vite 服务并用 Playwright 做实际 canvas 像素检查：页面上应该有四个图表标题、至少四个 canvas，且每个 canvas 不是空白。
+>
+> Playwright 命令返回 0，但工具输出没有把 JSON 打出来。为了给交接文档留下更清楚的证据，我再跑一次短输出版，只打印标题数、canvas 数和最小非空像素采样。
+>
+> 这次短输出看清楚了：runtime 里有 `playwright` 包入口，但缺 `playwright-core`，所以不能用它做浏览器验证。之前返回 0 是 PowerShell 管道没有把 node exit code 提升出来。我会记录这个真实阻塞，并继续用可跑的 build/type/test 证据。
+>
+> 我再试一下 Node REPL MCP 的包环境，它有时和 shell runtime 不同；如果也没有可用 Playwright，就不再硬拗浏览器冒烟。
+>
+> MCP tool call
+>
+> node_repl.js
+>
+> ```json
+> {
+>   "title": "Check Playwright availability",
+>   "code": "try {\n  const mod = await import('playwright');\n  nodeRepl.write(JSON.stringify({ ok: true, keys: Object.keys(mod).slice(0, 8) }));\n} catch (error) {\n  nodeRepl.write(JSON.stringify({ ok: false, message: error instanceof Error ? error.message : String(error) }));\n}",
+>   "timeout_ms": 30000
+> }
+> ```
+>
+> ```text
+> {"ok":false,"message":"Error: Module not found: playwright"}
+> ```
+>
+> 浏览器执行环境不可用这一点已经确认：Browser tool 没暴露，shell runtime 缺 `playwright-core`，Node REPL 也没有 Playwright。现在我把能跑的前端验证跑满：lint、type-check、store 测试、harness build、主 web build。
+>
+> 局部前端验证绿了。接着跑全项目类型检查，并把主 Web 构建输出到 `tmp/web-build-smoke`，避免改动现有 `dist-web`。
+>
+> 主 Web 构建也过了，只有既有 chunk/alias 警告。构建产物放在 `tmp/` 是临时验证输出，我会清掉这些生成目录和日志，只保留小型 harness 源文件。
+>
+> 日志文件被占用，说明刚才某个临时 Vite 子进程还活着。我要按端口 4174 定位并停止它，再清理剩余日志。
+>
+> 端口 4174 是我们刚开的临时 Vite server，占用进程是 `node`。我先看 command line 确认是 chart-smoke，再停止它。
+>
+> 确认是 `tmp/chart-smoke` 的 Vite 进程。我现在停掉这组三个临时进程，再清理剩余验证输出。
+>
+> 临时进程和日志已清理。我再确认没有 4174 监听，也没有遗留 build 输出。
+>
+> 端口已经没有监听。`tmp/` 里还有两个旧的 chart verify 日志，我先看内容和时间，确认是不是本轮临时产物再决定是否清理。
+>
+> 这些日志是 2026-05-30 的旧文件，不是本轮产生的，我不动它们。现在补跑持久化测试和最终 diff check，准备更新交接文档。
+>
+> 状态里出现了 `src/tmp/` 和 `tmp/`，这是构建验证留下的临时输出/源。我要清理本轮产生的临时目录，避免把验证脚手架混进功能改动。
+>
+> `src/tmp/web-build-smoke` 是主 Web 构建输出，`tmp/chart-smoke` 是本轮 harness 源；两者都清理。旧的 `tmp/chart-verify-*` 是之前就有的日志，我先不碰。
+>
+> 临时目录清理完成。现在确认工作树只剩功能/测试/文档改动。
+>
+> 刚才临时 harness 抓到了一个有价值的问题，但删掉后不可复跑。按仓库测试位置约定，我会把它转成 `tests/chart-smoke` 下的轻量构建 harness，后续可以用同一个命令复查 ChartBlockRenderer 的真实 Vue/ECharts import。
+>
+> <details><summary>Created 4 files</summary>
+>
+> - Wrote `./tests/chart-smoke/index.html` (+12 -0)
+> - Wrote `./tests/chart-smoke/src/main.ts` (+122 -0)
+> - Wrote `./tests/chart-smoke/src/style.css` (+28 -0)
+> - Wrote `./tests/chart-smoke/vite.config.mts` (+22 -0)
+>
+> </details>
+>
+> 可复跑的 chart smoke harness 已放到 `tests/chart-smoke`。我现在跑格式化、lint 和它的 Vite build，确认它本身是干净的。
+>
+> harness build 通过；输出在 `tmp/chart-smoke-build`，我清掉生成物，保留 `tests/chart-smoke` 源文件。
+>
+> 下一步是更新交接文档：本轮新增了前端 helper 回归测试、ChartBlockRenderer 依赖收窄、以及可复跑的 `tests/chart-smoke` 构建 harness；浏览器像素级 smoke 仍因 Playwright/Browser 不可用而未完成。
+>
+> 文档里“frontend component/store tests pending”已经过期。我现在把它更新为：store helper 已测、组件构建 harness 已加，仍缺真实浏览器像素级和 AI E2E。
+>
+> <details><summary>Edited 2 files</summary>
+>
+> - Wrote `./project document/README.md` (+1 -0)
+> - Wrote `./project document/ai-chart-runtime.md` (+4 -1)
+>
+> </details>
+>
+> 目标文档已对齐。最后把本轮作为 “Frontend Verification Slice” 追加到 handoff log，写清楚命令和剩余阻塞。
+>
+> <details><summary>Edited 1 file</summary>
+>
+> - Wrote `./project document/handoff-log.md` (+36 -1)
+>
+> </details>
+>
+> 交接文档已补。现在对文档格式化并做最终 diff check。
+>
+> 最终空白检查通过，只有 CRLF 提示。最后看一眼分支和新增文件清单，确保没有临时输出混进去。
+> </details>
+
+本轮继续补了前端验证链路：
+
+- 新增 [aiChatChartBlocks.ts](<./src/stores/aiChatChartBlocks.ts:1>)，把 `render_chart` 的 chart payload 提取逻辑从大 store 里拆成可测试纯函数。
+- 新增 [aiChatChartBlocks.test.ts](<./src/stores/aiChatChartBlocks.test.ts:1>)，覆盖单图、多图、无效 payload 过滤、chart block 转换。
+- 调整 [ChartBlockRenderer.vue](<./src/components/AIChat/chat/ChartBlockRenderer.vue:1>)，改为直接导入四个实际使用的图表组件，避免通过 charts barrel 拉入无关依赖。
+- 新增 [tests/chart-smoke](<./tests/chart-smoke/vite.config.mts:1>)，可复跑构建级 smoke harness，覆盖 bar / line / pie / heatmap payload。
+
+验证通过：
+
+- `pnpm run type-check:web`
+- `pnpm run type-check:node`
+- `pnpm exec vite build --config tests/chart-smoke/vite.config.mts`
+- `pnpm exec vite build --config vite.web.config.mts --outDir tmp/web-build-smoke`
+- 相关 `tsx --test`：chart core、render_chart、CLI adapter、前端 chart helper、conversation persistence
+- `git diff --check`
+
+浏览器像素级 smoke 仍没跑成：当前线程没有 Browser tool，shell runtime 的 `playwright` 缺 `playwright-core`，Node REPL 也无法 import `playwright`。这个限制和本轮进展都已写入 [handoff-log.md](<./project document/handoff-log.md:1>)。
+
+<details><summary>17 previous messages</summary>
+
+> 我继续补剩下最关键的“实际渲染证据”。既然 Browser/Playwright 不可用，我会尝试用本机 Edge/Chrome 的 headless 模式跑 `tests/chart-smoke`，再对截图做像素检查。这样能把“图表真的渲染出来”这块尽量补上。
+>
+> 先确认本机浏览器和图片分析工具是否可用；如果 Edge/Chrome 能 headless 截图，我就不需要引入新的 npm 依赖。
+>
+> PowerShell 里 `&` 被当成后台任务操作符了，刚才的 `where` 检查产生了临时 Job；我会清掉它们，并用 Windows 路径方式重新检查 Edge/Chrome。
+>
+> 环境够用了：本机有 Edge/Chrome，Codex runtime 的 Python 有 Pillow。现在我开临时 Vite server，用 Edge headless 截图，再用 Pillow 做非空像素检查。
+>
+> 命令返回 0，但输出没有显示出来；我单独确认截图文件并跑一次独立 Pillow 分析，让结果明确打印出来。
+>
+> 像素检查已经过了：截图 1024x1600，四个区段都有明显非背景像素。不过临时 Vite 子进程还在监听 4174，我会停掉它，然后视觉看一眼截图确认不是误判。
+>
+> 截图肉眼也确认了四种图表都渲染出来了，虽然这个 harness 没加载完整应用 Tailwind，只用于图表 canvas smoke。现在停掉临时 Vite 进程并清理本轮生成的截图/日志。
+>
+> 临时资源清掉了。我再确认端口空闲，然后把这次 Edge headless 验证写入项目文档。
+>
+> 端口 4174 已经空闲。现在把文档从“浏览器像素 smoke 未验证”更新为“Edge headless 已验证”，但仍保留真实 AI E2E 未完成。
+>
+> <details><summary>Edited 1 file</summary>
+>
+> - Wrote `./project document/README.md` (+1 -0)
+>
+> </details>
+>
+> README 已更新。继续把目标文档里的 pending 项改成当前事实，留下真正没做的 AI E2E。
+>
+> <details><summary>Edited 1 file</summary>
+>
+> - Wrote `./project document/ai-chart-runtime.md` (+1 -1)
+>
+> </details>
+>
+> 目标文档对齐了：浏览器像素 smoke 已经有 Edge 证据，in-app Browser 和真实 AI E2E 仍未完成。现在追加这轮 handoff log。
+>
+> <details><summary>Edited 1 file</summary>
+>
+> - Wrote `./project document/handoff-log.md` (+35 -0)
+>
+> </details>
+>
+> 文档更新完了。我现在跑文档格式化、diff 检查和状态确认，确保没有截图/日志残留。
+>
+> 格式和 diff 检查通过；4174 没有监听，`tmp/` 里只剩 2026-05-30 的旧日志，我没有动它们。最后看分支和状态。
+>
+> 本轮已经把浏览器像素级 smoke 补上了。目标仍不标记完成，因为“真实 AI 根据聊天数据生成图表”的 E2E 还没有运行过。
+> </details>
+
+本轮补上了浏览器级渲染证据：用本机 Microsoft Edge headless 打开 `tests/chart-smoke`，成功截到 bar / line / pie / heatmap 四种图表，并用 Pillow 做了像素检查。
+
+验证结果已写入 [handoff-log.md](<./project document/handoff-log.md:1>)：
+
+```text
+SMOKE_OK size=1024x1600 non_bg=73423 very_dark=934 colored=39133 bands=[5382, 33748, 4354, 29939]
+```
+
+同时我清理了本轮生成的截图和临时日志，确认 `4174` 端口没有残留监听。`git diff --check` 通过，只有 Windows CRLF 提示。
+
+目标还不能标记完成：剩下最大缺口是真实 AI E2E，也就是让 AI 在实际聊天数据上生成 SQL + ChartSpec，并确认图表数量、坐标/series 含义、内嵌位置都符合自然语言要求。
+
+<details><summary>26 previous messages</summary>
+
+> 我会继续往最后的 E2E 证据靠近：真实 LLM 可能未必能在本地无配置跑起来，但我可以先做一个“真实 SQLite 聊天数据 + 真实 `render_chart` SQL 执行 + 多图 ChartSpec”的集成测试，把工具执行这一段从 mock 提升到真实数据库证据。
+>
+> 先看现有 SQLite adapter 和测试约定，避免写一个只能在我这台机器上跑的测试。重点是复用已有 `CHATLAB_TEST_SQLITE_NATIVE_BINDING` 机制。
+>
+> 我会把这个测试放在根目录 `tests/chart-runtime/`，因为它跨了 core schema、node-runtime sqlite adapter、tools data provider 和 `render_chart` handler，属于集成测试而不是单模块单测。
+>
+> 测试会用临时 SQLite 文件，插入 Alice/Bob/Cara 的真实 message/member 行，然后用自然语言需求会触发的那类 SQL 分别生成 pie、line、heatmap 等图表。这样能证明工具不是只会处理 mock rows。
+>
+> <details><summary>Created 1 file</summary>
+>
+> - Wrote `./tests/chart-runtime/render-chart.integration.test.ts` (+193 -0)
+>
+> </details>
+>
+> 我先修一下 SQL 里 alias 用在 `WHERE` 的风险：不同数据库对这点支持不完全一致，虽然 SQLite 宽松，但测试应该表达清楚。用完整 `COALESCE(...)` 条件更稳。
+>
+> <details><summary>Edited 1 file</summary>
+>
+> - Wrote `./tests/chart-runtime/render-chart.integration.test.ts` (+2 -2)
+>
+> </details>
+>
+> 集成测试已就位。现在跑格式化、lint 和这条新测试，先看真实 SQLite 路径有没有细节问题。
+>
+> 失败原因不是集成逻辑，而是从 `@openchatlab/node-runtime` 包入口导入时会拉起整个 node-runtime index，间接碰到 `pi-ai` 的 package exports 问题。我把测试改为只导入 sqlite adapter 源文件，避免无关入口副作用。
+>
+> <details><summary>Edited 1 file</summary>
+>
+> - Wrote `./tests/chart-runtime/render-chart.integration.test.ts` (+1 -1)
+>
+> </details>
+>
+> 导入已收窄。重跑格式化和集成测试。
+>
+> 集成测试跑到了真实查询，失败是我预期值写错：Alice 在 09 点有两条（含一条图片），heatmap 聚合确实应该是 2。修正期望值。
+>
+> <details><summary>Edited 1 file</summary>
+>
+> - Wrote `./tests/chart-runtime/render-chart.integration.test.ts` (+1 -1)
+>
+> </details>
+>
+> Alice 的 10 点也有两条，所以修正后再跑一次。
+>
+> 真实 SQLite 集成测试已经通过。现在把本轮新增测试纳入完整 targeted check：lint、类型检查、已有 chart/tool/store/persistence 测试一起跑。
+>
+> 测试和 smoke build 都过了，Vite 生成了 `tmp/chart-smoke-build`，我先清理构建产物，再跑完整类型检查。
+>
+> 类型检查也绿了。现在把“真实 SQLite 聊天数据集成测试”记录进 `project document`，把剩余缺口进一步收窄到真实 LLM/AI Agent E2E。
+>
+> 文档里还有一处前一轮的“browser-backed canvas pixel smoke 未验证”，现在已经被 Edge headless 覆盖了。我会顺手改成“后来已验证”，避免下个接手者被旧状态误导。
+>
+> <details><summary>Edited 1 file</summary>
+>
+> - Wrote `./project document/README.md` (+1 -0)
+>
+> </details>
+>
+> README 已补真实 SQLite 集成覆盖。继续更新目标文档的 hardening 证据。
+>
+> <details><summary>Edited 1 file</summary>
+>
+> - Wrote `./project document/ai-chart-runtime.md` (+2 -1)
+>
+> </details>
+>
+> 目标文档现在说明了真实 SQLite 数据集成测试。最后更新 handoff log，追加本轮集成测试，并修正上一节的过期未验证项。
+>
+> <details><summary>Edited 1 file</summary>
+>
+> - Wrote `./project document/handoff-log.md` (+33 -1)
+>
+> </details>
+>
+> 交接文档已追加本轮真实 SQLite 证据。我现在做最终格式化和空白检查。
+>
+> 检查干净，只有 CRLF 提示。最后确认分支和新增测试文件状态。
+>
+> 本轮已完成真实 SQLite 工具链集成测试，但目标还不标记完成：还缺真实模型从自然语言发起 tool call 的 E2E。
+> </details>
+
+本轮补上了真实 SQLite 聊天数据链路的集成测试。
+
+新增 [render-chart.integration.test.ts](<./tests/chart-runtime/render-chart.integration.test.ts:1>)：它会创建临时 ChatLab SQLite 数据库，写入真实 `member` / `message` 表数据，然后通过 `CoreDataProvider + render_chart` 执行真实只读 SQL，验证：
+
+- Alice/Bob 自定义成员范围的 pie chart
+- 按天、按成员的 multi-series line chart
+- 自定义 `hour / member_name / message_count` 含义的 heatmap
+
+本轮验证通过：
+
+- `pnpm exec tsx --test tests/chart-runtime/render-chart.integration.test.ts`
+- 相关 chart/tool/frontend helper 测试合计 14 passed
+- conversation persistence 测试 13 passed
+- `pnpm exec vite build --config tests/chart-smoke/vite.config.mts`
+- `pnpm run type-check:node`
+- `pnpm run type-check:web`
+- `git diff --check`
+
+`project document` 已更新到最新状态。目标仍不标记完成，因为还缺最后一块真实 E2E：让实际 LLM/AI Agent 从自然语言 prompt 生成 SQL + ChartSpec 并完成 tool call，验证图表数量、坐标/series 语义和内嵌位置。
+
+<details><summary>34 previous messages</summary>
+
+> 我会继续补“AI Agent 侧是否真的会临时开放绘图能力”的证据。真实 LLM 调用可能受本机配置影响，但我们可以先验证 runner 的工具选择和 chart skill prompt wiring，避免 UI 有开关、工具也有了，但 Agent 运行时没把它们接进去。
+>
+> 先读 runner 和已有 agent 测试结构，找最合适的测试切入点。重点看 `skillId=chart_runtime` 时，prompt、`render_chart`、`get_schema` 是否都能进入当前请求。
+>
+> Context compaction
+>
+> Source: automatic
+> Status: completed
+>
+> 我接着补最后这块证据：确认“临时打开绘图能力”在 Agent runner 里真的会开放对应工具，并尽量用小测试把这个入口钉住。
+>
+> 现在看到一个关键点：`get_schema` 是 core 工具，`render_chart` 是 analysis 工具，所以当前 runner 只显式补 `render_chart` 大概率是对的。下一步我会把这个行为变成更直接的回归测试，避免以后重构时把入口弄断。
+>
+> 我会做一个很小的收束：把“绘图技能需要给 analysis 白名单补 `render_chart`，而 `get_schema` 仍走 core 工具”的规则抽成共享 helper，再用单测覆盖。这样 Electron 和 CLI 两端不会各自手写一份容易漂移的逻辑。
+>
+> 顺便发现 CLI 的共享工具注册里 `get_schema` 已经是非 analysis 路径，因此不会被白名单挡住；`render_chart` 是唯一需要绘图开关主动补进来的工具。我准备只改这个共享判断点，不碰其它工具权限语义。
+>
+> 接下来开始改文件：新增一个共享 helper 和对应单测，然后把 Electron/CLI runner 都切到这个 helper 上。改动会很窄，基本只服务于“图表开关打开时工具一定可用”这件事。
+>
+> <details><summary>Edited 1 file</summary>
+>
+> - Wrote `./packages/core/src/ai/chart-capability.ts` (+5 -0)
+>
+> </details>
+>
+> 共享 helper 已加好；它只负责把 `render_chart` 幂等地放进 analysis 工具白名单，`get_schema` 仍由 core 工具系统负责常驻。
+>
+> <details><summary>Edited 1 file</summary>
+>
+> - Wrote `./packages/core/src/ai/index.ts` (+6 -1)
+>
+> </details>
+>
+> 我把 helper 也从 core 的 AI 入口导出了，接下来同步顶层导出和两端 runner 的调用点。
+>
+> <details><summary>Edited 2 files</summary>
+>
+> - Wrote `./packages/core/src/index.ts` (+2 -0)
+> - Wrote `./apps/desktop/main/ai/agent-stream-runner.ts` (+6 -3)
+>
+> </details>
+>
+> Electron 端已经切过来，行为保持一致：保留原 assistant 的 analysis 工具，同时补上绘图工具。
+>
+> <details><summary>Edited 1 file</summary>
+>
+> - Wrote `./apps/cli/src/ai/agent-stream-runner.ts` (+10 -4)
+>
+> </details>
+>
+> CLI 端现在也和 Electron 对齐了：打开绘图技能时，不再依赖“原本是否配置过工具白名单”，都会得到绘图所需的 analysis 白名单。接下来补测试。
+>
+> <details><summary>Created 1 file</summary>
+>
+> - Wrote `./packages/core/src/ai/chart-capability.test.ts` (+30 -0)
+>
+> </details>
+>
+> 单测已经覆盖技能声明和白名单 helper。为了更接近真实入口，我再看一眼 Agent core 的可测边界，看能不能用假 LLM 流做一个不碰真实 API 的工具调用回归。
+>
+> Agent core 确实可以注入自定义 `streamFn`，但要模拟 pi-agent-core 的完整流协议会比这次收束更重。我先优先把低风险入口测试补全，避免为了测试而引入一层脆弱假实现。
+>
+> 我会再补一个更稳定的小测试：Agent event handler 收到带 `chart` 的工具结果时，要原样透传成 `tool_result` 流事件。这正好覆盖聊天区后续提取图表块的前一跳。
+>
+> <details><summary>Edited 1 file</summary>
+>
+> - Wrote `./packages/node-runtime/src/ai/agent/__tests__/event-handler.test.ts` (+36 -9)
+>
+> </details>
+>
+> 代码层面这一小轮改完了。现在跑格式化、lint 和这几条相关测试；如果检查里带出无关报错，我会一并处理。
+>
+> 格式化和 lint 过了。现在跑新增/受影响的单测，再跑 node/web type-check，确认这轮改动没有把两端入口弄歪。
+>
+> 单测和两端 type-check 都通过了。最后我会更新 `project document/`，把这一轮“入口工具白名单收束”和剩余 E2E 缺口写进去，方便后续接手。
+>
+> 检查部分已经完成，我在文档里补这一轮的结果和待办。这里会明确写：当前已完成无真实 API 的工具链验证，但真实 LLM 自然语言端到端仍是下一步。
+>
+> 文档里会新增一个 “Agent Capability Wiring Slice”，记录这轮实际改了哪些入口、跑了哪些检查、下一步还缺什么。
+>
+> <details><summary>Edited 1 file</summary>
+>
+> - Wrote `./project document/README.md` (+2 -0)
+>
+> </details>
+>
+> README 的当前状态补上了这轮入口收束。继续更新目标文档里的已实现/待验证部分。
+>
+> 刚才 patch 的锚点太宽，我改用更窄的位置追加。
+>
+> <details><summary>Edited 1 file</summary>
+>
+> - Wrote `./project document/ai-chart-runtime.md` (+2 -0)
+>
+> </details>
+>
+> 目标文档已补。最后把 handoff log 追加这一轮的实现记录和验证命令。
+>
+> <details><summary>Edited 1 file</summary>
+>
+> - Wrote `./project document/handoff-log.md` (+26 -0)
+>
+> </details>
+>
+> 文档已追加。我再给文档跑一次格式化，然后检查 git diff 状态。
+>
+> 最后的状态检查也过了：当前分支是 `codex/new-feature`，`git diff --check` 只有 Windows 换行提示，没有 whitespace error。我再快速看一下本轮 diff 的关键点，避免收尾时漏说。
+> </details>
+
+这一轮我补齐了 Agent 入口侧的绘图能力开关：
+
+- 在 [chart-capability.ts](./packages/core/src/ai/chart-capability.ts) 抽出共享 allowlist helper，统一给绘图能力补 `render_chart`。
+- Electron 和 CLI Web runner 都改为使用这个 helper。
+- 新增 `chart-capability` 单测，并补了 Agent event handler 对 chart 工具结果原样透传的测试。
+- 已更新 `project document/README.md`、`ai-chart-runtime.md`、`handoff-log.md`，方便后续 AI 继续接手。
+
+验证已通过：
+
+```text
+pnpm exec eslint ... --fix
+pnpm exec tsx --test ...
+pnpm run type-check:node
+pnpm run type-check:web
+git diff --check
+```
+
+当前分支仍是 `codex/new-feature`。剩余最大缺口还是：还没有跑真实 LLM 从自然语言请求到 `render_chart` 工具调用的完整 E2E。
+
+<details><summary>24 previous messages</summary>
+
+> 我会从当前工作树重新确认状态和文档约束，然后优先补那个最大的证据缺口：尽量做一个不依赖真实 API 的 Agent 级绘图 E2E 回归，证明自然语言请求进入 Agent 后可以走到 `render_chart` 并形成图表流事件。
+>
+> 沙箱刚才启动 PowerShell 失败了，我按要求用提权的只读命令继续；当前确认仍在 `codex/new-feature`，工作树有我们这条功能线的大量未提交改动。
+>
+> 文档确认了 `.docs/README.md` 仍不存在，当前内部依据还是 `docs/README.md` 和 `project document/`。下一步我去读 `pi-agent-core` / `pi-ai` 的流协议，判断能不能做一个离线 Agent E2E，而不是停在工具级测试。
+>
+> 第一次搜索没命中类型定义，可能包是 `.d.mts` 或编译后的 `dist` 结构。我会沿着包目录继续找入口文件。
+>
+> 包结构找到了。接下来我会读 `stream` 和 `agent-loop` 的类型/实现，找出假 `streamFn` 应该返回什么事件形态。
+>
+> 现在足够清楚了：`runAgentCore` 可以注入 `streamFn`，而流可以用 `createAssistantMessageEventStream()` 手动推 `toolcall_end` / `done`。我还要读一下工具执行如何包装 `details`，然后就能写测试。
+>
+> 我会新增一个根目录集成测试，不走真实网络模型，而是给 `runAgentCore` 注入一个假 `streamFn`：第一轮根据用户自然语言发出 `render_chart` 工具调用，第二轮输出解释文字。这样能验证 Agent 循环、工具执行、chart payload、最终文字都在同一条链路里跑通。
+>
+> 准备编辑：我会在 `tests/chart-runtime/` 下加一个 `agent-chart-flow.test.ts`，用假模型流驱动真实 `runAgentCore` 和真实 `render_chart` handler，证明工具调用后 `chart` payload 会出现在 Agent 的工具结果事件中，并且第二轮会输出解释文本。
+>
+> <details><summary>Created 1 file</summary>
+>
+> - Wrote `./tests/chart-runtime/agent-chart-flow.test.ts` (+217 -0)
+>
+> </details>
+>
+> 测试文件已经加上了。现在跑格式化、lint 和这一个新增测试，先看协议模拟是否和 `pi-agent-core` 真正兼容。
+>
+> 新增测试暴露了一个已知环境问题：`tsx --test` 走到 `runAgentCore` 时会触发 `pi-ai` 的 package exports/CJS 解析错误。这个不是业务逻辑失败；我先验证用 Node 的 ESM loader 能不能跑通，再决定是改测试运行方式还是调整测试边界。
+>
+> `tsx` 没有明显的“强制 ESM”开关，不过它会把 Node 参数透传。我试一个 `--conditions=import`，如果仍然失败，就把这个测试改成不直接加载 `runAgentCore` 的验证边界，避免留下红测。
+>
+> 好，`--conditions=import` 解决了 `pi-ai` 的导出条件问题，新 Agent 级离线绘图流测试已经跑通。接下来我把它放进相关测试组一起跑，再跑 type-check。
+>
+> 相关测试和 node/web type-check 都通过了。现在补文档，把这轮“离线 Agent 绘图 E2E”记录下来，并注明真实外部 LLM 调用仍未执行。
+>
+> 我开始改 `project document`：新增一段本轮 handoff，并把“仍待验证”的表述从泛泛的 E2E 缺口细化成“真实外部 LLM API 调用缺口”。
+>
+> <details><summary>Edited 1 file</summary>
+>
+> - Wrote `./project document/README.md` (+1 -0)
+>
+> </details>
+>
+> README 更新完了。继续更新目标文档里的实现证据和剩余缺口。
+>
+> <details><summary>Edited 1 file</summary>
+>
+> - Wrote `./project document/ai-chart-runtime.md` (+2 -1)
+>
+> </details>
+>
+> 目标文档已区分“离线 Agent E2E 已有”和“真实模型 E2E 未跑”。最后追加 handoff 日志。
+>
+> <details><summary>Edited 1 file</summary>
+>
+> - Wrote `./project document/handoff-log.md` (+30 -0)
+>
+> </details>
+>
+> 文档已补齐并格式化。最后跑 `git diff --check` 和状态检查，确认没有 whitespace 问题，也方便你看本轮新增了什么。
+>
+> `git diff --check` 没有 whitespace error，只有既有的 Windows 换行提示。本轮新增文件是 untracked，所以 `git diff` 不会展示内容；状态里可以看到 `tests/chart-runtime/` 仍是未跟踪目录的一部分。
+>
+> 我再补一轮安全侧审查：`render_chart` 现在先做 SELECT/WITH 入口判断，但最终安全边界还取决于 dataProvider 的执行层。我会确认共享 CoreDataProvider 和 Electron worker 路径是不是都走只读/参数化执行。
+>
+> 共享 `CoreDataProvider` 确实委托到 core 的 parameterized SQL 执行。我继续看 core 具体实现，以及 Electron worker 的 parameterized 路径；如果发现只靠字符串判断，我会补 `stmt.readonly` 测试。
+> </details>
+
+本轮继续往真正目标推进了一步：新增了离线 Agent 级绘图流程测试 [agent-chart-flow.test.ts](./tests/chart-runtime/agent-chart-flow.test.ts)。
+
+它验证的是一整条链路：自然语言请求进入 `runAgentCore`，假模型流发出 `render_chart` 工具调用，真实 `render_chart` handler 生成 line chart payload，然后 Agent 第二轮输出最终解释文本。这样比之前的工具级/适配器级测试更接近真实 AI 聊天流程。
+
+已同步更新：
+
+- [project document/README.md](./project%20document/README.md)
+- [project document/ai-chart-runtime.md](./project%20document/ai-chart-runtime.md)
+- [project document/handoff-log.md](./project%20document/handoff-log.md)
+
+验证通过：
+
+```text
+pnpm exec prettier --write tests/chart-runtime/agent-chart-flow.test.ts
+pnpm exec eslint tests/chart-runtime/agent-chart-flow.test.ts --fix
+pnpm exec tsx --conditions=import --test ...
+pnpm run type-check:node
+pnpm run type-check:web
+git diff --check
+```
+
+注意：普通 `pnpm exec tsx --test tests/chart-runtime/agent-chart-flow.test.ts` 会因为 `@earendil-works/pi-ai` 的 package exports 条件解析失败；加 `--conditions=import` 后通过。真实外部 LLM API 的 E2E 仍未跑，所以目标还不能标完成。
+
+<details><summary>22 previous messages</summary>
+
+> 我会先做一次当前状态复核，然后选一个还能实质补强的缺口继续推进。真实外部 LLM E2E 可能受本地配置/API Key 影响，但我先不假设，先看代码和配置入口能不能做出更强的自动化验证。
+>
+> 有两个只读命令又撞到 Windows 沙箱启动问题；我会只对这几个必要的状态读取走提权重跑，继续保持改动范围在工作区内。
+>
+> 当前文档里剩两个主要缺口：真实外部 LLM 调用，以及 in-app Browser 手动烟测。真实模型可能需要本地 AI 配置和 API Key；我先试着找一下 Browser 插件工具，如果这次可用，就把 UI 侧最后一个手动验证缺口补上。
+>
+> Browser 工具这次仍没有暴露出来；我不会硬绕。另一个更实际的产品缺口是“临时激活/发送后清空”的行为，现在主要靠现有 store 逻辑支撑，我去补一条前端 store 级回归，证明绘图能力真的是一次性开关。
+>
+> 沙箱又在 PowerShell 启动处失败了；这轮只读检查继续用提权重跑。我要先看清楚 store 的现有结构，避免为了测试而误改业务逻辑。
+>
+> store 里已经把 `chart_runtime` 作为合成技能放进 slash 兼容列表；发送请求时会读取当前 `activeSkillId` 传给 Agent。接下来我要看输入组件在哪里清除 active skill，确认能不能抽出可测 helper。
+>
+> 输入组件里已经明确发送后清空 active skill，这部分在组件内部；更稳定的可测点是 skill store：合成绘图技能在兼容列表中、可激活、可拿到完整配置。这能保护 slash 菜单入口不被后续重构丢掉。
+>
+> 我会新增 `src/stores/skill.test.ts`，只测 store 计算属性和合成技能配置，不调用后端 service，尽量避免把测试变成环境集成。
+>
+> 开始编辑：新增 skill store 回归测试，覆盖 `/` 菜单能看到绘图助手、激活后拿到当前 locale 的合成技能、发送后可通过同一个 store API 清空。
+>
+> <details><summary>Created 1 file</summary>
+>
+> - Wrote `./src/stores/skill.test.ts` (+49 -0)
+>
+> </details>
+>
+> 测试已加。现在对新测试跑格式化、lint、单测；如果路径别名或 service import 在 Node 测试里有问题，我会就地调整到项目现有测试方式能稳定跑。
+>
+> 格式化没改动。继续跑 lint 和这条测试。
+>
+> lint 过了。现在单独跑新测试，看 Node 环境是否能加载这个 Pinia store。
+>
+> 新测试通过，说明合成绘图技能的 slash 入口和单次 toggle API 有自动化保护了。接下来跑相关 chart/agent/store 测试组和两端 type-check。
+>
+> 相关测试组全部通过。现在跑 `type-check:web` / `type-check:node`，确认新增 store 测试不会破坏 TS 严格检查。
+>
+> 类型检查也过了。我会按项目要求更新 `project document/`，把这轮“slash 合成技能/单次 toggle 回归”记录进去。
+>
+> 开始编辑文档，只补本轮完成内容和验证命令，不扩写无关规划。
+>
+> <details><summary>Edited 2 files</summary>
+>
+> - Wrote `./project document/README.md` (+1 -0)
+> - Wrote `./project document/ai-chart-runtime.md` (+1 -0)
+>
+> </details>
+>
+> README 和目标文档已补。继续追加 handoff log。
+>
+> <details><summary>Edited 1 file</summary>
+>
+> - Wrote `./project document/handoff-log.md` (+24 -0)
+>
+> </details>
+>
+> 文档内容写完了。现在格式化文档并做最终 diff/check。
+>
+> 文档格式化完成。我再跑 whitespace 检查和状态检查，收口这轮。
+> </details>
+
+这轮补了前端临时激活入口的回归测试：[skill.test.ts](./src/stores/skill.test.ts)。
+
+它覆盖了：
+
+- `/` 菜单用的 `compatibleSkills` 会默认出现 `chart_runtime`
+- 不需要从技能市场导入也能使用绘图助手
+- 激活后能按 locale 返回“绘图助手 / Chart Assistant”
+- `getSkillConfig(chart_runtime)` 返回 `render_chart` + `get_schema`
+- 可通过同一个 store toggle 清空 active skill，对齐“单次消息生效”的产品行为
+
+也同步更新了 `project document` 三份文档。
+
+验证通过：
+
+```text
+pnpm exec eslint src/stores/skill.test.ts --fix
+pnpm exec tsx --conditions=import --test ...
+pnpm run type-check:web
+pnpm run type-check:node
+git diff --check
+```
+
+目标还不标完成：真实外部 LLM API E2E 和 in-app Browser 手动烟测仍未完成。
+
+<details><summary>18 previous messages</summary>
+
+> 我继续往目标收口。真实外部 LLM E2E 和 in-app Browser 仍可能受环境工具/配置限制，我先从当前代码里再找一处能实质增强目标的点：动态 SQL 安全和 ChartSpec 校验是否已经足够硬。
+>
+> PowerShell 又碰到 Windows 沙箱启动错误了；我会对这些只读检查走提权重跑，继续只读不改状态。
+>
+> 我发现一个值得补的安全回归：`render_chart` 允许 `WITH` 开头，真正的只读边界依赖 SQLite 的 `stmt.readonly`。我要加一个真实 SQLite 集成测试，验证 `WITH ... DELETE ...` 这种 CTE 前缀写操作不会穿透并且不会改动聊天库。
+>
+> <details><summary>Edited 1 file</summary>
+>
+> - Wrote `./tests/chart-runtime/render-chart.integration.test.ts` (+44 -0)
+>
+> </details>
+>
+> 安全集成测试已加。现在跑格式化、lint 和这条真实 SQLite 测试，确认 CTE 写操作确实被底层只读检查挡住且数据不变。
+>
+> 格式化没有改动。继续跑 lint 和目标测试。
+>
+> 真实 SQLite 安全测试通过了：`WITH` 前缀写操作被拒绝，消息数量保持不变。接下来跑相关回归组和类型检查。
+>
+> 相关回归组 30 条都通过。现在跑 node/web type-check，最后补 project document。
+>
+> 类型检查这次异常卡住直到工具超时，和之前 10-30 秒通过的行为不一致。我先确认没有残留 `tsc/vue-tsc` 进程，再分开重跑，避免并行检查互相拖住。
+>
+> 没有残留 type-check 进程，只有 Codex 自己的 Node REPL。现在我分开跑，先 node 再 web。
+>
+> node type-check 已通过，刚才的卡住看来是并行工具层异常。继续跑 web。
+>
+> web type-check 也通过了。现在更新 project document，记录 CTE 写操作安全回归和这次类型检查重跑情况。
+>
+> 我开始补文档：这轮只新增安全回归测试，不改产品行为，所以文档会聚焦在 “WITH 前缀写操作被真实 SQLite 只读边界拦截”。
+>
+> <details><summary>Edited 3 files</summary>
+>
+> - Wrote `./project document/README.md` (+1 -0)
+> - Wrote `./project document/ai-chart-runtime.md` (+1 -0)
+> - Wrote `./project document/handoff-log.md` (+29 -0)
+>
+> </details>
+>
+> 文档条目已加。现在格式化项目文档和更新过的测试文件，最后跑 whitespace/status 检查。
+>
+> 格式化命令又触发沙箱启动问题；我重跑一次提权的同一命令。
+>
+> 格式化完成。最后跑 `git diff --check` 和状态检查。
+>
+> `git diff --check` 通过，只有 Windows 换行提示；状态检查也正常。本轮只剩一个只读 diff 命令触发沙箱问题，不影响验证结论，我不再为它阻塞。
+> </details>
+
+这轮补强了 `render_chart` 的真实 SQLite 安全证据：在 [render-chart.integration.test.ts](./tests/chart-runtime/render-chart.integration.test.ts) 里新增了一个 `WITH` 前缀写操作回归测试。
+
+它验证：
+
+- SQL 以 `WITH` 开头，可以穿过 `render_chart` 的第一层 SELECT/WITH 入口判断
+- 但内部尝试 `DELETE FROM message`
+- `CoreDataProvider` / core SQL 执行层会用 SQLite readonly 元数据拒绝它
+- 拒绝后 `message` 表行数不变
+
+已更新 `project document` 三份文档，记录本轮安全回归。
+
+验证通过：
+
+```text
+pnpm exec eslint tests/chart-runtime/render-chart.integration.test.ts --fix
+pnpm exec tsx --conditions=import --test tests/chart-runtime/render-chart.integration.test.ts
+pnpm exec tsx --conditions=import --test ...相关 chart 回归组
+pnpm run type-check:node
+pnpm run type-check:web
+git diff --check
+```
+
+目标仍不标完成：真实外部 LLM API E2E 和 in-app Browser 手动烟测还没拿到完整证据。
+
+<details><summary>29 previous messages</summary>
+
+> 我继续找能实质补强目标的地方。真实外部模型和 in-app Browser 仍是环境型缺口；这轮我优先审一下 `render_chart` 的 SQL 限流和 ChartSpec 边界，看看有没有还能靠代码/测试收掉的风险。
+>
+> 一个实际风险点很明确：当前 `render_chart` 只在 SQL 没有 `LIMIT` 时追加限制，而且是直接拼到原 SQL 后面。这样模型如果自己写了很大的 `LIMIT`，或者末尾有 `-- comment`，就可能绕开 `maxRows + 1` 的执行层限流。我会改成统一外层包裹 `SELECT * FROM (...) LIMIT maxRows+1`，让行数上限始终由 ChatLab 控制。
+>
+> <details><summary>Edited 1 file</summary>
+>
+> - Wrote `./packages/tools/src/definitions/render-chart.ts` (+1 -2)
+>
+> </details>
+>
+> 限流逻辑已改成外层包裹。接下来调整现有测试预期，并补两条回归：内部已有 LIMIT 也会被外层上限约束，末尾行注释不会吞掉 LIMIT。
+>
+> <details><summary>Edited 1 file</summary>
+>
+> - Wrote `./packages/tools/src/definitions/render-chart.test.ts` (+43 -2)
+>
+> </details>
+>
+> 我刚注意到一个小细节：外层包裹本身也要把原 SQL 放在独立行里，否则原 SQL 末尾的 `-- comment` 仍可能注释掉外层右括号。马上修正为多行包裹。
+>
+> <details><summary>Edited 2 files</summary>
+>
+> - Wrote `./packages/tools/src/definitions/render-chart.ts` (+1 -1)
+> - Wrote `./packages/tools/src/definitions/render-chart.test.ts` (+4 -4)
+>
+> </details>
+>
+> 补丁完成。现在跑格式化、lint 和工具/SQLite 回归，确认新包裹 SQL 在 fake provider 与真实 SQLite 下都能工作。
+>
+> lint 命令这次又遇到沙箱启动错误，我按机制提权重跑同一检查。
+>
+> lint 过了。现在跑 `render_chart` 单测和真实 SQLite 集成测试。
+>
+> 真实 SQLite 测试准确地暴露了行为变化：外层包裹后，`WITH ... DELETE` 在 SQLite 里先变成不可作为子查询的语法错误，数据仍不会变。我要把断言从“必须 readonly 错误”放宽为“被拒绝且不变”，这更符合新的双保险边界。
+>
+> <details><summary>Edited 1 file</summary>
+>
+> - Wrote `./tests/chart-runtime/render-chart.integration.test.ts` (+1 -1)
+>
+> </details>
+>
+> 断言已修正。重跑相关测试。
+>
+> 格式化无变化。继续跑目标测试。
+>
+> 目标测试通过。现在跑完整相关 chart 回归组，确保 Agent flow 里的 SQL 包裹不会破坏工具链。
+>
+> 继续跑完整相关回归组和类型检查。
+>
+> 32 条相关回归都通过。现在分开跑 node/web type-check，避免之前并行检查偶发卡住。
+>
+> node type-check 通过。继续 web。
+>
+> 类型检查都过了。我会更新 project document，记录“外层 LIMIT 包裹”这轮修复和验证命令。
+>
+> 开始改文档：同时修正上一轮文档里“provider readonly metadata 拦截”的表述，因为现在外层包裹会先让 `WITH ... DELETE` 变成不可执行子查询，核心事实是“被拒绝且不变”。
+>
+> 只读文档搜索又碰到沙箱启动问题；我直接用已知位置做 patch，避免在读文件上耗时间。
+>
+> <details><summary>Edited 1 file</summary>
+>
+> - Wrote `./project document/README.md` (+1 -0)
+>
+> </details>
+>
+> README 补上执行层限流。继续更新目标文档硬化列表。
+>
+> <details><summary>Edited 1 file</summary>
+>
+> - Wrote `./project document/ai-chart-runtime.md` (+3 -2)
+>
+> </details>
+>
+> 目标文档已更新。最后追加 handoff log 新切片，并修正上一切片里过时的一句。
+>
+> <details><summary>Edited 1 file</summary>
+>
+> - Wrote `./project document/handoff-log.md` (+36 -1)
+>
+> </details>
+>
+> 文档 patch 完成。现在格式化文档和最终检查。
+>
+> 格式化完成。最后跑 whitespace 检查和状态。
+>
+> `git diff --check` 通过，只有已有换行提示；状态里仍是这条功能线的未提交改动。收口这轮。
+> </details>
+
+这轮修了一个实际安全/性能边界：`render_chart` 现在不再只是在 SQL 后面简单追加 `LIMIT`，而是统一包一层外部查询：
+
+```sql
+SELECT * FROM (
+  <model SQL>
+) AS chart_query LIMIT maxRows + 1
+```
+
+这样即使模型自己写了很大的 `LIMIT`，或者 SQL 末尾有 `-- comment`，也不能绕开 ChatLab 的抓取上限。相关测试也更新了：
+
+- `render_chart` 单测新增：已有 `LIMIT 100000` 仍会被外层限制
+- `render_chart` 单测新增：尾部行注释不会吞掉外层限制
+- 真实 SQLite 集成测试仍通过：pie / line / heatmap / 写操作拒绝都没被破坏
+
+验证通过：
+
+```text
+pnpm exec eslint ... --fix
+pnpm exec tsx --conditions=import --test ...相关 chart 回归组
+pnpm run type-check:node
+pnpm run type-check:web
+git diff --check
+```
+
+也已更新 `project document` 三份文档。目标仍不标完成，剩余未验证项还是外部真实 LLM E2E 和 in-app Browser 手动烟测。
+
+<details><summary>15 previous messages</summary>
+
+> 我会继续做一次当前状态复核，然后挑一个还没有被强证据覆盖的链路补上。今天（2026-06-04）先从“真实 app stream 到 content block”这段看起，因为它比纯工具测试更贴近用户看到的结果。
+>
+> 状态确认：仍在 `codex/new-feature`，`.docs/README.md` 不存在，现有依据是 `docs/README.md` 和 `project document/`。我现在看前端 stream 处理是否有可抽测的薄弱点。
+>
+> 又遇到 Windows 沙箱启动问题；我用提权只读重跑这些检查。
+>
+> 这里有一个用户可见的边界：`render_chart` 是“只显示图表、不显示工具胶囊”的工具；如果它失败且没有 chart payload，当前聊天区可能什么也不展示。我要补一个小 helper，让 render-only 工具的失败结果能转成错误块，同时保持成功时只显示图表。
+>
+> 只读命令有一部分又失败；我已经拿到 `ContentBlock` 类型，需要再看错误类型和 normalize 函数。
+>
+> 我会把这个逻辑放在 `aiChatChartBlocks.ts` 里，避免把巨大的 `aiChat.ts` 再拆一块。新增 helper 只识别 `render_chart` 的 Error 文本或显式 error 形状，并用现有 `error` content block 展示。
+>
+> 开始编辑：新增 `toRenderOnlyToolErrorBlock` helper，并把两处 `tool_result` 处理改成“有 chart 就追加 chart；render_chart 失败且无 chart 就追加错误块”。
+>
+> <details><summary>Edited 2 files</summary>
+>
+> - Wrote `./src/stores/aiChatChartBlocks.ts` (+35 -0)
+> - Wrote `./src/stores/aiChatChartBlocks.test.ts` (+27 -1)
+>
+> </details>
+>
+> helper 和测试已加。接下来接入 `aiChat.ts` 的两条 stream 路径。
+>
+> <details><summary>Edited 1 file</summary>
+>
+> - Wrote `./src/stores/aiChat.ts` (+6 -1)
+> - Wrote `./src/stores/aiChat.ts` (+9 -0)
+> - Wrote `./src/stores/aiChat.ts` (+9 -3)
+>
+> </details>
+>
+> 第一条发送路径接上了：render_chart 成功还是只加 chart；失败则加错误块并把当前工具状态标成 error。再接编辑重跑路径。
+>
+> 第二段代码和第一段略有差别，我先读一下精确上下文再 patch。
+>
+> <details><summary>Edited 1 file</summary>
+>
+> - Wrote `./src/stores/aiChat.ts` (+8 -2)
+>
+> </details>
+>
+> 两条 stream 路径都接好了。现在格式化、lint，并跑 chart-block helper测试和相关前端/agent回归。
+>
+> 格式化和 lint 过了。继续跑相关测试组。
+> </details>
+
+34 条相关回归都通过。现在分开跑 type-check，确认新的 helper 类型和 `aiChat.ts` 改动没有 TS 问题。
+
+<details><summary>9 previous messages</summary>
+
+> 我接着上一次被中断的位置收尾：代码和相关测试已经过了，`type-check:node` 也过了；我现在补跑 `type-check:web`，然后把这轮“render_chart 失败也要可见”的改动写进 `project document/`。
+>
+> `type-check:web` 通过。现在我会更新交接文档，记录这轮用户可见错误块的行为和验证命令。
+>
+> 开始改 `project document`：这轮只记录新补的“render-only 工具失败可见”切片，不改目标范围。
+>
+> <details><summary>Edited 2 files</summary>
+>
+> - Wrote `./project document/README.md` (+1 -0)
+> - Wrote `./project document/ai-chart-runtime.md` (+1 -0)
+>
+> </details>
+>
+> README 和目标文档已补。继续追加 2026-06-04 的 handoff log。
+>
+> <details><summary>Edited 1 file</summary>
+>
+> - Wrote `./project document/handoff-log.md` (+25 -0)
+>
+> </details>
+>
+> 文档已写完。我会格式化本轮改动文件，并再跑一次必要检查。
+>
+> 格式化完成。代码检查和相关测试在中断前已通过，刚刚补跑了 `type-check:web`；现在做最终 whitespace/status 检查。
+>
+> 最终检查完成：`git diff --check` 只有换行提示，没有 whitespace error；工作树仍是这条功能线的未提交改动。
+> </details>
+
+这轮把被中断前的工作收完了：`render_chart` 作为“只显示图表、不显示工具胶囊”的工具，现在失败时也不会静默消失。
+
+改动要点：
+
+- [aiChatChartBlocks.ts](./src/stores/aiChatChartBlocks.ts) 新增 `toRenderOnlyToolErrorBlock()`
+- [aiChat.ts](./src/stores/aiChat.ts) 两条 stream 路径都接入了这个逻辑
+- [aiChatChartBlocks.test.ts](./src/stores/aiChatChartBlocks.test.ts) 增加成功图表、render-only 失败、普通工具不误判的测试
+- `project document` 已更新 2026-06-04 的 handoff 记录
+
+已验证：
+
+```text
+pnpm exec eslint src/stores/aiChat.ts src/stores/aiChatChartBlocks.ts src/stores/aiChatChartBlocks.test.ts --fix
+pnpm exec tsx --conditions=import --test ...相关回归组
+pnpm run type-check:node
+pnpm run type-check:web
+git diff --check
+```
+
+剩余仍是两个环境型证据缺口：真实外部 LLM API E2E，以及 in-app Browser 手动烟测。
+
+<details><summary>10 previous messages</summary>
+
+> 我继续往目标查漏补强。剩余两个大缺口偏环境验证，我先从产品明确要求的“图表数量按用户需求”下手，看看现有 Agent 离线 E2E 是否已经覆盖多图；如果没有，就补一个多图回归。
+>
+> 先读现有离线 Agent 测试和 chart helper，确认需要补在哪个层级最稳。
+>
+> Windows 沙箱又在启动 PowerShell 时失败；我对这些只读检查走提权重跑。
+>
+> 现有离线 Agent E2E 只覆盖了一张图；用户目标里“图表数量按用户需求”是明确要求。我会把 fake model 流扩展成支持一次发多个 `render_chart` tool call，并补一个“两张图”Agent 回归。
+>
+> 开始编辑 `tests/chart-runtime/agent-chart-flow.test.ts`，只改测试侧协议构造和新增用例，不碰运行时代码。
+>
+> <details><summary>Edited 1 file</summary>
+>
+> - Wrote `./tests/chart-runtime/agent-chart-flow.test.ts` (+19 -9)
+>
+> </details>
+>
+> 多 tool call 流构造已加。现在添加第二个用例，模拟用户要求两张图：一张饼图、一张热力图。
+>
+> <details><summary>Edited 1 file</summary>
+>
+> - Wrote `./tests/chart-runtime/agent-chart-flow.test.ts` (+123 -0)
+>
+> </details>
+>
+> Context compaction
+>
+> Source: automatic
+> Status: completed
+>
+> 我先把目标写成可以直接放进 `project document` 的版本：足够明确，让后续 AI 一眼知道要做什么，同时不把实现细节锁死。
+> </details>
+
+可以写成这个目标：
+
+**目标：**
+在 ChatLab 中实现一个独立、可开关、可按对话启用的 AI 动态图表能力。用户可以用自然语言自定义统计对象、时间范围、维度、指标、图表类型和图表数量；AI 负责理解需求并生成安全的图表请求，系统负责校验、取数、标准化和渲染，最终让饼图、折线图、柱状图、热力图等图表像普通文本内容一样自然嵌入 AI 回复中，并支持历史消息稳定重放与后续图表类型扩展。
+
+<details><summary>25 previous messages</summary>
+
+> 我会继续往“真正可交付的动态绘图能力”推进，这一轮先补上一个关键缺口：验证同一轮 AI 回复里能按用户要求生成多张图表。先重新读当前代码和项目文档，避免拿旧上下文当真。
+>
+> 当前分支是 `codex/new-feature`，`.docs/README.md` 仍不存在；我已按仓库现状读取了 `docs/README.md` 作为公开文档入口。`project document` 里也明确记录了“多图表数量跟随用户需求”，所以这轮会直接补对应的 Agent 级回归。
+>
+> 测试文件里已经有一个多图表用例雏形了，但它还依赖工具结束顺序，并且 SQL 太像占位符。我会把它收紧成更贴近真实模型输出的 CTE + 参数化 SQL，同时让断言不受并行工具完成顺序影响。
+>
+> 接下来会改动 `tests/chart-runtime/agent-chart-flow.test.ts`，只动这个多图表用例，让它明确证明“一次用户请求可以触发两次 render_chart，并产出两种图表内容块所需的 payload”。
+>
+> <details><summary>Edited 1 file</summary>
+>
+> - Wrote `./tests/chart-runtime/agent-chart-flow.test.ts` (+43 -17)
+>
+> </details>
+>
+> 多图表用例已经补强：现在模拟的是用户明确要两个图表，模型一次性发出 pie 和 heatmap 两个工具调用，且两个调用都走参数化 SQL。下一步我会格式化并运行这一组测试，看实际 agent/tool 流是否承认这个行为。
+>
+> PowerShell 沙箱这次又碰到 Windows runner 的 `1312` 问题；这是环境启动问题，不是代码结果。我会对必要命令直接走已批准的提升执行来继续验证。
+>
+> 格式化和 ESLint 已经通过，没有额外改动需求。现在跑 Agent 图表流程测试，重点看两个 `render_chart` 是否能在同一轮工具回合里完整返回。
+>
+> 关键用例已通过：同一个自然语言请求触发了两个 `render_chart`，并分别拿到了 pie 和 heatmap 的标准化 payload。接下来跑更宽一点的回归，防止这次测试辅助函数改动影响单图表、前端提取、工具适配和持久化路径。
+>
+> 更宽回归里只有 `packages/node-runtime/src/ai/__tests__/conversations.test.ts` 失败，原因不是这次代码断言，而是本地 `better-sqlite3.node` 的 Node ABI 不匹配：模块是 `NODE_MODULE_VERSION 133`，当前测试 Node 要 `137`。我会先尝试本地重建这个原生依赖，再重新跑失败组。
+>
+> `better-sqlite3` 已本地重建完成。先单独重跑 conversation 测试确认 ABI 问题消失，再继续整组回归。
+>
+> 重建命令返回 0，但二进制仍是旧 ABI，说明 pnpm 没有真正重新编译当前测试 Node 所需的原生产物。我要查一下当前 Node 版本、better-sqlite3 构建目录和项目脚本，找一个不改业务代码的验证路径。
+>
+> 项目要求 Node 24，这和测试进程要的 ABI 137 一致。沙箱又拦了几个诊断命令，我会把剩下的原生模块诊断提升执行。
+>
+> 构建产物时间戳还是旧的，`pnpm rebuild` 没有覆盖那个 `.node` 文件。`better-sqlite3` 自带 `build-release` 脚本，我会直接在它的包目录里用当前 Node 24 重新编译一次。
+>
+> 直接本地编译失败是因为这台 Windows 没有可用的 Visual Studio C++ 构建工具。下一步我会尝试走 `prebuild-install` 下载/安装 Node 24 对应的预编译二进制；这仍然只是修复本地测试环境，不改业务代码。
+>
+> 预编译的 Node 24 / ABI 137 版本已经成功解包到 `better_sqlite3.node`。现在重跑刚才失败的 conversation 持久化测试。
+>
+> SQLite 持久化测试恢复通过了。现在重新跑完整相关回归组，确认刚才的失败确实只是本地原生依赖 ABI 问题。
+>
+> 完整相关回归现在 48 项全绿。接下来做类型检查和 diff 空白检查；这部分会覆盖更广的 TypeScript 约束。
+>
+> 类型检查也通过了，`git diff --check` 只有已有的 CRLF 提示，没有空白错误。现在进入交接文档更新，把这轮“多图表 Agent 流程”写进 `project document`，方便下一位 AI 直接接上。
+>
+> 交接日志已经记录了最近几轮，但还缺这轮“多图表 Agent 流程”的条目。为了不误改结构，我会再读取 `project document/README.md` 和目标文档后补充。
+>
+> 现在会改 `project document/README.md`、`project document/ai-chart-runtime.md`、`project document/handoff-log.md`，记录本轮新增的“用户要求两张图表 -> Agent 同轮两次 render_chart -> 两个标准化图表 payload”证据，以及本地 SQLite 原生依赖修复说明。
+>
+> <details><summary>Edited 3 files</summary>
+>
+> - Wrote `./project document/README.md` (+2 -1)
+> - Wrote `./project document/ai-chart-runtime.md` (+1 -0)
+> - Wrote `./project document/handoff-log.md` (+36 -0)
+>
+> </details>
+>
+> 文档已更新。现在对这三个 Markdown 文件跑 Prettier，再做最终的空白检查。
+>
+> Markdown 格式化没有产生额外改动。最后再跑一次 `git diff --check`，然后我会查看本轮 diff 摘要，给你收口说明。
+>
+> 最终空白检查通过，只有 Git 的 CRLF 规范化警告。最后我会抓一下变更摘要和关键行号，方便你快速定位本轮改动。
+> </details>
+
+注意：`git diff --stat` 只展示已跟踪文件，所以不会列出这些新建/未跟踪的测试和 project document 文件；`git status` 里它们仍显示为未跟踪，符合当前分支还没 stage/commit 的状态。
+
+<details><summary>33 previous messages</summary>
+
+> Stream error
+>
+> Reconnecting... 2/5
+> request timed out
+>
+> Stream error
+>
+> Reconnecting... 3/5
+> request timed out
+>
+> Stream error
+>
+> Reconnecting... 4/5
+> request timed out
+>
+> Stream error
+>
+> Reconnecting... 5/5
+> request timed out
+>
+> 上一段多图表回归已经完成并写进交接文档了。现在我继续补下一个真实交付缺口：优先尝试用 Codex 的 in-app Browser 做一次图表渲染烟测；如果工具仍不可用，再把不可验证点明确留在文档里。
+>
+> 我会先查工具列表，而不是假设 Browser 已经暴露；这能避免把“还没法人工验”的缺口误报成已完成。
+>
+> 工具发现结果里仍没有 in-app Browser 的可调用工具，只有自动化和子代理工具，所以这条验收暂时不能用 Browser 插件完成。我不会把它硬说成已验证；接下来转向另一个缺口：看看能否补一个真实外部 LLM E2E 的可运行测试入口，至少让后续有 API key 时能直接跑。
+>
+> 我会先读 Agent 入口和现有测试用法，判断“真实 LLM E2E”应该接在哪一层，尽量复用项目现有的模型调用路径，而不是另起一套临时脚本。
+>
+> <details><summary>Ran 4 commands</summary>
+>
+> - Ran `Get-Content -Path packages/node-runtime/src/ai/agent/index.ts -TotalCount 240`
+> - Ran `Get-Content -Path packages/node-runtime/src/ai/agent/agent-core.ts -TotalCount 360`
+> - Ran `Get-Content -Path node_modules/@earendil-works/pi-ai/dist/index.d.ts -TotalCount 260`
+> - Ran `rg -n "runAgentCore|OPENAI_API_KEY|apiKey|piModel|streamFn|create.*Model|provider" packages/node-runtime/src apps/cli/src apps/desktop/main tests -g "*.ts"`
+>
+> </details>
+>
+> `runAgentCore` 本身已经支持不传 `streamFn` 走真实模型流，测试层可以挂在这里。我要再看模型构建器和内置 OpenAI 模型定义，决定这个 E2E 用哪些环境变量驱动、如何默认跳过。
+>
+> <details><summary>Ran 4 commands</summary>
+>
+> - Ran `Get-Content -Path packages/node-runtime/src/ai/agent/core.ts -TotalCount 300`
+> - Ran `Get-Content -Path packages/node-runtime/src/ai/llm-builder.ts -TotalCount 260`
+> - Ran `rg -n "gpt-4o|gpt-4.1|gpt-5|openai" packages/core/src packages/node-runtime/src apps -g "*.ts"`
+> - Ran `Get-Content -Path packages/node-runtime/src/ai/agent/types.ts -TotalCount 180`
+>
+> </details>
+>
+> 模型构建路径很清楚：用 `buildPiModel({ provider, model, baseUrl })` 构建，再把 `apiKey` 交给 `runAgentCore`。我会先查仓库里有没有“环境变量开启的外部 E2E”惯例，保持测试风格一致。
+>
+> <details><summary>Ran 4 commands</summary>
+>
+> - Ran `rg -n "process\.env|skip\(|it\.skip|describe\.skip|RUN_|E2E|OPENAI|API_KEY|CHATLAB_" tests packages apps src -g "*.test.ts" -g "*.test.js" -g "*.ts"`
+> - Ran `Get-Content -Path packages/core/src/ai/chart-capability.ts -TotalCount 260`
+> - Ran `Get-Content -Path packages/tools/src/definitions/render-chart.ts -TotalCount 260`
+> - Ran `Get-Content -Path packages/tools/src/definitions/schema.ts -TotalCount 220`
+>
+> </details>
+>
+> 仓库里已有 E2E smoke 的惯例：用 `CHATLAB_RUN_E2E_SMOKE=1` 这种环境变量显式开启，否则跳过。这正适合真实 LLM 测试，因为它依赖外部网络和 API key。
+>
+> <details><summary>Ran 4 commands</summary>
+>
+> - Ran `rg -n "name: 'get_schema'|get_schema|schemaTool|executeParameterizedSql|getSchema" packages/tools/src packages/core/src apps/cli/src apps/desktop/main -g "*.ts"`
+> - Ran `Get-Content -Path tests/e2e/smoke/app-launcher.smoke.test.js -TotalCount 120`
+> - Ran `Get-ChildItem -Path packages/tools/src/definitions -Force`
+> - Ran `Get-Content -Path packages/core/src/ai/model-catalog.ts -TotalCount 160`
+>
+> </details>
+>
+> 为了让真实 E2E 真正覆盖“模型自己推导 SQL + ChartSpec”，我不准备只用 fake dataProvider。更有价值的是复用临时 ChatLab SQLite 数据库，让模型看到真实 schema，然后靠 `get_schema` / `render_chart` 自己生成查询。
+>
+> <details><summary>Ran 2 commands</summary>
+>
+> - Ran `Get-Content -Path tests/chart-runtime/render-chart.integration.test.ts -TotalCount 360`
+> - Ran `Get-Content -Path packages/tools/src/definitions/sql-query.ts -TotalCount 180`
+>
+> </details>
+>
+> 我会添加一个默认跳过的真实 LLM E2E 文件：只有设置 `CHATLAB_RUN_REAL_LLM_CHART_E2E=1` 且提供 API key 时才会打外部模型；平时回归不会花钱、不会因为网络波动失败。测试本身会创建真实 ChatLab SQLite 临时库，并要求模型生成两张图。
+>
+> <details><summary>Created 1 file, ran 2 commands</summary>
+>
+> - Wrote `./tests/chart-runtime/real-llm-chart-flow.e2e.test.ts` (+193 -0)
+> - Ran `rg -n "export type ChartPayload|interface ChartPayload|type ChartData|PieChart" packages/core/src/chart/index.ts`
+> - Ran `Get-Content -Path packages/core/src/chart/index.ts -TotalCount 130`
+>
+> </details>
+>
+> 测试文件已加好。现在跑格式化、lint 和这个新 E2E 文件的默认跳过模式，确认它不会影响普通回归。
+>
+> <details><summary>Ran 2 commands</summary>
+>
+> - Ran `pnpm exec prettier --write tests/chart-runtime/real-llm-chart-flow.e2e.test.ts`
+> - Ran `pnpm exec eslint tests/chart-runtime/real-llm-chart-flow.e2e.test.ts --fix`
+>
+> </details>
+>
+> 格式化和 lint 都过了。接下来运行新文件；默认没有打开真实外部调用开关，所以期望它被 node:test 标记为 skipped。
+>
+> <details><summary>Ran 1 command</summary>
+>
+> - Ran `pnpm exec tsx --conditions=import --test tests/chart-runtime/real-llm-chart-flow.e2e.test.ts`
+>
+> </details>
+>
+> 新 E2E 入口正常被跳过，没有污染普通测试。现在我会把它并入相关回归组，再跑类型检查，确保新增测试文件在项目约束下也没问题。
+>
+> <details><summary>Ran 1 command</summary>
+>
+> - Ran `pnpm exec tsx --conditions=import --test src/stores/aiChatChartBlocks.test.ts src/stores/skill.test.ts tests/chart-runtime/agent-chart-flow.test.ts tests/chart-runtime/real-llm-chart-flow.e2e.test.ts packages/core/src/ai/chart-capability.test.ts packages/node-runtime/src/ai/agent/__tests__/event-handler.test.ts packages/core/src/chart/index.test.ts packages/tools/src/definitions/render-chart.test.ts apps/cli/src/ai/tool-adapter.test.ts tests/chart-runtime/render-chart.integration.test.ts packages/node-runtime/src/ai/__tests__/conversations.test.ts`
+>
+> </details>
+>
+> 相关回归通过：48 个通过，新增真实 LLM E2E 入口按预期跳过 1 个。现在跑 node/web 类型检查和 diff 空白检查。
+>
+> <details><summary>Ran 3 commands</summary>
+>
+> - Ran `pnpm run type-check:node`
+> - Ran `pnpm run type-check:web`
+> - Ran `git diff --check`
+>
+> </details>
+>
+> 类型检查都过了，空白检查仍只有 CRLF 提示。现在我会把“真实 LLM E2E 入口已添加，但实际外部调用仍需显式环境变量/API key 才能运行”写进交接文档，避免后续 AI 误判状态。
+>
+> <details><summary>Edited 3 files, ran 1 command</summary>
+>
+> - Wrote `./project document/README.md` (+1 -0)
+> - Wrote `./project document/ai-chart-runtime.md` (+2 -1)
+> - Wrote `./project document/handoff-log.md` (+40 -0)
+> - Ran `pnpm exec prettier --write 'project document/README.md' 'project document/ai-chart-runtime.md' 'project document/handoff-log.md'`
+>
+> </details>
+>
+> 文档也更新完了。最后再跑一次空白检查，并抓取本轮关键文件位置，方便你后续查看。
+>
+> <details><summary>Ran 3 commands</summary>
+>
+> - Ran `git diff --check`
+> - Ran `rg -n "real external LLM chart flow|CHATLAB_RUN_REAL_LLM_CHART_E2E|Real LLM E2E Harness|opt-in real external LLM" tests/chart-runtime/real-llm-chart-flow.e2e.test.ts "project document/README.md" "project document/ai-chart-runtime.md" "project document/handoff-log.md"`
+> - Ran `git status --short`
+>
+> </details>
+>
+> 本轮新增文件和文档位置已经确认。工作区仍然有大量未跟踪文件，这是当前 feature 分支整体状态；我没有 stage/commit，也没有碰 unrelated 的 `.dev-home/`、`CLAUDE.md` 等文件。
+>
+> <details><summary>Plan</summary>
+>
+> - [x] 确认 Browser 工具是否可用：tool_search 未暴露 Browser，可用性已记录
+> - [x] 浏览器手工烟测暂无法执行，保留为未验证项
+> - [x] 添加并验证真实外部 LLM E2E 的 opt-in 测试入口
+> - [x] 更新 project document 和最终验证记录
+>
+> </details>
+> </details>
+
+本轮继续推进了两块：
+
+1. 在 [agent-chart-flow.test.ts](./tests/chart-runtime/agent-chart-flow.test.ts:49) 补强了多图表 Agent 流程测试：用户明确要求两张图时，同一轮 Agent 可以发出两个 `render_chart` 调用，并产出 pie + heatmap 两个标准化 chart payload。
+
+2. 新增 [real-llm-chart-flow.e2e.test.ts](./tests/chart-runtime/real-llm-chart-flow.e2e.test.ts:1)：这是默认跳过的真实外部 LLM E2E 入口。设置 `CHATLAB_RUN_REAL_LLM_CHART_E2E=1` 加 API key 后，会创建真实临时 ChatLab SQLite 数据，暴露 `get_schema` / `render_chart`，让真实模型自己生成 SQL + ChartSpec。
+
+交接文档也更新了：[README.md](./project%20document/README.md:41)、[ai-chart-runtime.md](./project%20document/ai-chart-runtime.md:122)、[handoff-log.md](./project%20document/handoff-log.md:413)。
+
+验证已跑：
+
+- `pnpm exec eslint ... --fix`
+- `pnpm exec tsx --conditions=import --test ...`：48 pass，1 skip
+- `pnpm run type-check:node`
+- `pnpm run type-check:web`
+- `git diff --check`：仅 CRLF 提示，无空白错误
+
+还没把总目标标记完成：真实外部 LLM 测试入口已存在，但本轮没有实际打外部 API；in-app Browser 工具也仍未暴露，所以浏览器手工烟测继续保留为未验证项。
+
+<details><summary>1 previous message</summary>
+
+> System error
+>
+> You've hit your usage limit. Upgrade to Pro (https://chatgpt.com/explore/pro), visit https://chatgpt.com/codex/settings/usage to purchase more credits or try again at 1:06 AM.
+> </details>

--- a/project document/handoff-log.md
+++ b/project document/handoff-log.md
@@ -1,0 +1,473 @@
+# Handoff Log
+
+## 2026-06-04 EChart Init Timing Fix
+
+### Completed
+
+- Fixed EChart.vue initialization timing bug: ECharts was reading container width before layout completed, resulting in 92px-wide canvases instead of full-width charts.
+- Changed `onMounted` to defer `initChart()` to `nextTick`, ensuring the container has completed layout before ECharts reads its dimensions.
+- Verified the fix in the browser: all 4 chart canvases (bar, line, pie, heatmap) now render at full 920px width without requiring a resize event.
+- Ran full type-check (web + node), all 26 chart-related tests, and lint/format on modified files — all pass.
+
+### Verified
+
+- `pnpm run type-check:all`
+- `pnpm exec tsx --conditions=import --test` (all 26 chart tests pass)
+- `pnpm exec eslint src/components/charts/EChart.vue --fix`
+- `pnpm exec prettier --write src/components/charts/EChart.vue`
+- Browser smoke: canvas widths are 920px after page load without manual resize
+
+### Still Not Verified
+
+- Real external LLM API E2E execution remains pending: run the harness with `CHATLAB_RUN_REAL_LLM_CHART_E2E=1` and a live API key.
+- Full in-app Electron UI smoke test with real chat data.
+
+## 2026-06-03
+
+### Completed
+
+- Updated local `main` to latest upstream main and created branch `codex/new-feature`.
+- Read the original chart plan in `newPlan.md`.
+- Re-evaluated that plan against the current refactored codebase.
+- Confirmed that the old `chartHint` path no longer exists in current main:
+  - `packages/tools/src/types.ts` has no `chartHint` in `ToolResult`.
+  - tool adapters currently return text-oriented results.
+  - AI `ContentBlock` types do not include `chart`.
+  - `ChatMessage.vue` does not render chart blocks.
+- Clarified the desired product behavior:
+  - charts must be flexible, not fixed reports
+  - x/y/value/series meanings must follow user intent
+  - users should activate the chart assistant with `/` per conversation turn
+  - charts should embed naturally inside AI output text
+  - chart count should follow the user's request
+  - first version should prioritize a dynamic chart loop, not fixed templates
+- Produced a concise implementation plan for a slash-activated dynamic chart runtime.
+- Created this `project document/` handoff folder.
+
+## 2026-06-03 First Implementation Slice
+
+### Completed
+
+- Added shared chart runtime types and validation in `packages/core/src/chart/`.
+- Added row-to-chart normalization for `bar`, `line`, `pie`, and `heatmap`.
+- Added core tests for pie aggregation, multi-series line charts, heatmaps, and missing field validation.
+- Added a synthetic chart capability in `packages/core/src/ai/chart-capability.ts`.
+- Added `get_schema` as a shared core tool and `render_chart` as a shared analysis tool.
+- Registered `render_chart` in shared tools, Electron tools, and CLI Web tools.
+- Updated Electron and CLI Web tool adapters so structured chart payloads survive tool result transport.
+- Added `chart` content blocks to node-runtime and frontend AI chat types.
+- Updated AI chat stream handling so successful `render_chart` calls append chart blocks instead of normal tool capsules.
+- Added `ChartBlockRenderer.vue` and wired it into `ChatMessage.vue`.
+- Extended `EChartLine.vue` to render optional multi-series line chart payloads.
+- Added slash menu support through a synthetic per-message chart capability.
+- Added i18n entries for `get_schema` and `render_chart` in frontend and node-runtime locales.
+
+### Verified
+
+- `pnpm exec prettier --write` on modified code, i18n, and project document files.
+- `pnpm exec tsx --test packages/core/src/chart/index.test.ts`
+- `pnpm run type-check:node`
+- `pnpm run type-check:web`
+- `pnpm exec eslint ... --fix` on modified code files.
+- `git diff --check`
+
+### Not Verified
+
+- In-app browser UI smoke test was not run because the Browser tool was not exposed in this thread after tool discovery.
+- End-to-end AI call with real chat data is still pending.
+- Long-term historical replay should be confirmed after deciding whether current JSON content block persistence is enough.
+
+### Next Recommended Step
+
+Start with targeted hardening:
+
+```text
+adapter regression tests + frontend chart block tests + manual in-app browser smoke test
+```
+
+Then test an end-to-end real prompt that asks for multiple charts and confirms that chart count, x/y/series meanings, and inline placement match the user's natural-language request.
+
+### Important Product Decisions
+
+- Activation model: slash menu, single message only.
+- MVP depth: dynamic SQL + ChartSpec loop.
+- AI proactive charts: allowed but conservative; at most one chart unless the user asks for more.
+- Chart presentation: show only the chart by default, not the tool capsule.
+- Persistence: save normalized render data for stable historical replay.
+
+## 2026-06-03 Hardening Slice
+
+### Completed
+
+- Tightened `render_chart` SQL normalization so direct non-`SELECT` / non-`WITH` statements are rejected before calling `dataProvider.executeParameterizedSql`.
+- Added `packages/tools/src/definitions/render-chart.test.ts`.
+- Added `apps/cli/src/ai/tool-adapter.test.ts` to verify chart payload preservation in CLI Web agent tool result details.
+- Extended `packages/node-runtime/src/ai/__tests__/conversations.test.ts` with chart content block persistence/reload coverage.
+- Confirmed chart history replay can use existing `ai_message.content_blocks` JSON storage; no explicit migration is currently required.
+
+### Verified
+
+- `pnpm exec prettier --write packages/tools/src/definitions/render-chart.ts packages/tools/src/definitions/render-chart.test.ts packages/node-runtime/src/ai/__tests__/conversations.test.ts apps/cli/src/ai/tool-adapter.test.ts`
+- `pnpm exec eslint packages/tools/src/definitions/render-chart.ts packages/tools/src/definitions/render-chart.test.ts packages/node-runtime/src/ai/__tests__/conversations.test.ts apps/cli/src/ai/tool-adapter.test.ts --fix`
+- `pnpm run type-check:node`
+- `pnpm run type-check:web`
+- `pnpm exec tsx --test packages/core/src/chart/index.test.ts packages/tools/src/definitions/render-chart.test.ts apps/cli/src/ai/tool-adapter.test.ts`
+- `CHATLAB_TEST_SQLITE_NATIVE_BINDING=apps/cli/native/better_sqlite3.node pnpm exec tsx --test packages/node-runtime/src/ai/__tests__/conversations.test.ts`
+
+### Verification Note
+
+- Running the conversation test without `CHATLAB_TEST_SQLITE_NATIVE_BINDING` fails on this machine because the pnpm `better-sqlite3` native module was compiled for `NODE_MODULE_VERSION 133`, while current Node `v24.15.0` requires `NODE_MODULE_VERSION 137`.
+- `apps/cli/native/better_sqlite3.node` loads successfully with current Node and was used for the passing persistence test.
+
+### Still Not Verified
+
+- In-app browser UI smoke test is still pending because the Browser tool was not exposed in this thread.
+- End-to-end AI chart generation against real chat data is still pending.
+
+## 2026-06-03 Frontend Verification Slice
+
+### Completed
+
+- Extracted chart-result parsing helpers into `src/stores/aiChatChartBlocks.ts`.
+- Added `src/stores/aiChatChartBlocks.test.ts` for frontend chart payload extraction and chart content block conversion.
+- Updated `src/stores/aiChat.ts` to use the shared helper functions.
+- Updated `ChartBlockRenderer.vue` to import only `EChartBar`, `EChartLine`, `EChartPie`, and `EChartHeatmap` directly instead of importing from the full charts barrel.
+- Added `tests/chart-smoke/`, a repeatable Vite smoke-build harness that mounts `ChartBlockRenderer` with bar, line, pie, and heatmap payloads.
+
+### Verified
+
+- `pnpm exec prettier --write src/stores/aiChat.ts src/stores/aiChatChartBlocks.ts src/stores/aiChatChartBlocks.test.ts src/components/AIChat/chat/ChartBlockRenderer.vue tests/chart-smoke/index.html tests/chart-smoke/src/main.ts tests/chart-smoke/src/style.css tests/chart-smoke/vite.config.mts`
+- `pnpm exec eslint src/stores/aiChat.ts src/stores/aiChatChartBlocks.ts src/stores/aiChatChartBlocks.test.ts src/components/AIChat/chat/ChartBlockRenderer.vue tests/chart-smoke/src/main.ts tests/chart-smoke/vite.config.mts --fix`
+- `pnpm exec tsx --test src/stores/aiChatChartBlocks.test.ts`
+- `pnpm exec vite build --config tests/chart-smoke/vite.config.mts`
+- `pnpm run type-check:web`
+- `pnpm run type-check:node`
+- `pnpm exec vite build --config vite.web.config.mts --outDir tmp/web-build-smoke`
+- `pnpm exec tsx --test packages/core/src/chart/index.test.ts packages/tools/src/definitions/render-chart.test.ts apps/cli/src/ai/tool-adapter.test.ts src/stores/aiChatChartBlocks.test.ts`
+- `CHATLAB_TEST_SQLITE_NATIVE_BINDING=apps/cli/native/better_sqlite3.node pnpm exec tsx --test packages/node-runtime/src/ai/__tests__/conversations.test.ts`
+- `git diff --check`
+
+### Verification Note
+
+- A browser-backed Playwright smoke test could not run in this thread:
+  - the in-app Browser tool was not exposed
+  - shell runtime `playwright` is missing `playwright-core`
+  - Node REPL MCP could not import `playwright`
+- `tests/chart-smoke` remains available for future browser-backed verification when a browser tool is available.
+
+### Still Not Verified
+
+- Browser-backed canvas pixel smoke test for `tests/chart-smoke`; later covered by the headless Microsoft Edge smoke slice below.
+- End-to-end AI chart generation against real chat data.
+
+## 2026-06-03 Headless Browser Smoke Slice
+
+### Completed
+
+- Used local Microsoft Edge headless mode to open the `tests/chart-smoke` Vite harness.
+- Captured a 1024 x 1600 screenshot of the rendered chart smoke page.
+- Visually inspected the screenshot and confirmed visible bar, line, pie, and heatmap chart output.
+- Ran Pillow-based pixel analysis over the screenshot to confirm nonblank rendered chart regions.
+- Stopped the temporary Vite process and removed generated screenshot/log artifacts after verification.
+
+### Verified
+
+- Temporary server command:
+
+```text
+pnpm exec vite --config tests/chart-smoke/vite.config.mts --host 127.0.0.1 --port 4174 --strictPort
+```
+
+- Headless browser command:
+
+```text
+"C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe" --headless=new --disable-gpu --no-first-run --disable-extensions --hide-scrollbars --window-size=1024,1600 --virtual-time-budget=5000 --screenshot=tmp/chart-smoke-edge.png http://127.0.0.1:4174/
+```
+
+- Pixel analysis result:
+
+```text
+SMOKE_OK size=1024x1600 non_bg=73423 very_dark=934 colored=39133 bands=[5382, 33748, 4354, 29939]
+```
+
+### Still Not Verified
+
+- In-app Browser manual smoke test remains pending because the Browser tool is still not exposed in this thread.
+- End-to-end AI chart generation against real chat data is still pending.
+
+## 2026-06-03 Real SQLite Chart Runtime Slice
+
+### Completed
+
+- Added `tests/chart-runtime/render-chart.integration.test.ts`.
+- The test creates a temporary ChatLab SQLite database using `CHAT_DB_SCHEMA`.
+- Seed data includes real `member` and `message` rows for Alice, Bob, and Cara across multiple days/hours/message types.
+- The test executes `render_chart` through `CoreDataProvider` and real parameterized readonly SQL.
+- Verified flexible chart semantics over real chat tables:
+  - selected-member pie chart for Alice/Bob only
+  - multi-series line chart by day and member
+  - heatmap with custom x/y/value meanings (`hour`, `member_name`, `message_count`)
+
+### Verified
+
+- `pnpm exec prettier --write tests/chart-runtime/render-chart.integration.test.ts`
+- `pnpm exec eslint tests/chart-runtime/render-chart.integration.test.ts --fix`
+- `pnpm exec tsx --test tests/chart-runtime/render-chart.integration.test.ts`
+- `pnpm exec tsx --test packages/core/src/chart/index.test.ts packages/tools/src/definitions/render-chart.test.ts tests/chart-runtime/render-chart.integration.test.ts apps/cli/src/ai/tool-adapter.test.ts src/stores/aiChatChartBlocks.test.ts`
+- `CHATLAB_TEST_SQLITE_NATIVE_BINDING=apps/cli/native/better_sqlite3.node pnpm exec tsx --test packages/node-runtime/src/ai/__tests__/conversations.test.ts`
+- `pnpm exec vite build --config tests/chart-smoke/vite.config.mts`
+- `pnpm run type-check:node`
+- `pnpm run type-check:web`
+
+### Verification Note
+
+- The integration test originally failed when importing the full `@openchatlab/node-runtime` package entry because that entry loads unrelated node-runtime AI modules and hit a `pi-ai` package exports issue. The test now imports only `packages/node-runtime/src/better-sqlite3-adapter`, avoiding unrelated side effects.
+
+### Still Not Verified
+
+- Real LLM/AI agent E2E remains pending: no test has yet driven an actual model from a natural-language prompt through tool calling into `render_chart`.
+
+## 2026-06-03 Agent Capability Wiring Slice
+
+### Completed
+
+- Added `getChartCapabilityAllowedBuiltinTools` in `packages/core/src/ai/chart-capability.ts`.
+- Electron and CLI Web agent stream runners now use the shared chart allowlist helper instead of hard-coding `render_chart` locally.
+- CLI Web chart activation now always creates an analysis-tool allowlist containing `render_chart`, even when the assistant did not already define `allowedBuiltinTools`.
+- Added `packages/core/src/ai/chart-capability.test.ts` to verify:
+  - chart capability advertises both `render_chart` and `get_schema`
+  - only `render_chart` needs analysis-tool allowlist injection
+  - duplicate `render_chart` entries are not created
+- Extended `packages/node-runtime/src/ai/agent/__tests__/event-handler.test.ts` to verify chart-bearing `render_chart` tool results pass through stream events unchanged.
+
+### Verified
+
+- `pnpm exec prettier --write packages/core/src/ai/chart-capability.ts packages/core/src/ai/chart-capability.test.ts packages/core/src/ai/index.ts packages/core/src/index.ts apps/desktop/main/ai/agent-stream-runner.ts apps/cli/src/ai/agent-stream-runner.ts packages/node-runtime/src/ai/agent/__tests__/event-handler.test.ts`
+- `pnpm exec eslint packages/core/src/ai/chart-capability.ts packages/core/src/ai/chart-capability.test.ts packages/core/src/ai/index.ts packages/core/src/index.ts apps/desktop/main/ai/agent-stream-runner.ts apps/cli/src/ai/agent-stream-runner.ts packages/node-runtime/src/ai/agent/__tests__/event-handler.test.ts --fix`
+- `pnpm exec tsx --test packages/core/src/ai/chart-capability.test.ts packages/node-runtime/src/ai/agent/__tests__/event-handler.test.ts packages/core/src/chart/index.test.ts packages/tools/src/definitions/render-chart.test.ts apps/cli/src/ai/tool-adapter.test.ts src/stores/aiChatChartBlocks.test.ts tests/chart-runtime/render-chart.integration.test.ts`
+- `pnpm run type-check:node`
+- `pnpm run type-check:web`
+
+### Still Not Verified
+
+- Real LLM/AI agent E2E remains pending: no test has yet driven an actual model from a natural-language prompt through tool calling into `render_chart`.
+- In-app Browser manual smoke remains pending because the Browser tool was not exposed in this thread.
+
+## 2026-06-03 Offline Agent Chart Flow Slice
+
+### Completed
+
+- Added `tests/chart-runtime/agent-chart-flow.test.ts`.
+- The new test injects a fake `streamFn` into the real `runAgentCore` loop instead of calling an external LLM API.
+- The first fake model turn validates the natural-language request and emits a `render_chart` tool call with readonly SQL plus ChartSpec.
+- The real `render_chart` handler runs against a fake `ToolDataProvider`, normalizes returned rows into a multi-series line chart payload, and emits a chart-bearing `tool_end` event.
+- The second fake model turn sees the tool result in context and streams a final natural-language answer.
+- This verifies the Agent loop, tool execution, chart payload propagation, and final answer flow in one offline regression.
+
+### Verified
+
+- `pnpm exec prettier --write tests/chart-runtime/agent-chart-flow.test.ts`
+- `pnpm exec eslint tests/chart-runtime/agent-chart-flow.test.ts --fix`
+- `pnpm exec tsx --conditions=import --test tests/chart-runtime/agent-chart-flow.test.ts`
+- `pnpm exec tsx --conditions=import --test tests/chart-runtime/agent-chart-flow.test.ts packages/core/src/ai/chart-capability.test.ts packages/node-runtime/src/ai/agent/__tests__/event-handler.test.ts packages/core/src/chart/index.test.ts packages/tools/src/definitions/render-chart.test.ts apps/cli/src/ai/tool-adapter.test.ts src/stores/aiChatChartBlocks.test.ts tests/chart-runtime/render-chart.integration.test.ts`
+- `pnpm run type-check:node`
+- `pnpm run type-check:web`
+
+### Verification Note
+
+- The usual `pnpm exec tsx --test tests/chart-runtime/agent-chart-flow.test.ts` fails in this environment with `ERR_PACKAGE_PATH_NOT_EXPORTED` while resolving `@earendil-works/pi-ai` through CommonJS conditions.
+- Running the same test with `--conditions=import` uses the package's ESM export path and passes.
+
+### Still Not Verified
+
+- Real external LLM API E2E remains pending: no test has yet asked an actual model to infer SQL and ChartSpec from natural language over real chat data.
+- In-app Browser manual smoke remains pending because the Browser tool was not exposed in this thread.
+
+## 2026-06-04 Render-Only Chart Failure Visibility Slice
+
+### Completed
+
+- Updated `src/stores/aiChatChartBlocks.ts`.
+- Added `toRenderOnlyToolErrorBlock()` so `render_chart` failures returned as tool text such as `Error: ...` become visible `error` content blocks when no chart payload is present.
+- Updated both `sendMessage` and edited-message stream handling in `src/stores/aiChat.ts`:
+  - successful `render_chart` results still append only chart blocks and no normal tool capsule
+  - failed `render_chart` results now append an error block
+  - current render-only tool status is marked `error` when such a failure is detected
+- Extended `src/stores/aiChatChartBlocks.test.ts` to cover successful chart results, render-only failures, and normal non-render-only tools.
+
+### Verified
+
+- `pnpm exec prettier --write src/stores/aiChat.ts src/stores/aiChatChartBlocks.ts src/stores/aiChatChartBlocks.test.ts`
+- `pnpm exec eslint src/stores/aiChat.ts src/stores/aiChatChartBlocks.ts src/stores/aiChatChartBlocks.test.ts --fix`
+- `pnpm exec tsx --conditions=import --test src/stores/aiChatChartBlocks.test.ts src/stores/skill.test.ts tests/chart-runtime/agent-chart-flow.test.ts packages/core/src/ai/chart-capability.test.ts packages/node-runtime/src/ai/agent/__tests__/event-handler.test.ts packages/core/src/chart/index.test.ts packages/tools/src/definitions/render-chart.test.ts apps/cli/src/ai/tool-adapter.test.ts tests/chart-runtime/render-chart.integration.test.ts`
+- `pnpm run type-check:node`
+- `pnpm run type-check:web`
+
+### Still Not Verified
+
+- Real external LLM API E2E remains pending: no test has yet asked an actual model to infer SQL and ChartSpec from natural language over real chat data.
+- In-app Browser manual smoke remains pending because the Browser tool was not exposed in this thread.
+
+## 2026-06-03 Render Chart SQL Safety Slice
+
+### Completed
+
+- Extended `tests/chart-runtime/render-chart.integration.test.ts`.
+- Added a real SQLite safety regression for a `WITH`-prefixed write attempt:
+  - SQL starts with `WITH`, so it exercises the path that is allowed past `render_chart`'s first-token check.
+  - The statement then attempts `DELETE FROM message`.
+  - ChatLab rejects the statement before any mutation can happen.
+  - The test verifies the `message` row count is unchanged after rejection.
+
+### Verified
+
+- `pnpm exec prettier --write tests/chart-runtime/render-chart.integration.test.ts`
+- `pnpm exec eslint tests/chart-runtime/render-chart.integration.test.ts --fix`
+- `pnpm exec tsx --conditions=import --test tests/chart-runtime/render-chart.integration.test.ts`
+- `pnpm exec tsx --conditions=import --test src/stores/skill.test.ts tests/chart-runtime/agent-chart-flow.test.ts packages/core/src/ai/chart-capability.test.ts packages/node-runtime/src/ai/agent/__tests__/event-handler.test.ts packages/core/src/chart/index.test.ts packages/tools/src/definitions/render-chart.test.ts apps/cli/src/ai/tool-adapter.test.ts src/stores/aiChatChartBlocks.test.ts tests/chart-runtime/render-chart.integration.test.ts`
+- `pnpm run type-check:node`
+- `pnpm run type-check:web`
+
+### Verification Note
+
+- An initial parallel `type-check:node` + `type-check:web` run timed out unexpectedly at the shell/tool layer. No leftover `tsc`/`vue-tsc` process remained. Rerunning the two commands separately passed.
+
+### Still Not Verified
+
+- Real external LLM API E2E remains pending: no test has yet asked an actual model to infer SQL and ChartSpec from natural language over real chat data.
+- In-app Browser manual smoke remains pending because the Browser tool was not exposed in this thread.
+
+## 2026-06-03 Render Chart Row Limit Wrapper Slice
+
+### Completed
+
+- Updated `packages/tools/src/definitions/render-chart.ts`.
+- `render_chart` now wraps every accepted SQL statement in an outer query:
+
+```text
+SELECT * FROM (
+  <model SQL>
+) AS chart_query LIMIT maxRows + 1
+```
+
+- This means ChatLab enforces the fetch cap even when the model writes its own large `LIMIT`.
+- The multi-line wrapper also prevents a trailing `-- comment` in model SQL from swallowing the enforced outer limit.
+- Updated `packages/tools/src/definitions/render-chart.test.ts` expectations for the outer wrapper.
+- Added regressions for:
+  - SQL that already contains `LIMIT 100000`
+  - SQL ending with a trailing line comment
+- Re-ran the real SQLite integration test to confirm selected-member pie, multi-series line, heatmap, and write-attempt rejection still pass with wrapped SQL.
+
+### Verified
+
+- `pnpm exec prettier --write packages/tools/src/definitions/render-chart.ts packages/tools/src/definitions/render-chart.test.ts tests/chart-runtime/render-chart.integration.test.ts`
+- `pnpm exec eslint packages/tools/src/definitions/render-chart.ts packages/tools/src/definitions/render-chart.test.ts tests/chart-runtime/render-chart.integration.test.ts --fix`
+- `pnpm exec tsx --conditions=import --test packages/tools/src/definitions/render-chart.test.ts tests/chart-runtime/render-chart.integration.test.ts`
+- `pnpm exec tsx --conditions=import --test src/stores/skill.test.ts tests/chart-runtime/agent-chart-flow.test.ts packages/core/src/ai/chart-capability.test.ts packages/node-runtime/src/ai/agent/__tests__/event-handler.test.ts packages/core/src/chart/index.test.ts packages/tools/src/definitions/render-chart.test.ts apps/cli/src/ai/tool-adapter.test.ts src/stores/aiChatChartBlocks.test.ts tests/chart-runtime/render-chart.integration.test.ts`
+- `pnpm run type-check:node`
+- `pnpm run type-check:web`
+
+### Still Not Verified
+
+- Real external LLM API E2E remains pending: no test has yet asked an actual model to infer SQL and ChartSpec from natural language over real chat data.
+- In-app Browser manual smoke remains pending because the Browser tool was not exposed in this thread.
+
+## 2026-06-03 Frontend Skill Toggle Regression Slice
+
+### Completed
+
+- Added `src/stores/skill.test.ts`.
+- Verified the synthetic chart capability appears first in `compatibleSkills` without requiring import from the skill marketplace.
+- Verified locale-aware activation metadata for `chart_runtime`.
+- Verified `getSkillConfig(CHART_CAPABILITY_SKILL_ID)` returns the synthetic full config with `render_chart` and `get_schema`.
+- Verified the same store toggle API can clear the active chart capability, matching the single-message activation model used by `AIChatInput.vue` after submit.
+
+### Verified
+
+- `pnpm exec prettier --write src/stores/skill.test.ts`
+- `pnpm exec eslint src/stores/skill.test.ts --fix`
+- `pnpm exec tsx --conditions=import --test src/stores/skill.test.ts`
+- `pnpm exec tsx --conditions=import --test src/stores/skill.test.ts tests/chart-runtime/agent-chart-flow.test.ts packages/core/src/ai/chart-capability.test.ts packages/node-runtime/src/ai/agent/__tests__/event-handler.test.ts packages/core/src/chart/index.test.ts packages/tools/src/definitions/render-chart.test.ts apps/cli/src/ai/tool-adapter.test.ts src/stores/aiChatChartBlocks.test.ts tests/chart-runtime/render-chart.integration.test.ts`
+- `pnpm run type-check:web`
+- `pnpm run type-check:node`
+
+### Still Not Verified
+
+- Real external LLM API E2E remains pending: no test has yet asked an actual model to infer SQL and ChartSpec from natural language over real chat data.
+- In-app Browser manual smoke remains pending because the Browser tool was not exposed in this thread.
+
+## 2026-06-04 Multi-Chart Agent Flow Slice
+
+### Completed
+
+- Updated `tests/chart-runtime/agent-chart-flow.test.ts`.
+- Extended the fake model stream helper so one assistant turn can emit multiple tool calls.
+- Added a regression for a user asking for two charts in one answer:
+  - one pie chart for selected-member message share
+  - one heatmap for selected-member hour density
+- The test drives the real `runAgentCore` loop with a fake stream, then executes the real `render_chart` tool adapter against a fake `ToolDataProvider`.
+- Both chart calls use parameterized readonly CTE SQL plus ChartSpec.
+- Assertions verify two `render_chart` tool results in one tool round, two chart-bearing `tool_end` events, stable pie payload data, stable heatmap payload data, and a final answer that mentions both charts.
+
+### Verified
+
+- `pnpm exec prettier --write tests/chart-runtime/agent-chart-flow.test.ts`
+- `pnpm exec eslint tests/chart-runtime/agent-chart-flow.test.ts --fix`
+- `pnpm exec tsx --conditions=import --test tests/chart-runtime/agent-chart-flow.test.ts`
+- `pnpm exec tsx --conditions=import --test src/stores/aiChatChartBlocks.test.ts src/stores/skill.test.ts tests/chart-runtime/agent-chart-flow.test.ts packages/core/src/ai/chart-capability.test.ts packages/node-runtime/src/ai/agent/__tests__/event-handler.test.ts packages/core/src/chart/index.test.ts packages/tools/src/definitions/render-chart.test.ts apps/cli/src/ai/tool-adapter.test.ts tests/chart-runtime/render-chart.integration.test.ts packages/node-runtime/src/ai/__tests__/conversations.test.ts`
+- `pnpm run type-check:node`
+- `pnpm run type-check:web`
+- `git diff --check`
+
+### Verification Note
+
+- The first full related regression run failed only in `packages/node-runtime/src/ai/__tests__/conversations.test.ts` because the local `better-sqlite3.node` binary was built for `NODE_MODULE_VERSION 133` while the project Node 24 test runtime requires `NODE_MODULE_VERSION 137`.
+- `pnpm rebuild better-sqlite3` returned success but did not replace the stale binary.
+- Direct `node-gyp` rebuild failed because Visual Studio C++ build tools are not installed on this machine.
+- Running `prebuild-install` in the `better-sqlite3` package directory installed the cached Node 24 / win32-x64 prebuild, after which conversation tests and the full related regression group passed.
+- `git diff --check` reported only existing CRLF normalization warnings and no whitespace errors.
+
+### Still Not Verified
+
+- Real external LLM API E2E remains pending: no test has yet asked an actual model to infer SQL and ChartSpec from natural language over real chat data.
+- In-app Browser manual smoke remains pending because the Browser tool was not exposed in this thread.
+
+## 2026-06-04 Real LLM E2E Harness Slice
+
+### Completed
+
+- Added `tests/chart-runtime/real-llm-chart-flow.e2e.test.ts`.
+- The test is opt-in and skipped unless `CHATLAB_RUN_REAL_LLM_CHART_E2E=1` is set.
+- When enabled, it requires `CHATLAB_REAL_LLM_API_KEY` or `OPENAI_API_KEY`.
+- Optional provider/model overrides:
+  - `CHATLAB_REAL_LLM_PROVIDER`
+  - `CHATLAB_REAL_LLM_MODEL`
+  - `CHATLAB_REAL_LLM_BASE_URL`
+- Default provider/model are `openai` and `gpt-4.1-mini`.
+- The harness creates a temporary real ChatLab SQLite database with `CHAT_DB_SCHEMA` and seeded Alice/Bob/Cara chat data.
+- It exposes real `get_schema` and `render_chart` tools through the real `runAgentCore` loop.
+- The user prompt asks the model for exactly two charts:
+  - selected-member pie chart for Alice/Bob message share
+  - selected-member heatmap by hour and member
+- Assertions verify two chart payloads, pie labels and total, heatmap exclusion of Cara, heatmap x/y semantics, and final explanatory content.
+
+### Verified
+
+- `pnpm exec prettier --write tests/chart-runtime/real-llm-chart-flow.e2e.test.ts`
+- `pnpm exec eslint tests/chart-runtime/real-llm-chart-flow.e2e.test.ts --fix`
+- `pnpm exec tsx --conditions=import --test tests/chart-runtime/real-llm-chart-flow.e2e.test.ts`
+- `pnpm exec tsx --conditions=import --test src/stores/aiChatChartBlocks.test.ts src/stores/skill.test.ts tests/chart-runtime/agent-chart-flow.test.ts tests/chart-runtime/real-llm-chart-flow.e2e.test.ts packages/core/src/ai/chart-capability.test.ts packages/node-runtime/src/ai/agent/__tests__/event-handler.test.ts packages/core/src/chart/index.test.ts packages/tools/src/definitions/render-chart.test.ts apps/cli/src/ai/tool-adapter.test.ts tests/chart-runtime/render-chart.integration.test.ts packages/node-runtime/src/ai/__tests__/conversations.test.ts`
+- `pnpm run type-check:node`
+- `pnpm run type-check:web`
+- `git diff --check`
+
+### Verification Note
+
+- The real external LLM test was run only in its default skipped mode. The harness compiled and was included in the related regression group, but no external provider call was made because the opt-in environment flag was not set.
+- `tool_search` still did not expose the in-app Browser tool in this thread, so manual Browser smoke remains unverified.
+- `git diff --check` reported only existing CRLF normalization warnings and no whitespace errors.
+
+### Still Not Verified
+
+- Real external LLM API E2E execution remains pending: run the harness with `CHATLAB_RUN_REAL_LLM_CHART_E2E=1` and a live API key to prove actual model SQL/ChartSpec generation quality.
+- In-app Browser manual smoke remains pending because the Browser tool was not exposed in this thread.

--- a/src/components/AIChat/chat/ChartBlockRenderer.vue
+++ b/src/components/AIChat/chat/ChartBlockRenderer.vue
@@ -1,0 +1,79 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import type {
+  BarChartRenderData,
+  ChartPayload,
+  HeatmapChartRenderData,
+  LineChartRenderData,
+  PieChartRenderData,
+} from '@openchatlab/core'
+import EChartBar from '@/components/charts/EChartBar.vue'
+import EChartHeatmap from '@/components/charts/EChartHeatmap.vue'
+import EChartLine from '@/components/charts/EChartLine.vue'
+import EChartPie from '@/components/charts/EChartPie.vue'
+
+const props = defineProps<{
+  chart: ChartPayload
+}>()
+
+const title = computed(() => props.chart.spec.title)
+const subtitle = computed(() => props.chart.spec.subtitle || props.chart.spec.description || '')
+const height = computed(() => props.chart.spec.display?.height ?? (props.chart.spec.type === 'heatmap' ? 300 : 260))
+const isEmpty = computed(() => props.chart.rowCount === 0)
+
+const summary = computed(() => {
+  const parts: string[] = []
+  if (props.chart.spec.unit) parts.push(props.chart.spec.unit)
+  if (props.chart.truncated) parts.push('truncated')
+  parts.push(`${props.chart.rowCount} rows`)
+  return parts.join(' · ')
+})
+
+const barData = computed(() => props.chart.data as BarChartRenderData)
+const lineData = computed(() => props.chart.data as LineChartRenderData)
+const pieData = computed(() => props.chart.data as PieChartRenderData)
+const heatmapData = computed(() => props.chart.data as HeatmapChartRenderData)
+</script>
+
+<template>
+  <div
+    class="my-2 w-full overflow-hidden rounded-lg border border-gray-200 bg-white/80 shadow-sm dark:border-gray-700/70 dark:bg-gray-900/70"
+  >
+    <div class="border-b border-gray-100 px-3 py-2 dark:border-gray-800">
+      <div class="flex min-w-0 items-start justify-between gap-3">
+        <div class="min-w-0">
+          <h3 class="truncate text-sm font-semibold text-gray-900 dark:text-gray-100">{{ title }}</h3>
+          <p v-if="subtitle" class="mt-0.5 line-clamp-2 text-xs text-gray-500 dark:text-gray-400">
+            {{ subtitle }}
+          </p>
+        </div>
+        <span
+          class="shrink-0 rounded-md bg-gray-100 px-1.5 py-0.5 text-[10px] uppercase text-gray-500 dark:bg-gray-800"
+        >
+          {{ chart.spec.type }}
+        </span>
+      </div>
+      <p class="mt-1 text-[11px] text-gray-400 dark:text-gray-500">{{ summary }}</p>
+    </div>
+
+    <div class="px-2 py-3">
+      <div v-if="isEmpty" class="flex h-32 items-center justify-center text-xs text-gray-400 dark:text-gray-500">
+        No data
+      </div>
+      <EChartBar
+        v-else-if="chart.spec.type === 'bar'"
+        :data="barData"
+        :height="height"
+        :horizontal="chart.spec.display?.horizontal"
+      />
+      <EChartLine v-else-if="chart.spec.type === 'line'" :data="lineData" :height="height" />
+      <EChartPie
+        v-else-if="chart.spec.type === 'pie'"
+        :data="pieData"
+        :height="height"
+        :show-legend="chart.spec.display?.showLegend ?? true"
+      />
+      <EChartHeatmap v-else-if="chart.spec.type === 'heatmap'" :data="heatmapData" :height="height" />
+    </div>
+  </div>
+</template>

--- a/src/components/AIChat/chat/ChatMessage.vue
+++ b/src/components/AIChat/chat/ChatMessage.vue
@@ -6,6 +6,7 @@ import MarkdownIt from 'markdown-it'
 import type { ContentBlock, ToolBlockContent } from '@/composables/useAIChat'
 import CaptureButton from '@/components/common/CaptureButton.vue'
 import ErrorBlock from './ErrorBlock.vue'
+import ChartBlockRenderer from './ChartBlockRenderer.vue'
 import { useToast } from '@/composables/useToast'
 
 const { t, te, locale } = useI18n()
@@ -330,6 +331,10 @@ const copyMarkdownText = computed(() => {
         return `> ${t('ai.skill.active.label', { name: block.skillName })}`
       }
 
+      if (block.type === 'chart') {
+        return `> Chart: ${block.chart.spec.title}`
+      }
+
       if (block.type === 'tool') {
         const toolName = getToolDisplayName(block.tool)
         const toolParams = formatToolParams(block.tool)
@@ -483,6 +488,9 @@ async function handleCopyMarkdown() {
               <UIcon name="i-heroicons-bolt" class="h-3.5 w-3.5" />
               <span>{{ t('ai.skill.active.label', { name: block.skillName }) }}</span>
             </div>
+
+            <!-- 图表块 -->
+            <ChartBlockRenderer v-else-if="block.type === 'chart'" :chart="block.chart" />
 
             <!-- 工具块 -->
             <div

--- a/src/components/charts/EChart.vue
+++ b/src/components/charts/EChart.vue
@@ -3,7 +3,7 @@
  * ECharts 基础封装组件
  * 提供自动响应式、主题适配、加载状态等通用功能
  */
-import { ref, onMounted, onUnmounted, watch, computed } from 'vue'
+import { ref, onMounted, onUnmounted, watch, computed, nextTick } from 'vue'
 import * as echarts from 'echarts/core'
 import { CanvasRenderer } from 'echarts/renderers'
 import { PieChart, BarChart, LineChart, HeatmapChart } from 'echarts/charts'
@@ -129,7 +129,10 @@ watch(
 let observer: MutationObserver | null = null
 
 onMounted(() => {
-  initChart()
+  // Defer init to next tick so the container has completed layout before ECharts reads its width
+  nextTick(() => {
+    initChart()
+  })
   window.addEventListener('resize', handleResize)
 
   // 监听 HTML 元素的 class 变化（用于检测暗色模式切换）

--- a/src/components/charts/EChartLine.vue
+++ b/src/components/charts/EChartLine.vue
@@ -9,6 +9,7 @@ import EChart from './EChart.vue'
 export interface EChartLineData {
   labels: string[]
   values: number[]
+  series?: Array<{ name: string; values: number[] }>
 }
 
 interface Props {
@@ -27,6 +28,65 @@ const props = withDefaults(defineProps<Props>(), {
 })
 
 const option = computed<EChartsOption>(() => {
+  const hasSeries = !!props.data.series?.length
+  const series = hasSeries
+    ? props.data.series!.map((item) => ({
+        name: item.name,
+        type: 'line' as const,
+        data: item.values,
+        smooth: props.smooth,
+        symbol: 'circle',
+        symbolSize: 4,
+        showSymbol: false,
+        lineStyle: {
+          width: 2,
+        },
+        areaStyle: props.showArea ? { opacity: 0.08 } : undefined,
+        emphasis: {
+          focus: 'series' as const,
+        },
+      }))
+    : [
+        {
+          type: 'line' as const,
+          data: props.data.values,
+          smooth: props.smooth,
+          symbol: 'circle',
+          symbolSize: 4,
+          showSymbol: false,
+          lineStyle: {
+            width: 2,
+            color: '#ee4567',
+          },
+          itemStyle: {
+            color: '#ee4567',
+          },
+          areaStyle: props.showArea
+            ? {
+                color: {
+                  type: 'linear' as const,
+                  x: 0,
+                  y: 0,
+                  x2: 0,
+                  y2: 1,
+                  colorStops: [
+                    { offset: 0, color: 'rgba(238, 69, 103, 0.3)' },
+                    { offset: 1, color: 'rgba(238, 69, 103, 0.05)' },
+                  ],
+                },
+              }
+            : undefined,
+          emphasis: {
+            focus: 'series' as const,
+            itemStyle: {
+              color: '#ee4567',
+              borderColor: '#fff',
+              borderWidth: 2,
+            },
+          },
+        },
+      ]
+
   return {
     tooltip: {
       trigger: 'axis',
@@ -39,9 +99,15 @@ const option = computed<EChartsOption>(() => {
     grid: {
       left: 50,
       right: 20,
-      top: 20,
+      top: hasSeries ? 36 : 20,
       bottom: 30,
     },
+    legend: hasSeries
+      ? {
+          top: 0,
+          textStyle: { color: '#6b7280', fontSize: 11 },
+        }
+      : undefined,
     xAxis: {
       type: 'category',
       data: props.data.labels,
@@ -66,46 +132,7 @@ const option = computed<EChartsOption>(() => {
         },
       },
     },
-    series: [
-      {
-        type: 'line',
-        data: props.data.values,
-        smooth: props.smooth,
-        symbol: 'circle',
-        symbolSize: 4,
-        showSymbol: false,
-        lineStyle: {
-          width: 2,
-          color: '#ee4567', // 项目主题 pink-500
-        },
-        itemStyle: {
-          color: '#ee4567',
-        },
-        areaStyle: props.showArea
-          ? {
-              color: {
-                type: 'linear',
-                x: 0,
-                y: 0,
-                x2: 0,
-                y2: 1,
-                colorStops: [
-                  { offset: 0, color: 'rgba(238, 69, 103, 0.3)' }, // 项目主题粉色
-                  { offset: 1, color: 'rgba(238, 69, 103, 0.05)' },
-                ],
-              },
-            }
-          : undefined,
-        emphasis: {
-          focus: 'series',
-          itemStyle: {
-            color: '#ee4567',
-            borderColor: '#fff',
-            borderWidth: 2,
-          },
-        },
-      },
-    ],
+    series,
   }
 })
 </script>

--- a/src/i18n/locales/en-US/ai.json
+++ b/src/i18n/locales/en-US/ai.json
@@ -76,6 +76,7 @@
         "get_member_name_history": "Get Nickname History",
         "get_conversation_between": "Get Conversation",
         "get_message_context": "Get Message Context",
+        "get_schema": "Inspect Schema",
         "search_sessions": "Search Sessions",
         "get_session_messages": "Get Session Messages",
         "get_session_summaries": "Get Session Summaries",
@@ -91,7 +92,8 @@
         "daily_active_members": "Daily Active Members",
         "conversation_initiator_stats": "Conversation Initiators",
         "activity_heatmap": "Activity Heatmap",
-        "unanswered_messages": "Unanswered Messages"
+        "unanswered_messages": "Unanswered Messages",
+        "render_chart": "Generate Chart"
       },
       "generating": "Generating response...",
       "summary": {
@@ -414,6 +416,7 @@
       "get_message_context": "Get message context",
       "get_conversation_between": "Get conversation between two members",
       "get_members": "Get members",
+      "get_schema": "Inspect database schema",
       "get_member_stats": "Get member statistics",
       "get_member_name_history": "Get member name history",
       "get_time_stats": "Get time statistics",
@@ -432,7 +435,8 @@
       "conversation_initiator_stats": "Conversation initiators",
       "activity_heatmap": "Activity heatmap",
       "response_time_analysis": "Response time analysis",
-      "keyword_frequency": "Keyword frequency"
+      "keyword_frequency": "Keyword frequency",
+      "render_chart": "Generate dynamic chart"
     }
   },
   "skill": {

--- a/src/i18n/locales/ja-JP/ai.json
+++ b/src/i18n/locales/ja-JP/ai.json
@@ -76,6 +76,7 @@
         "get_member_name_history": "ニックネーム履歴を取得",
         "get_conversation_between": "やり取り履歴を取得",
         "get_message_context": "コンテキストを取得",
+        "get_schema": "スキーマ確認",
         "search_sessions": "セッションを検索",
         "get_session_messages": "セッションメッセージを取得",
         "get_session_summaries": "セッション要約を取得",
@@ -91,7 +92,8 @@
         "daily_active_members": "日別アクティブ人数",
         "conversation_initiator_stats": "話題開始者統計",
         "activity_heatmap": "活動ヒートマップ",
-        "unanswered_messages": "未返信メッセージ"
+        "unanswered_messages": "未返信メッセージ",
+        "render_chart": "チャート生成"
       },
       "generating": "回答を作成中...",
       "summary": {
@@ -414,6 +416,7 @@
       "get_message_context": "メッセージのコンテキストを取得",
       "get_conversation_between": "2人のやり取りを取得",
       "get_members": "メンバー一覧を取得",
+      "get_schema": "データベーススキーマを確認",
       "get_member_stats": "メンバー統計を取得",
       "get_member_name_history": "メンバーの名前変更履歴を取得",
       "get_time_stats": "時間統計を取得",
@@ -432,7 +435,8 @@
       "conversation_initiator_stats": "話題開始者統計",
       "activity_heatmap": "活性度ヒートマップ",
       "response_time_analysis": "応答時間分析",
-      "keyword_frequency": "高頻度キーワード統計"
+      "keyword_frequency": "高頻度キーワード統計",
+      "render_chart": "動的チャート生成"
     }
   },
   "skill": {

--- a/src/i18n/locales/zh-CN/ai.json
+++ b/src/i18n/locales/zh-CN/ai.json
@@ -76,6 +76,7 @@
         "get_member_name_history": "获取昵称历史",
         "get_conversation_between": "获取对话记录",
         "get_message_context": "获取上下文",
+        "get_schema": "查看表结构",
         "search_sessions": "搜索会话",
         "get_session_messages": "获取会话消息",
         "get_session_summaries": "获取会话摘要",
@@ -91,7 +92,8 @@
         "daily_active_members": "每日活跃人数",
         "conversation_initiator_stats": "话题发起者统计",
         "activity_heatmap": "活跃度热力图",
-        "unanswered_messages": "未回复消息"
+        "unanswered_messages": "未回复消息",
+        "render_chart": "生成图表"
       },
       "generating": "正在生成回复...",
       "summary": {
@@ -414,6 +416,7 @@
       "get_message_context": "获取消息上下文",
       "get_conversation_between": "获取两人对话",
       "get_members": "获取成员列表",
+      "get_schema": "查看数据表结构",
       "get_member_stats": "获取成员统计",
       "get_member_name_history": "获取成员改名历史",
       "get_time_stats": "获取时间统计",
@@ -432,7 +435,8 @@
       "conversation_initiator_stats": "话题发起者统计",
       "activity_heatmap": "活跃度热力图",
       "response_time_analysis": "响应时间分析",
-      "keyword_frequency": "高频词统计"
+      "keyword_frequency": "高频词统计",
+      "render_chart": "生成动态图表"
     }
   },
   "skill": {

--- a/src/i18n/locales/zh-TW/ai.json
+++ b/src/i18n/locales/zh-TW/ai.json
@@ -76,6 +76,7 @@
         "get_member_name_history": "取得暱稱歷史",
         "get_conversation_between": "取得對話紀錄",
         "get_message_context": "取得上下文",
+        "get_schema": "查看表結構",
         "search_sessions": "搜尋會話",
         "get_session_messages": "取得會話訊息",
         "get_session_summaries": "取得會話摘要",
@@ -91,7 +92,8 @@
         "daily_active_members": "每日活躍人數",
         "conversation_initiator_stats": "話題發起者統計",
         "activity_heatmap": "活躍度熱力圖",
-        "unanswered_messages": "未回覆訊息"
+        "unanswered_messages": "未回覆訊息",
+        "render_chart": "生成圖表"
       },
       "generating": "正在產生回覆...",
       "summary": {
@@ -414,6 +416,7 @@
       "get_message_context": "取得訊息上下文",
       "get_conversation_between": "取得兩人對話",
       "get_members": "取得成員列表",
+      "get_schema": "查看資料表結構",
       "get_member_stats": "取得成員統計",
       "get_member_name_history": "取得成員改名歷史",
       "get_time_stats": "取得時間統計",
@@ -432,7 +435,8 @@
       "conversation_initiator_stats": "話題發起者統計",
       "activity_heatmap": "活躍度熱力圖",
       "response_time_analysis": "回應時間分析",
-      "keyword_frequency": "高頻詞統計"
+      "keyword_frequency": "高頻詞統計",
+      "render_chart": "生成動態圖表"
     }
   },
   "skill": {

--- a/src/services/ai/types.ts
+++ b/src/services/ai/types.ts
@@ -1,4 +1,5 @@
 import type { TimeFilter } from '@/types/base'
+import type { ChartPayload } from '@openchatlab/core'
 
 export interface AIConversation {
   id: string
@@ -13,6 +14,7 @@ export interface AIConversation {
 export type ContentBlock =
   | { type: 'text'; text: string }
   | { type: 'think'; tag: string; text: string; durationMs?: number }
+  | { type: 'chart'; chart: ChartPayload }
   | {
       type: 'tool'
       tool: {

--- a/src/stores/aiChat.ts
+++ b/src/stores/aiChat.ts
@@ -17,6 +17,13 @@ import { useSkillStore } from '@/stores/skill'
 import { useLLMStore } from '@/stores/llm'
 import type { TokenUsage, AgentRuntimeStatus, SerializedErrorInfo } from '@electron/shared/types'
 import { useAgentStreamService } from '@/services/ai-stream/service'
+import type { ChartPayload } from '@openchatlab/core'
+import {
+  extractChartPayloads,
+  isRenderOnlyTool,
+  toChartContentBlocks,
+  toRenderOnlyToolErrorBlock,
+} from './aiChatChartBlocks'
 
 // 工具调用记录
 export interface ToolCallRecord {
@@ -48,6 +55,7 @@ export interface MentionedMemberContext {
 export type ContentBlock =
   | { type: 'text'; text: string }
   | { type: 'think'; tag: string; text: string; durationMs?: number }
+  | { type: 'chart'; chart: ChartPayload }
   | {
       type: 'tool'
       tool: ToolBlockContent
@@ -595,6 +603,8 @@ export const useAIChatStore = defineStore('aiChatRuntime', () => {
     updateAIMessage: (updates: Partial<ChatMessage>) => void
     appendTextToBlocks: (text: string) => void
     appendThinkToBlocks: (text: string, tag?: string, durationMs?: number) => void
+    appendChartsToBlocks: (charts: ChartPayload[]) => void
+    appendErrorToBlocks: (error: SerializedErrorInfo) => void
     addToolBlock: (toolName: string, params?: Record<string, unknown>) => void
     updateToolBlockStatus: (toolName: string, status: 'done' | 'error') => void
   }
@@ -649,6 +659,21 @@ export const useAIChatStore = defineStore('aiChatRuntime', () => {
       updateAIMessage({ contentBlocks: [...blocks] })
     }
 
+    const appendChartsToBlocks = (charts: ChartPayload[]) => {
+      if (charts.length === 0) return
+      const idx = getAiMessageIndex()
+      const blocks = targetBuffer.messages[idx].contentBlocks || []
+      blocks.push(...toChartContentBlocks(charts))
+      updateAIMessage({ contentBlocks: [...blocks] })
+    }
+
+    const appendErrorToBlocks = (error: SerializedErrorInfo) => {
+      const idx = getAiMessageIndex()
+      const blocks = targetBuffer.messages[idx].contentBlocks || []
+      blocks.push({ type: 'error', error })
+      updateAIMessage({ contentBlocks: [...blocks] })
+    }
+
     const addToolBlock = (toolName: string, params?: Record<string, unknown>) => {
       const idx = getAiMessageIndex()
       const blocks = targetBuffer.messages[idx].contentBlocks || []
@@ -669,7 +694,15 @@ export const useAIChatStore = defineStore('aiChatRuntime', () => {
       updateAIMessage({ contentBlocks: [...blocks] })
     }
 
-    return { updateAIMessage, appendTextToBlocks, appendThinkToBlocks, addToolBlock, updateToolBlockStatus }
+    return {
+      updateAIMessage,
+      appendTextToBlocks,
+      appendThinkToBlocks,
+      appendChartsToBlocks,
+      appendErrorToBlocks,
+      addToolBlock,
+      updateToolBlockStatus,
+    }
   }
 
   async function sendMessage(
@@ -777,8 +810,15 @@ export const useAIChatStore = defineStore('aiChatRuntime', () => {
       let aiMessageIndex = targetBuffer.messages.length - 1
       let hasStreamError = false
 
-      const { updateAIMessage, appendTextToBlocks, appendThinkToBlocks, addToolBlock, updateToolBlockStatus } =
-        createStreamBlockHelpers(targetBuffer, () => aiMessageIndex)
+      const {
+        updateAIMessage,
+        appendTextToBlocks,
+        appendThinkToBlocks,
+        appendChartsToBlocks,
+        appendErrorToBlocks,
+        addToolBlock,
+        updateToolBlockStatus,
+      } = createStreamBlockHelpers(targetBuffer, () => aiMessageIndex)
 
       const currentAssistantId = targetBuffer.assistantId ?? getDefaultGeneralAssistantId(state.locale)
       if (!resolvedConversationId) {
@@ -873,19 +913,29 @@ export const useAIChatStore = defineStore('aiChatRuntime', () => {
                   status: 'running',
                 }
                 state.toolsUsedInCurrentRound.push(chunk.toolName)
-                addToolBlock(chunk.toolName, toolParams)
+                if (!isRenderOnlyTool(chunk.toolName)) {
+                  addToolBlock(chunk.toolName, toolParams)
+                }
               }
               break
 
             case 'tool_result':
               if (chunk.toolName) {
+                const charts = extractChartPayloads(chunk.toolResult)
+                appendChartsToBlocks(charts)
+                const renderOnlyError = toRenderOnlyToolErrorBlock(chunk.toolName, chunk.toolResult)
+                if (renderOnlyError) {
+                  appendErrorToBlocks(renderOnlyError.error)
+                }
                 if (state.currentToolStatus?.name === chunk.toolName) {
                   state.currentToolStatus = {
                     ...state.currentToolStatus,
-                    status: 'done',
+                    status: renderOnlyError ? 'error' : 'done',
                   }
                 }
-                updateToolBlockStatus(chunk.toolName, 'done')
+                if (!isRenderOnlyTool(chunk.toolName)) {
+                  updateToolBlockStatus(chunk.toolName, renderOnlyError ? 'error' : 'done')
+                }
               }
               state.isLoadingSource = false
               break
@@ -1326,8 +1376,15 @@ export const useAIChatStore = defineStore('aiChatRuntime', () => {
       targetBuffer.messages.push(...subsequentMessages)
     }
 
-    const { updateAIMessage, appendTextToBlocks, appendThinkToBlocks, addToolBlock, updateToolBlockStatus } =
-      createStreamBlockHelpers(targetBuffer, () => aiMessageIndex)
+    const {
+      updateAIMessage,
+      appendTextToBlocks,
+      appendThinkToBlocks,
+      appendChartsToBlocks,
+      appendErrorToBlocks,
+      addToolBlock,
+      updateToolBlockStatus,
+    } = createStreamBlockHelpers(targetBuffer, () => aiMessageIndex)
 
     try {
       const hasConfig = await useLLMService().hasConfig()
@@ -1409,11 +1466,23 @@ export const useAIChatStore = defineStore('aiChatRuntime', () => {
               if (chunk.toolName) {
                 state.currentToolStatus = { name: chunk.toolName, displayName: chunk.toolName, status: 'running' }
                 state.toolsUsedInCurrentRound.push(chunk.toolName)
-                addToolBlock(chunk.toolName, chunk.toolParams as Record<string, unknown> | undefined)
+                if (!isRenderOnlyTool(chunk.toolName)) {
+                  addToolBlock(chunk.toolName, chunk.toolParams as Record<string, unknown> | undefined)
+                }
               }
               break
             case 'tool_result':
-              if (chunk.toolName) updateToolBlockStatus(chunk.toolName, 'done')
+              if (chunk.toolName) {
+                const charts = extractChartPayloads(chunk.toolResult)
+                appendChartsToBlocks(charts)
+                const renderOnlyError = toRenderOnlyToolErrorBlock(chunk.toolName, chunk.toolResult)
+                if (renderOnlyError) {
+                  appendErrorToBlocks(renderOnlyError.error)
+                }
+                if (!isRenderOnlyTool(chunk.toolName)) {
+                  updateToolBlockStatus(chunk.toolName, renderOnlyError ? 'error' : 'done')
+                }
+              }
               state.currentToolStatus = null
               state.isLoadingSource = false
               break

--- a/src/stores/aiChatChartBlocks.test.ts
+++ b/src/stores/aiChatChartBlocks.test.ts
@@ -1,0 +1,111 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import type { ChartPayload } from '@openchatlab/core'
+import {
+  extractChartPayloads,
+  isRenderOnlyTool,
+  toChartContentBlocks,
+  toRenderOnlyToolErrorBlock,
+} from './aiChatChartBlocks'
+
+const chart: ChartPayload = {
+  version: 1,
+  spec: {
+    version: 1,
+    type: 'line',
+    title: 'Daily messages',
+    encoding: { x: 'day', y: 'message_count', series: 'member_name' },
+  },
+  dataset: {
+    columns: [
+      { name: 'day', type: 'date' },
+      { name: 'member_name', type: 'category' },
+      { name: 'message_count', type: 'integer' },
+    ],
+    rows: [{ day: '2026-06-01', member_name: 'Alice', message_count: 4 }],
+  },
+  data: {
+    labels: ['2026-06-01'],
+    values: [4],
+    series: [{ name: 'Alice', values: [4] }],
+  },
+  rowCount: 1,
+}
+
+const secondChart: ChartPayload = {
+  ...chart,
+  spec: {
+    ...chart.spec,
+    type: 'pie',
+    title: 'Selected members',
+    encoding: { label: 'member_name', value: 'message_count' },
+  },
+  data: {
+    labels: ['Alice'],
+    values: [4],
+  },
+}
+
+describe('aiChat chart block helpers', () => {
+  it('treats render_chart as render-only', () => {
+    assert.equal(isRenderOnlyTool('render_chart'), true)
+    assert.equal(isRenderOnlyTool('search_messages'), false)
+    assert.equal(isRenderOnlyTool(undefined), false)
+  })
+
+  it('extracts chart payloads from agent result details', () => {
+    const result = {
+      content: [{ type: 'text', text: 'Generated chart.' }],
+      details: { rowCount: 1, chart },
+    }
+
+    assert.deepEqual(extractChartPayloads(result), [chart])
+  })
+
+  it('extracts multiple chart payloads and filters invalid entries', () => {
+    const result = {
+      details: {
+        charts: [chart, { version: 1, spec: null }, secondChart],
+      },
+    }
+
+    assert.deepEqual(extractChartPayloads(result), [chart, secondChart])
+  })
+
+  it('supports top-level chart payload fallback', () => {
+    assert.deepEqual(extractChartPayloads({ chart }), [chart])
+  })
+
+  it('converts chart payloads to content blocks', () => {
+    assert.deepEqual(toChartContentBlocks([chart, secondChart]), [
+      { type: 'chart', chart },
+      { type: 'chart', chart: secondChart },
+    ])
+  })
+
+  it('converts render-only chart tool failures to visible error blocks', () => {
+    const errorBlock = toRenderOnlyToolErrorBlock('render_chart', {
+      content: [{ type: 'text', text: 'Error: Field "missing_count" does not exist in SQL result' }],
+      details: null,
+    })
+
+    assert.deepEqual(errorBlock, {
+      type: 'error',
+      error: {
+        name: 'ChartRenderError',
+        message: 'Field "missing_count" does not exist in SQL result',
+        stack: null,
+      },
+    })
+  })
+
+  it('does not create render-only error blocks for successful charts or normal tools', () => {
+    assert.equal(toRenderOnlyToolErrorBlock('render_chart', { details: { chart } }), null)
+    assert.equal(
+      toRenderOnlyToolErrorBlock('search_messages', {
+        content: [{ type: 'text', text: 'Error: search failed' }],
+      }),
+      null
+    )
+  })
+})

--- a/src/stores/aiChatChartBlocks.ts
+++ b/src/stores/aiChatChartBlocks.ts
@@ -1,0 +1,75 @@
+import type { ChartPayload } from '@openchatlab/core'
+
+export type ChartContentBlock = { type: 'chart'; chart: ChartPayload }
+export type RenderOnlyToolErrorBlock = {
+  type: 'error'
+  error: { name: string | null; message: string; stack: string | null }
+}
+
+export function isRenderOnlyTool(toolName?: string): boolean {
+  return toolName === 'render_chart'
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+export function isChartPayload(value: unknown): value is ChartPayload {
+  return isRecord(value) && value.version === 1 && isRecord(value.spec) && isRecord(value.dataset)
+}
+
+export function extractChartPayloads(toolResult: unknown): ChartPayload[] {
+  if (!isRecord(toolResult)) return []
+  const details = isRecord(toolResult.details) ? toolResult.details : toolResult
+  const charts: ChartPayload[] = []
+
+  if (isChartPayload(details.chart)) charts.push(details.chart)
+  if (Array.isArray(details.charts)) {
+    for (const chart of details.charts) {
+      if (isChartPayload(chart)) charts.push(chart)
+    }
+  }
+
+  return charts
+}
+
+export function toChartContentBlocks(charts: ChartPayload[]): ChartContentBlock[] {
+  return charts.map((chart) => ({ type: 'chart', chart }))
+}
+
+function extractToolResultText(toolResult: unknown): string | null {
+  if (!isRecord(toolResult)) return null
+  if (typeof toolResult.error === 'string') return toolResult.error
+  if (isRecord(toolResult.error) && typeof toolResult.error.message === 'string') return toolResult.error.message
+  if (Array.isArray(toolResult.content)) {
+    return toolResult.content
+      .map((part) => (isRecord(part) && part.type === 'text' && typeof part.text === 'string' ? part.text : ''))
+      .join('\n')
+      .trim()
+  }
+  return null
+}
+
+export function toRenderOnlyToolErrorBlock(
+  toolName: string | undefined,
+  toolResult: unknown
+): RenderOnlyToolErrorBlock | null {
+  if (!isRenderOnlyTool(toolName)) return null
+  if (extractChartPayloads(toolResult).length > 0) return null
+
+  const text = extractToolResultText(toolResult)
+  if (!text) return null
+
+  const match = /^Error:\s*(.+)$/is.exec(text)
+  const message = match?.[1]?.trim()
+  if (!message) return null
+
+  return {
+    type: 'error',
+    error: {
+      name: 'ChartRenderError',
+      message,
+      stack: null,
+    },
+  }
+}

--- a/src/stores/skill.test.ts
+++ b/src/stores/skill.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { createPinia, setActivePinia } from 'pinia'
+import { CHART_CAPABILITY_SKILL_ID } from '@openchatlab/core'
+import { useSkillStore, type SkillSummary } from './skill'
+
+const localSkill: SkillSummary = {
+  id: 'local_summary',
+  name: 'Local Summary',
+  description: 'Summarize the current chat',
+  tags: ['summary'],
+  chatScope: 'all',
+  tools: [],
+}
+
+describe('skill store chart capability', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('exposes chart capability as a compatible slash skill without import', () => {
+    const store = useSkillStore()
+    store.skills = [localSkill]
+    store.setFilterContext('group', 'en-US')
+
+    const ids = store.compatibleSkills.map((skill) => skill.id)
+    assert.equal(ids[0], CHART_CAPABILITY_SKILL_ID)
+    assert.ok(ids.includes(localSkill.id))
+    assert.equal(store.compatibleSkills[0].name, 'Chart Assistant')
+  })
+
+  it('activates and clears the chart capability through the same single-message toggle', async () => {
+    const store = useSkillStore()
+    store.setFilterContext('group', 'zh-CN')
+
+    store.activateSkill(CHART_CAPABILITY_SKILL_ID)
+    assert.equal(store.activeSkillId, CHART_CAPABILITY_SKILL_ID)
+    assert.equal(store.activeSkill?.name, '绘图助手')
+
+    const config = await store.getSkillConfig(CHART_CAPABILITY_SKILL_ID)
+    assert.equal(config?.id, CHART_CAPABILITY_SKILL_ID)
+    assert.deepEqual(config?.tools, ['render_chart', 'get_schema'])
+    assert.match(config?.prompt ?? '', /render_chart/)
+
+    store.activateSkill(null)
+    assert.equal(store.activeSkillId, null)
+    assert.equal(store.activeSkill, null)
+  })
+})

--- a/src/stores/skill.ts
+++ b/src/stores/skill.ts
@@ -7,6 +7,7 @@ import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
 import { useAssistantStore } from './assistant'
 import { usePlatformService, useSkillService } from '@/services'
+import { CHART_CAPABILITY_SKILL_ID, getChartCapabilitySkill } from '@openchatlab/core'
 
 import { CHATLAB_SITE_BASE } from '@/utils/chatlabSiteLocale'
 const CLOUD_MARKET_BASE_URL = CHATLAB_SITE_BASE
@@ -65,8 +66,13 @@ export const useSkillStore = defineStore('skill', () => {
 
   const activeSkill = computed(() => {
     if (!activeSkillId.value) return null
+    if (activeSkillId.value === CHART_CAPABILITY_SKILL_ID) {
+      return getChartCapabilitySkill(currentLocale.value)
+    }
     return skills.value.find((s) => s.id === activeSkillId.value) ?? null
   })
+
+  const chartCapabilitySkill = computed(() => getChartCapabilitySkill(currentLocale.value))
 
   const scopedSkills = computed(() => {
     return skills.value.filter((s) => s.chatScope === 'all' || s.chatScope === currentChatType.value)
@@ -75,9 +81,10 @@ export const useSkillStore = defineStore('skill', () => {
   const compatibleSkills = computed(() => {
     const assistantStore = useAssistantStore()
     const config = assistantStore.selectedAssistant
-    if (!config) return scopedSkills.value
+    const baseSkills = [chartCapabilitySkill.value, ...scopedSkills.value]
+    if (!config) return baseSkills
 
-    return scopedSkills.value.filter((s) => {
+    return baseSkills.filter((s) => {
       if (!s.tools.length) return true
       return true
     })
@@ -188,6 +195,13 @@ export const useSkillStore = defineStore('skill', () => {
   }
 
   async function getSkillConfig(id: string): Promise<SkillConfigFull | null> {
+    if (id === CHART_CAPABILITY_SKILL_ID) {
+      const skill = getChartCapabilitySkill(currentLocale.value)
+      return {
+        ...skill,
+        builtinId: CHART_CAPABILITY_SKILL_ID,
+      }
+    }
     try {
       return await useSkillService().getConfig(id)
     } catch (error) {

--- a/tests/chart-runtime/agent-chart-flow.test.ts
+++ b/tests/chart-runtime/agent-chart-flow.test.ts
@@ -1,0 +1,381 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  createAssistantMessageEventStream,
+  type AssistantMessage,
+  type Context,
+  type Message,
+  type Model,
+  type ToolCall,
+  type Usage,
+} from '@earendil-works/pi-ai'
+import type { AgentTool, AgentToolResult } from '@earendil-works/pi-agent-core'
+import {
+  renderChartTool,
+  type ToolDataProvider,
+  type ToolDefinition,
+  type ToolExecutionContext,
+} from '@openchatlab/tools'
+import type { ChartPayload } from '@openchatlab/core'
+import { runAgentCore, type AgentCoreEvent } from '../../packages/node-runtime/src/ai/agent'
+
+function emptyUsage(): Usage {
+  return {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: 0,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+  }
+}
+
+function assistantMessage(
+  content: AssistantMessage['content'],
+  stopReason: AssistantMessage['stopReason']
+): AssistantMessage {
+  return {
+    role: 'assistant',
+    content,
+    api: 'openai-completions',
+    provider: 'chatlab-test',
+    model: 'fake-chart-model',
+    usage: emptyUsage(),
+    stopReason,
+    timestamp: Date.now(),
+  }
+}
+
+function createToolCallsStream(toolCalls: ToolCall[]) {
+  const stream = createAssistantMessageEventStream()
+  const partialStart = assistantMessage([], 'toolUse')
+  const finalMessage = assistantMessage(toolCalls, 'toolUse')
+  stream.push({ type: 'start', partial: partialStart })
+  toolCalls.forEach((toolCall, contentIndex) => {
+    stream.push({ type: 'toolcall_start', contentIndex, partial: finalMessage })
+    stream.push({
+      type: 'toolcall_delta',
+      contentIndex,
+      delta: JSON.stringify(toolCall.arguments),
+      partial: finalMessage,
+    })
+    stream.push({ type: 'toolcall_end', contentIndex, toolCall, partial: finalMessage })
+  })
+  stream.push({ type: 'done', reason: 'toolUse', message: finalMessage })
+  return stream
+}
+
+function createToolCallStream(toolCall: ToolCall) {
+  return createToolCallsStream([toolCall])
+}
+
+function createTextStream(text: string) {
+  const stream = createAssistantMessageEventStream()
+  const partialStart = assistantMessage([], 'stop')
+  const finalMessage = assistantMessage([{ type: 'text', text }], 'stop')
+  stream.push({ type: 'start', partial: partialStart })
+  stream.push({ type: 'text_start', contentIndex: 0, partial: partialStart })
+  stream.push({ type: 'text_delta', contentIndex: 0, delta: text, partial: finalMessage })
+  stream.push({ type: 'text_end', contentIndex: 0, content: text, partial: finalMessage })
+  stream.push({ type: 'done', reason: 'stop', message: finalMessage })
+  return stream
+}
+
+function hasToolResult(messages: Message[]): boolean {
+  return messages.some((message) => message.role === 'toolResult' && message.toolName === 'render_chart')
+}
+
+function countToolResults(messages: Message[]): number {
+  return messages.filter((message) => message.role === 'toolResult' && message.toolName === 'render_chart').length
+}
+
+function convertJsonSchemaToParameters(schema: ToolDefinition['inputSchema']) {
+  const properties: Record<string, unknown> = {}
+  for (const [key, prop] of Object.entries(schema.properties)) {
+    properties[key] = { ...prop }
+  }
+  return {
+    type: 'object' as const,
+    properties,
+    required: schema.required || [],
+  }
+}
+
+function adaptRenderChartTool(dataProvider: ToolDataProvider): AgentTool<any, unknown> {
+  return {
+    name: renderChartTool.name,
+    label: renderChartTool.name,
+    description: renderChartTool.description,
+    parameters: convertJsonSchemaToParameters(renderChartTool.inputSchema) as any,
+    async execute(_toolCallId: string, params: unknown): Promise<AgentToolResult<unknown>> {
+      const context: ToolExecutionContext = {
+        sessionId: 'offline-agent-chart-flow',
+        locale: 'en-US',
+        dataProvider,
+      }
+      const result = await renderChartTool.handler((params ?? {}) as Record<string, unknown>, context)
+      return {
+        content: [{ type: 'text', text: result.content }],
+        details: {
+          ...(typeof result.data === 'object' && result.data !== null ? result.data : {}),
+          ...(result.chart ? { chart: result.chart } : {}),
+        },
+      }
+    },
+  }
+}
+
+describe('offline Agent chart flow', () => {
+  it('turns a natural-language chart request into a render_chart tool result and final answer', async () => {
+    const requestedSql: string[] = []
+    const dataProvider: ToolDataProvider = {
+      async executeParameterizedSql(sql, params) {
+        requestedSql.push(sql)
+        assert.match(sql, /JOIN member/i)
+        assert.match(sql, /@memberA/)
+        assert.deepEqual(params, { memberA: 'Alice', memberB: 'Bob', startTs: 1780272000, endTs: 1780444800 })
+        return [
+          { day: '2026-06-01', member_name: 'Alice', message_count: 2 },
+          { day: '2026-06-01', member_name: 'Bob', message_count: 1 },
+          { day: '2026-06-02', member_name: 'Alice', message_count: 2 },
+          { day: '2026-06-02', member_name: 'Bob', message_count: 2 },
+        ]
+      },
+      async getSchema() {
+        return []
+      },
+    } as Partial<ToolDataProvider> as ToolDataProvider
+    const tools = [adaptRenderChartTool(dataProvider)]
+    const streamFn = (_model: Model<any>, context: Context) => {
+      const userMessages = context.messages.filter((message) => message.role === 'user')
+      const latestUser = userMessages[userMessages.length - 1]
+      const userText = Array.isArray(latestUser?.content)
+        ? latestUser.content.map((part) => (part.type === 'text' ? part.text : '')).join('\n')
+        : latestUser?.content || ''
+      assert.match(userText, /Alice/)
+      assert.match(userText, /Bob/)
+      assert.match(userText, /line/i)
+
+      if (!hasToolResult(context.messages)) {
+        return createToolCallStream({
+          type: 'toolCall',
+          id: 'call_chart_1',
+          name: 'render_chart',
+          arguments: {
+            sql: `
+              SELECT date(msg.ts, 'unixepoch') AS day,
+                     COALESCE(m.group_nickname, m.account_name, m.platform_id) AS member_name,
+                     COUNT(*) AS message_count
+              FROM message msg
+              JOIN member m ON m.id = msg.sender_id
+              WHERE COALESCE(m.group_nickname, m.account_name, m.platform_id) IN (@memberA, @memberB)
+                AND msg.ts >= @startTs AND msg.ts < @endTs
+              GROUP BY day, m.id
+              ORDER BY day ASC, member_name ASC
+            `,
+            params: { memberA: 'Alice', memberB: 'Bob', startTs: 1780272000, endTs: 1780444800 },
+            chartSpec: {
+              version: 1,
+              type: 'line',
+              title: 'Alice vs Bob daily message trend',
+              encoding: { x: 'day', y: 'message_count', series: 'member_name' },
+              filters: { members: [{ name: 'Alice' }, { name: 'Bob' }] },
+              unit: 'messages',
+            },
+          },
+        })
+      }
+
+      return createTextStream('Alice stayed ahead on both days, while Bob caught up on June 2.')
+    }
+    const events: AgentCoreEvent[] = []
+
+    const result = await runAgentCore({
+      piModel: {
+        id: 'fake-chart-model',
+        provider: 'chatlab-test',
+        api: 'openai-completions',
+      } as Model<any>,
+      apiKey: 'test-key',
+      systemPrompt: 'Use render_chart for chart requests.',
+      tools,
+      history: [],
+      userMessage: 'Please draw a line chart comparing Alice and Bob message counts by day.',
+      maxToolRounds: 3,
+      steerMessage: 'Please explain the chart briefly.',
+      streamFn,
+      onEvent: (event) => events.push(event),
+    })
+
+    assert.equal(result.error, undefined)
+    assert.deepEqual(result.toolsUsed, ['render_chart'])
+    assert.equal(result.toolRounds, 1)
+    assert.equal(requestedSql.length, 1)
+
+    const toolEnd = events.find((event) => event.type === 'tool_end' && event.toolName === 'render_chart')
+    assert.ok(toolEnd && 'toolResult' in toolEnd, 'expected render_chart tool_end event')
+    const chart = (toolEnd.toolResult as { details?: { chart?: ChartPayload } }).details?.chart
+    assert.ok(chart, 'expected chart payload in render_chart tool result details')
+    assert.equal(chart.spec.type, 'line')
+    assert.deepEqual(chart.data, {
+      labels: ['2026-06-01', '2026-06-02'],
+      values: [2, 2],
+      series: [
+        { name: 'Alice', values: [2, 2] },
+        { name: 'Bob', values: [1, 2] },
+      ],
+    })
+
+    const content = events
+      .filter((event) => event.type === 'content')
+      .map((event) => event.content)
+      .join('')
+    assert.match(content, /Bob caught up/)
+  })
+
+  it('runs multiple render_chart calls when the user asks for two charts', async () => {
+    const requestedSql: string[] = []
+    const dataProvider: ToolDataProvider = {
+      async executeParameterizedSql(sql, params) {
+        requestedSql.push(sql)
+        if (sql.includes('selected_member_share_source')) {
+          assert.deepEqual(params, { memberA: 'Alice', memberB: 'Bob' })
+          return [
+            { member_name: 'Alice', message_count: 4 },
+            { member_name: 'Bob', message_count: 3 },
+          ]
+        }
+        if (sql.includes('member_hour_density_source')) {
+          assert.deepEqual(params, { memberA: 'Alice', memberB: 'Bob' })
+          return [
+            { hour: '09', member_name: 'Alice', message_count: 2 },
+            { hour: '10', member_name: 'Alice', message_count: 2 },
+            { hour: '09', member_name: 'Bob', message_count: 1 },
+            { hour: '10', member_name: 'Bob', message_count: 2 },
+          ]
+        }
+        throw new Error(`unexpected SQL: ${sql}`)
+      },
+      async getSchema() {
+        return []
+      },
+    } as Partial<ToolDataProvider> as ToolDataProvider
+    const tools = [adaptRenderChartTool(dataProvider)]
+    const streamFn = (_model: Model<any>, context: Context) => {
+      const userMessages = context.messages.filter((message) => message.role === 'user')
+      const latestUser = userMessages[userMessages.length - 1]
+      const userText = Array.isArray(latestUser?.content)
+        ? latestUser.content.map((part) => (part.type === 'text' ? part.text : '')).join('\n')
+        : latestUser?.content || ''
+      assert.match(userText, /two charts/i)
+      assert.match(userText, /pie/i)
+      assert.match(userText, /heatmap/i)
+
+      if (countToolResults(context.messages) < 2) {
+        return createToolCallsStream([
+          {
+            type: 'toolCall',
+            id: 'call_chart_pie',
+            name: 'render_chart',
+            arguments: {
+              sql: `
+                WITH selected_member_share_source AS (
+                  SELECT @memberA AS member_name, 4 AS message_count
+                  UNION ALL
+                  SELECT @memberB AS member_name, 3 AS message_count
+                )
+                SELECT member_name, message_count
+                FROM selected_member_share_source
+              `,
+              params: { memberA: 'Alice', memberB: 'Bob' },
+              chartSpec: {
+                version: 1,
+                type: 'pie',
+                title: 'Selected members message share',
+                encoding: { label: 'member_name', value: 'message_count' },
+              },
+            },
+          },
+          {
+            type: 'toolCall',
+            id: 'call_chart_heatmap',
+            name: 'render_chart',
+            arguments: {
+              sql: `
+                WITH member_hour_density_source AS (
+                  SELECT '09' AS hour, @memberA AS member_name, 2 AS message_count
+                  UNION ALL
+                  SELECT '10' AS hour, @memberA AS member_name, 2 AS message_count
+                  UNION ALL
+                  SELECT '09' AS hour, @memberB AS member_name, 1 AS message_count
+                  UNION ALL
+                  SELECT '10' AS hour, @memberB AS member_name, 2 AS message_count
+                )
+                SELECT hour, member_name, message_count
+                FROM member_hour_density_source
+              `,
+              params: { memberA: 'Alice', memberB: 'Bob' },
+              chartSpec: {
+                version: 1,
+                type: 'heatmap',
+                title: 'Selected members hour density',
+                encoding: { x: 'hour', y: 'member_name', value: 'message_count' },
+              },
+            },
+          },
+        ])
+      }
+
+      return createTextStream('Here are the requested pie chart and heatmap.')
+    }
+    const events: AgentCoreEvent[] = []
+
+    const result = await runAgentCore({
+      piModel: {
+        id: 'fake-chart-model',
+        provider: 'chatlab-test',
+        api: 'openai-completions',
+      } as Model<any>,
+      apiKey: 'test-key',
+      systemPrompt: 'Use render_chart for chart requests.',
+      tools,
+      history: [],
+      userMessage: 'Please generate two charts: a pie chart for Alice and Bob, plus a heatmap by hour.',
+      maxToolRounds: 3,
+      steerMessage: 'Please explain both charts briefly.',
+      streamFn,
+      onEvent: (event) => events.push(event),
+    })
+
+    assert.equal(result.error, undefined)
+    assert.deepEqual(result.toolsUsed, ['render_chart', 'render_chart'])
+    assert.equal(result.toolRounds, 1)
+    assert.equal(requestedSql.length, 2)
+
+    const chartPayloads = events
+      .filter((event) => event.type === 'tool_end' && event.toolName === 'render_chart')
+      .map((event) => (event.toolResult as { details?: { chart?: ChartPayload } }).details?.chart)
+      .filter((chart): chart is ChartPayload => !!chart)
+
+    assert.equal(chartPayloads.length, 2)
+    const chartsByType = new Map(chartPayloads.map((chart) => [chart.spec.type, chart]))
+    assert.deepEqual([...chartsByType.keys()].sort(), ['heatmap', 'pie'])
+    assert.deepEqual(chartsByType.get('pie')?.data, { labels: ['Alice', 'Bob'], values: [4, 3] })
+    assert.deepEqual(chartsByType.get('heatmap')?.data, {
+      xLabels: ['09', '10'],
+      yLabels: ['Alice', 'Bob'],
+      data: [
+        [0, 0, 2],
+        [1, 0, 2],
+        [0, 1, 1],
+        [1, 1, 2],
+      ],
+    })
+
+    const content = events
+      .filter((event) => event.type === 'content')
+      .map((event) => event.content)
+      .join('')
+    assert.match(content, /pie chart and heatmap/)
+  })
+})

--- a/tests/chart-runtime/real-llm-chart-flow.e2e.test.ts
+++ b/tests/chart-runtime/real-llm-chart-flow.e2e.test.ts
@@ -1,0 +1,198 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { existsSync, mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import type { AgentTool, AgentToolResult } from '@earendil-works/pi-agent-core'
+import { CHAT_DB_SCHEMA, getChartCapabilitySkill, type ChartPayload } from '@openchatlab/core'
+import {
+  CoreDataProvider,
+  renderChartTool,
+  schemaTool,
+  type ToolDataProvider,
+  type ToolDefinition,
+  type ToolExecutionContext,
+} from '@openchatlab/tools'
+import { buildPiModel } from '../../packages/node-runtime/src/ai/llm-builder'
+import { runAgentCore, type AgentCoreEvent } from '../../packages/node-runtime/src/ai/agent'
+import { openBetterSqliteDatabase } from '../../packages/node-runtime/src/better-sqlite3-adapter'
+
+const shouldRunRealLlmE2E = process.env.CHATLAB_RUN_REAL_LLM_CHART_E2E === '1'
+
+function resolveNativeBinding(): string | undefined {
+  if (process.env.CHATLAB_TEST_SQLITE_NATIVE_BINDING) return process.env.CHATLAB_TEST_SQLITE_NATIVE_BINDING
+  const repoNativeBinding = path.resolve('apps/cli/native/better_sqlite3.node')
+  return existsSync(repoNativeBinding) ? repoNativeBinding : undefined
+}
+
+function unixTs(iso: string): number {
+  return Math.floor(Date.parse(iso) / 1000)
+}
+
+function createTempDir(): string {
+  return mkdtempSync(path.join(tmpdir(), 'chatlab-real-llm-chart-e2e-'))
+}
+
+function seedChatDb(db: ReturnType<typeof openBetterSqliteDatabase>): void {
+  db.exec(CHAT_DB_SCHEMA)
+  db.prepare(
+    `INSERT INTO meta (name, platform, type, imported_at, group_id, owner_id)
+     VALUES ('Chart E2E Group', 'wechat', 'group', ?, 'g1', 'u_alice')`
+  ).run(unixTs('2026-06-03T00:00:00Z'))
+
+  const insertMember = db.prepare(
+    `INSERT INTO member (platform_id, account_name, group_nickname)
+     VALUES (?, ?, ?)`
+  )
+  insertMember.run('u_alice', 'Alice Account', 'Alice')
+  insertMember.run('u_bob', 'Bob Account', 'Bob')
+  insertMember.run('u_cara', 'Cara Account', 'Cara')
+
+  const memberRows = db.prepare('SELECT id, group_nickname FROM member').all() as Array<{
+    id: number
+    group_nickname: string
+  }>
+  const memberId = new Map(memberRows.map((row) => [row.group_nickname, row.id]))
+  const insertMessage = db.prepare(
+    `INSERT INTO message (sender_id, sender_account_name, sender_group_nickname, ts, type, content, platform_message_id)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`
+  )
+  const add = (name: 'Alice' | 'Bob' | 'Cara', ts: string, type: number, content: string) => {
+    const id = memberId.get(name)
+    assert.ok(id, `missing member id for ${name}`)
+    insertMessage.run(id, `${name} Account`, name, unixTs(ts), type, content, `${name}-${ts}`)
+  }
+
+  add('Alice', '2026-06-01T09:00:00Z', 0, 'morning hello')
+  add('Alice', '2026-06-01T10:00:00Z', 0, 'standup note')
+  add('Alice', '2026-06-02T09:00:00Z', 1, '[图片]')
+  add('Alice', '2026-06-02T10:00:00Z', 0, 'follow up')
+  add('Bob', '2026-06-01T09:00:00Z', 0, 'first reply')
+  add('Bob', '2026-06-02T10:00:00Z', 0, 'second reply')
+  add('Bob', '2026-06-02T11:00:00Z', 0, 'third reply')
+  add('Cara', '2026-06-01T09:00:00Z', 0, 'other member')
+  add('Cara', '2026-06-03T12:00:00Z', 0, 'outside selected members')
+}
+
+function convertJsonSchemaToParameters(schema: ToolDefinition['inputSchema']) {
+  const properties: Record<string, unknown> = {}
+  for (const [key, prop] of Object.entries(schema.properties)) {
+    properties[key] = { ...prop }
+  }
+  return {
+    type: 'object' as const,
+    properties,
+    required: schema.required || [],
+  }
+}
+
+function adaptTool(tool: ToolDefinition, dataProvider: ToolDataProvider): AgentTool<any, unknown> {
+  return {
+    name: tool.name,
+    label: tool.name,
+    description: tool.description,
+    parameters: convertJsonSchemaToParameters(tool.inputSchema) as any,
+    async execute(_toolCallId: string, params: unknown): Promise<AgentToolResult<unknown>> {
+      const context: ToolExecutionContext = {
+        sessionId: 'real-llm-chart-flow',
+        locale: 'en-US',
+        dataProvider,
+      }
+      const result = await tool.handler((params ?? {}) as Record<string, unknown>, context)
+      return {
+        content: [{ type: 'text', text: result.content }],
+        details: {
+          ...(typeof result.data === 'object' && result.data !== null && !Array.isArray(result.data)
+            ? result.data
+            : {}),
+          ...(result.chart ? { chart: result.chart } : {}),
+        },
+      }
+    },
+  }
+}
+
+function getChartPayloads(events: AgentCoreEvent[]): ChartPayload[] {
+  return events
+    .filter((event) => event.type === 'tool_end' && event.toolName === 'render_chart')
+    .map((event) => (event.toolResult as { details?: { chart?: ChartPayload } }).details?.chart)
+    .filter((chart): chart is ChartPayload => !!chart)
+}
+
+describe('real external LLM chart flow', () => {
+  it(
+    'asks a real model to generate two chart payloads from real chat data',
+    { skip: !shouldRunRealLlmE2E },
+    async () => {
+      const apiKey = process.env.CHATLAB_REAL_LLM_API_KEY || process.env.OPENAI_API_KEY
+      assert.ok(apiKey, 'Set CHATLAB_REAL_LLM_API_KEY or OPENAI_API_KEY to run the real LLM chart E2E test')
+
+      const provider = process.env.CHATLAB_REAL_LLM_PROVIDER || 'openai'
+      const model = process.env.CHATLAB_REAL_LLM_MODEL || 'gpt-4.1-mini'
+      const baseUrl = process.env.CHATLAB_REAL_LLM_BASE_URL || undefined
+      const piModel = buildPiModel({ provider, model, baseUrl })
+      const dir = createTempDir()
+      const dbPath = path.join(dir, 'chat.db')
+      const nativeBinding = resolveNativeBinding()
+      const db = openBetterSqliteDatabase(dbPath, { nativeBinding })
+
+      try {
+        seedChatDb(db)
+        const dataProvider = new CoreDataProvider(db)
+        const tools = [adaptTool(schemaTool, dataProvider), adaptTool(renderChartTool, dataProvider)]
+        const events: AgentCoreEvent[] = []
+        const chartPrompt = getChartCapabilitySkill('en-US').prompt
+
+        const result = await runAgentCore({
+          piModel,
+          apiKey,
+          systemPrompt: `${chartPrompt}
+
+Test-specific requirements:
+- Use get_schema if you need table names or columns.
+- Produce exactly two render_chart calls.
+- The pie chart must include only Alice and Bob and must exclude Cara.
+- The heatmap must include only Alice and Bob and use hour on x, member name on y, and message count as value.
+- Use the data from June 1-2, 2026 inclusive. The database stores Unix seconds in message.ts.`,
+          tools,
+          history: [],
+          userMessage:
+            'Create exactly two charts from this chat data: first a pie chart comparing Alice and Bob message share, then a heatmap showing Alice and Bob message density by hour. Briefly explain both.',
+          maxToolRounds: 4,
+          steerMessage: 'Explain the generated charts briefly. Do not call more tools.',
+          thinkingLevel: 'off',
+          onEvent: (event) => events.push(event),
+        })
+
+        assert.equal(result.error, undefined)
+        const charts = getChartPayloads(events)
+        assert.equal(charts.length, 2, `expected exactly two chart payloads, got ${charts.length}`)
+
+        const chartsByType = new Map(charts.map((chart) => [chart.spec.type, chart]))
+        const pie = chartsByType.get('pie')
+        const heatmap = chartsByType.get('heatmap')
+        assert.ok(pie, 'expected a pie chart payload')
+        assert.ok(heatmap, 'expected a heatmap chart payload')
+        assert.deepEqual(new Set(pie.data.labels), new Set(['Alice', 'Bob']))
+        assert.equal(
+          pie.data.values.reduce((sum, value) => sum + value, 0),
+          7
+        )
+        assert.ok(!heatmap.data.yLabels.includes('Cara'), 'heatmap should exclude Cara')
+        assert.ok(heatmap.data.yLabels.includes('Alice'), 'heatmap should include Alice')
+        assert.ok(heatmap.data.yLabels.includes('Bob'), 'heatmap should include Bob')
+        assert.ok(heatmap.data.xLabels.includes('09'), 'heatmap should include hour 09')
+        assert.ok(heatmap.data.data.length > 0, 'heatmap should include density cells')
+
+        const finalContent = events
+          .filter((event) => event.type === 'content')
+          .map((event) => event.content)
+          .join('')
+        assert.match(finalContent, /Alice|Bob|pie|heatmap/i)
+      } finally {
+        db.close()
+        rmSync(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
+      }
+    }
+  )
+})

--- a/tests/chart-runtime/render-chart.integration.test.ts
+++ b/tests/chart-runtime/render-chart.integration.test.ts
@@ -1,0 +1,243 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { existsSync, mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { CHAT_DB_SCHEMA, type ChartPayload } from '@openchatlab/core'
+import { CoreDataProvider, renderChartTool } from '@openchatlab/tools'
+import { openBetterSqliteDatabase } from '../../packages/node-runtime/src/better-sqlite3-adapter'
+
+function resolveNativeBinding(): string | undefined {
+  if (process.env.CHATLAB_TEST_SQLITE_NATIVE_BINDING) return process.env.CHATLAB_TEST_SQLITE_NATIVE_BINDING
+  const repoNativeBinding = path.resolve('apps/cli/native/better_sqlite3.node')
+  return existsSync(repoNativeBinding) ? repoNativeBinding : undefined
+}
+
+function unixTs(iso: string): number {
+  return Math.floor(Date.parse(iso) / 1000)
+}
+
+function createTempDir(): string {
+  return mkdtempSync(path.join(tmpdir(), 'chatlab-chart-runtime-'))
+}
+
+function getChart(result: Awaited<ReturnType<typeof renderChartTool.handler>>): ChartPayload {
+  assert.ok(result.chart, 'expected render_chart to return a chart payload')
+  return result.chart
+}
+
+function seedChatDb(db: ReturnType<typeof openBetterSqliteDatabase>): void {
+  db.exec(CHAT_DB_SCHEMA)
+  db.prepare(
+    `INSERT INTO meta (name, platform, type, imported_at, group_id, owner_id)
+     VALUES ('Chart Test Group', 'wechat', 'group', ?, 'g1', 'u_alice')`
+  ).run(unixTs('2026-06-03T00:00:00Z'))
+
+  const insertMember = db.prepare(
+    `INSERT INTO member (platform_id, account_name, group_nickname)
+     VALUES (?, ?, ?)`
+  )
+  insertMember.run('u_alice', 'Alice Account', 'Alice')
+  insertMember.run('u_bob', 'Bob Account', 'Bob')
+  insertMember.run('u_cara', 'Cara Account', 'Cara')
+
+  const memberRows = db.prepare('SELECT id, group_nickname FROM member').all() as Array<{
+    id: number
+    group_nickname: string
+  }>
+  const memberId = new Map(memberRows.map((row) => [row.group_nickname, row.id]))
+  const insertMessage = db.prepare(
+    `INSERT INTO message (sender_id, sender_account_name, sender_group_nickname, ts, type, content, platform_message_id)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`
+  )
+  const add = (name: 'Alice' | 'Bob' | 'Cara', ts: string, type: number, content: string) => {
+    const id = memberId.get(name)
+    assert.ok(id, `missing member id for ${name}`)
+    insertMessage.run(id, `${name} Account`, name, unixTs(ts), type, content, `${name}-${ts}`)
+  }
+
+  add('Alice', '2026-06-01T09:00:00Z', 0, 'morning hello')
+  add('Alice', '2026-06-01T10:00:00Z', 0, 'standup note')
+  add('Alice', '2026-06-02T09:00:00Z', 1, '[图片]')
+  add('Alice', '2026-06-02T10:00:00Z', 0, 'follow up')
+  add('Bob', '2026-06-01T09:00:00Z', 0, 'first reply')
+  add('Bob', '2026-06-02T10:00:00Z', 0, 'second reply')
+  add('Bob', '2026-06-02T11:00:00Z', 0, 'third reply')
+  add('Cara', '2026-06-01T09:00:00Z', 0, 'other member')
+  add('Cara', '2026-06-03T12:00:00Z', 0, 'outside selected members')
+}
+
+describe('render_chart integration with a real chat SQLite database', () => {
+  it('executes read-only SQL against chat tables and returns flexible chart payloads', async () => {
+    const dir = createTempDir()
+    const dbPath = path.join(dir, 'chat.db')
+    const nativeBinding = resolveNativeBinding()
+    const db = openBetterSqliteDatabase(dbPath, { nativeBinding })
+
+    try {
+      seedChatDb(db)
+      const dataProvider = new CoreDataProvider(db)
+      const context = {
+        sessionId: 'chart-test-session',
+        locale: 'en-US',
+        dataProvider,
+      }
+      const range = {
+        startTs: unixTs('2026-06-01T00:00:00Z'),
+        endTs: unixTs('2026-06-03T00:00:00Z'),
+      }
+
+      const pie = getChart(
+        await renderChartTool.handler(
+          {
+            sql: `
+              SELECT COALESCE(m.group_nickname, m.account_name, m.platform_id) AS name,
+                     COUNT(*) AS message_count
+              FROM message msg
+              JOIN member m ON m.id = msg.sender_id
+              WHERE COALESCE(m.group_nickname, m.account_name, m.platform_id) IN (@memberA, @memberB)
+                AND msg.ts >= @startTs AND msg.ts < @endTs
+              GROUP BY m.id
+              ORDER BY message_count DESC, name ASC
+            `,
+            params: { memberA: 'Alice', memberB: 'Bob', ...range },
+            chartSpec: {
+              version: 1,
+              type: 'pie',
+              title: 'Selected members message share',
+              encoding: { label: 'name', value: 'message_count' },
+              filters: { members: [{ name: 'Alice' }, { name: 'Bob' }] },
+            },
+          },
+          context
+        )
+      )
+      assert.equal(pie.spec.type, 'pie')
+      assert.deepEqual(pie.data, { labels: ['Alice', 'Bob'], values: [4, 3] })
+      assert.deepEqual(
+        pie.spec.filters?.members?.map((member) => member.name),
+        ['Alice', 'Bob']
+      )
+
+      const line = getChart(
+        await renderChartTool.handler(
+          {
+            sql: `
+              SELECT date(msg.ts, 'unixepoch') AS day,
+                     COALESCE(m.group_nickname, m.account_name, m.platform_id) AS member_name,
+                     COUNT(*) AS message_count
+              FROM message msg
+              JOIN member m ON m.id = msg.sender_id
+              WHERE COALESCE(m.group_nickname, m.account_name, m.platform_id) IN (@memberA, @memberB)
+                AND msg.ts >= @startTs AND msg.ts < @endTs
+              GROUP BY day, m.id
+              ORDER BY day ASC, member_name ASC
+            `,
+            params: { memberA: 'Alice', memberB: 'Bob', ...range },
+            chartSpec: {
+              version: 1,
+              type: 'line',
+              title: 'Selected members daily trend',
+              encoding: { x: 'day', y: 'message_count', series: 'member_name' },
+            },
+          },
+          context
+        )
+      )
+      assert.equal(line.spec.type, 'line')
+      assert.deepEqual(line.data, {
+        labels: ['2026-06-01', '2026-06-02'],
+        values: [2, 2],
+        series: [
+          { name: 'Alice', values: [2, 2] },
+          { name: 'Bob', values: [1, 2] },
+        ],
+      })
+
+      const heatmap = getChart(
+        await renderChartTool.handler(
+          {
+            sql: `
+              SELECT strftime('%H', msg.ts, 'unixepoch') AS hour,
+                     COALESCE(m.group_nickname, m.account_name, m.platform_id) AS member_name,
+                     COUNT(*) AS message_count
+              FROM message msg
+              JOIN member m ON m.id = msg.sender_id
+              WHERE msg.ts >= @startTs AND msg.ts < @endTs
+              GROUP BY hour, m.id
+              ORDER BY member_name ASC, hour ASC
+            `,
+            params: range,
+            chartSpec: {
+              version: 1,
+              type: 'heatmap',
+              title: 'Member hour density',
+              encoding: { x: 'hour', y: 'member_name', value: 'message_count' },
+            },
+          },
+          context
+        )
+      )
+      assert.equal(heatmap.spec.type, 'heatmap')
+      assert.deepEqual(heatmap.data, {
+        xLabels: ['09', '10', '11'],
+        yLabels: ['Alice', 'Bob', 'Cara'],
+        data: [
+          [0, 0, 2],
+          [1, 0, 2],
+          [0, 1, 1],
+          [1, 1, 1],
+          [2, 1, 1],
+          [0, 2, 1],
+        ],
+      })
+    } finally {
+      db.close()
+      rmSync(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
+    }
+  })
+
+  it('does not mutate chat data when a WITH-prefixed write is attempted', async () => {
+    const dir = createTempDir()
+    const dbPath = path.join(dir, 'chat.db')
+    const nativeBinding = resolveNativeBinding()
+    const db = openBetterSqliteDatabase(dbPath, { nativeBinding })
+
+    try {
+      seedChatDb(db)
+      const dataProvider = new CoreDataProvider(db)
+      const context = {
+        sessionId: 'chart-test-session',
+        locale: 'en-US',
+        dataProvider,
+      }
+      const beforeCount = (db.prepare('SELECT COUNT(*) AS count FROM message').get() as { count: number }).count
+
+      await assert.rejects(
+        async () =>
+          renderChartTool.handler(
+            {
+              sql: `
+                WITH victim AS (SELECT id FROM message LIMIT 1)
+                DELETE FROM message WHERE id IN (SELECT id FROM victim)
+              `,
+              chartSpec: {
+                version: 1,
+                type: 'bar',
+                title: 'Should not render',
+                encoding: { x: 'name', y: 'message_count' },
+              },
+            },
+            context
+          ),
+        /READ-ONLY|read-only|not authorized|readonly|SELECT|syntax/i
+      )
+
+      const afterCount = (db.prepare('SELECT COUNT(*) AS count FROM message').get() as { count: number }).count
+      assert.equal(afterCount, beforeCount)
+    } finally {
+      db.close()
+      rmSync(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
+    }
+  })
+})

--- a/tests/chart-smoke/index.html
+++ b/tests/chart-smoke/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Chart Smoke</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/tests/chart-smoke/src/main.ts
+++ b/tests/chart-smoke/src/main.ts
@@ -1,0 +1,122 @@
+import { createApp, h } from 'vue'
+import type { ChartPayload } from '@openchatlab/core'
+import ChartBlockRenderer from '../../../src/components/AIChat/chat/ChartBlockRenderer.vue'
+import './style.css'
+
+const charts: ChartPayload[] = [
+  {
+    version: 1,
+    spec: {
+      version: 1,
+      type: 'bar',
+      title: 'Messages by member',
+      encoding: { x: 'name', y: 'message_count' },
+    },
+    dataset: {
+      columns: [
+        { name: 'name', type: 'category' },
+        { name: 'message_count', type: 'integer' },
+      ],
+      rows: [
+        { name: 'Alice', message_count: 8 },
+        { name: 'Bob', message_count: 5 },
+        { name: 'Cara', message_count: 3 },
+      ],
+    },
+    data: { labels: ['Alice', 'Bob', 'Cara'], values: [8, 5, 3] },
+    rowCount: 3,
+  },
+  {
+    version: 1,
+    spec: {
+      version: 1,
+      type: 'line',
+      title: 'Daily member trend',
+      encoding: { x: 'day', y: 'message_count', series: 'member_name' },
+    },
+    dataset: {
+      columns: [
+        { name: 'day', type: 'date' },
+        { name: 'member_name', type: 'category' },
+        { name: 'message_count', type: 'integer' },
+      ],
+      rows: [
+        { day: '2026-06-01', member_name: 'Alice', message_count: 3 },
+        { day: '2026-06-02', member_name: 'Alice', message_count: 5 },
+        { day: '2026-06-01', member_name: 'Bob', message_count: 2 },
+        { day: '2026-06-02', member_name: 'Bob', message_count: 4 },
+      ],
+    },
+    data: {
+      labels: ['2026-06-01', '2026-06-02'],
+      values: [3, 5],
+      series: [
+        { name: 'Alice', values: [3, 5] },
+        { name: 'Bob', values: [2, 4] },
+      ],
+    },
+    rowCount: 4,
+  },
+  {
+    version: 1,
+    spec: {
+      version: 1,
+      type: 'pie',
+      title: 'Selected members',
+      encoding: { label: 'name', value: 'message_count' },
+    },
+    dataset: {
+      columns: [
+        { name: 'name', type: 'category' },
+        { name: 'message_count', type: 'integer' },
+      ],
+      rows: [
+        { name: 'Alice', message_count: 8 },
+        { name: 'Bob', message_count: 5 },
+      ],
+    },
+    data: { labels: ['Alice', 'Bob'], values: [8, 5] },
+    rowCount: 2,
+  },
+  {
+    version: 1,
+    spec: {
+      version: 1,
+      type: 'heatmap',
+      title: 'Weekday hour density',
+      encoding: { x: 'hour', y: 'weekday', value: 'message_count' },
+    },
+    dataset: {
+      columns: [
+        { name: 'hour', type: 'integer' },
+        { name: 'weekday', type: 'category' },
+        { name: 'message_count', type: 'integer' },
+      ],
+      rows: [
+        { hour: '09', weekday: 'Mon', message_count: 3 },
+        { hour: '10', weekday: 'Mon', message_count: 5 },
+        { hour: '09', weekday: 'Tue', message_count: 2 },
+      ],
+    },
+    data: {
+      xLabels: ['09', '10'],
+      yLabels: ['Mon', 'Tue'],
+      data: [
+        [0, 0, 3],
+        [1, 0, 5],
+        [0, 1, 2],
+      ],
+    },
+    rowCount: 3,
+  },
+]
+
+createApp({
+  render() {
+    return h(
+      'main',
+      { class: 'chart-smoke-shell' },
+      charts.map((chart) => h(ChartBlockRenderer, { key: chart.spec.title, chart }))
+    )
+  },
+}).mount('#app')

--- a/tests/chart-smoke/src/style.css
+++ b/tests/chart-smoke/src/style.css
@@ -1,0 +1,28 @@
+html,
+body,
+#app {
+  min-height: 100%;
+  margin: 0;
+}
+
+body {
+  background: #f7f8fb;
+  color: #111827;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    sans-serif;
+}
+
+.chart-smoke-shell {
+  box-sizing: border-box;
+  display: grid;
+  gap: 16px;
+  width: min(920px, calc(100vw - 32px));
+  margin: 0 auto;
+  padding: 24px 0;
+}

--- a/tests/chart-smoke/vite.config.mts
+++ b/tests/chart-smoke/vite.config.mts
@@ -1,0 +1,22 @@
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+
+const root = fileURLToPath(new URL('.', import.meta.url))
+const projectRoot = fileURLToPath(new URL('../..', import.meta.url))
+
+export default defineConfig({
+  root,
+  plugins: [vue()],
+  resolve: {
+    alias: {
+      '@': path.join(projectRoot, 'src'),
+      '@openchatlab/core': path.join(projectRoot, 'packages/core/src'),
+    },
+  },
+  build: {
+    outDir: path.join(projectRoot, 'tmp/chart-smoke-build'),
+    emptyOutDir: true,
+  },
+})


### PR DESCRIPTION
## Summary

Add a slash-activated, AI-driven chart capability for ChatLab. Users can activate the chart assistant from the `/` menu in AI chat, then ask natural-language questions to generate dynamic charts (bar, line, pie, heatmap) inline in the conversation.

## Key Changes

### Core Runtime
- **ChartSpec validation & normalization** (`packages/core/src/chart/`): shared chart schema, row-to-chart data normalization for bar/line/pie/heatmap
- **render_chart analysis tool** (`packages/tools/src/definitions/render-chart.ts`): AI calls this tool with SQL + ChartSpec; runtime validates SQL is read-only, wraps with outer LIMIT, executes query, normalizes data
- **get_schema core tool**: lets chart capability inspect database shape before generating SQL
- **Chart capability** (`packages/core/src/ai/chart-capability.ts`): synthetic skill that exposes render_chart + get_schema via shared allowlist

### SQL Safety
- Rejects non-SELECT / non-WITH statements before reaching the data provider
- Wraps every accepted query as `SELECT * FROM (...) AS chart_query LIMIT maxRows + 1`
- CTE-prefixed write attempts (e.g., `WITH ... DELETE`) are rejected

### Frontend
- **chart content block type** in ContentBlock union
- **ChartBlockRenderer.vue**: renders bar/line/pie/heatmap inline in AI chat messages
- **Slash menu activation**: chart capability appears as a compatible skill, single-use per message
- **Error block handling**: failed render_chart calls show visible error blocks
- **Chart payload persistence**: normalized render data saved via content_blocks JSON

### Cross-Platform
- Electron and CLI Web agent-stream-runners both handle chart capability tool allowlist
- Tool adapters preserve structured chart payloads in result details

### Bug Fix
- **EChart.vue init timing**: deferred initChart() to nextTick so container layout completes before ECharts reads width (was rendering 92px canvases instead of full-width)

### i18n
- render_chart and get_schema translations in 4 locales (zh-CN, zh-TW, ja-JP, en-US)

### Tests (26 passing)
- Core: ChartSpec validation, pie aggregation, multi-series line, heatmap, missing field rejection
- Tool: render_chart SQL safety, outer LIMIT, write rejection, row truncation
- Integration: real SQLite chat database with flexible SQL + ChartSpec payloads
- Agent flow: offline single-chart and multi-chart agent loop with fake model stream
- Frontend: chart payload extraction, render-only error blocks, skill store toggle
- Adapter: CLI Web chart payload preservation
- Smoke: Vite build harness + headless Edge screenshot verification

## Product Behavior

- User types / in chat input, selects chart capability, asks a chart question
- AI generates read-only SQL + ChartSpec, ChatLab validates, executes, normalizes
- Chart renders inline in AI response, like a Markdown content block
- Chart count follows user request (1 chart by default, more if asked)
- Capability is single-use: clears after sending the message

## Remaining Work

- [ ] Run real external LLM E2E test with live API key
- [ ] Full in-app Electron UI smoke test with real chat data