### PR TITLE
feat(ai): upgrade MiniMax default model to M3

### DIFF
--- a/packages/core/src/ai/model-catalog.ts
+++ b/packages/core/src/ai/model-catalog.ts
@@ -827,10 +827,20 @@ const XAI_MODELS: ModelDefinition[] = [
 
 const MINIMAX_MODELS: ModelDefinition[] = [
   builtin({
+    id: 'MiniMax-M3',
+    providerId: 'minimax',
+    name: 'MiniMax M3',
+    description: 'Latest flagship, 512K context, 128K max output, vision',
+    contextWindow: 512000,
+    capabilities: ['chat', 'vision', 'function_calling'],
+    recommendedFor: ['chat'],
+    status: 'stable',
+  }),
+  builtin({
     id: 'MiniMax-M2.7',
     providerId: 'minimax',
     name: 'MiniMax M2.7',
-    description: 'Latest flagship model',
+    description: 'Previous generation flagship',
     contextWindow: 200000,
     capabilities: ['chat', 'function_calling'],
     recommendedFor: ['chat'],
@@ -844,26 +854,6 @@ const MINIMAX_MODELS: ModelDefinition[] = [
     contextWindow: 200000,
     capabilities: ['chat', 'function_calling'],
     recommendedFor: ['chat'],
-    status: 'stable',
-  }),
-  builtin({
-    id: 'MiniMax-M2.5',
-    providerId: 'minimax',
-    name: 'MiniMax M2.5',
-    description: 'M2.5 standard',
-    contextWindow: 204800,
-    capabilities: ['chat', 'function_calling'],
-    recommendedFor: [],
-    status: 'stable',
-  }),
-  builtin({
-    id: 'MiniMax-M2.5-highspeed',
-    providerId: 'minimax',
-    name: 'MiniMax M2.5 HS',
-    description: 'M2.5 high-speed',
-    contextWindow: 204800,
-    capabilities: ['chat', 'function_calling'],
-    recommendedFor: [],
     status: 'stable',
   }),
 ]

--- a/packages/core/src/ai/provider-registry.ts
+++ b/packages/core/src/ai/provider-registry.ts
@@ -245,7 +245,7 @@ const MINIMAX: ProviderDefinition = {
   supportsCustomModels: true,
   builtin: true,
   enabledByDefault: true,
-  modelIds: ['MiniMax-M2.7', 'MiniMax-M2.7-highspeed', 'MiniMax-M2.5', 'MiniMax-M2.5-highspeed'],
+  modelIds: ['MiniMax-M3', 'MiniMax-M2.7', 'MiniMax-M2.7-highspeed'],
 }
 
 const OPENAI_COMPATIBLE: ProviderDefinition = {

--- a/src/i18n/locales/en-US/providers.json
+++ b/src/i18n/locales/en-US/providers.json
@@ -24,8 +24,9 @@
   "minimax": {
     "name": "MiniMax",
     "models": {
-      "MiniMax-M2": "Flagship model",
-      "MiniMax-M2-Stable": "Stable version"
+      "MiniMax-M3": "Latest flagship, 512K context, 128K max output, vision",
+      "MiniMax-M2.7": "Previous generation flagship",
+      "MiniMax-M2.7-highspeed": "M2.7 high-speed"
     }
   },
   "glm": {

--- a/src/i18n/locales/ja-JP/providers.json
+++ b/src/i18n/locales/ja-JP/providers.json
@@ -24,8 +24,9 @@
   "minimax": {
     "name": "MiniMax",
     "models": {
-      "MiniMax-M2": "フラッグシップモデル",
-      "MiniMax-M2-Stable": "安定版"
+      "MiniMax-M3": "最新フラッグシップ、512K コンテキスト、最大出力 128K、画像入力対応",
+      "MiniMax-M2.7": "前世代フラッグシップ",
+      "MiniMax-M2.7-highspeed": "M2.7 高速版"
     }
   },
   "glm": {

--- a/src/i18n/locales/zh-CN/providers.json
+++ b/src/i18n/locales/zh-CN/providers.json
@@ -24,8 +24,9 @@
   "minimax": {
     "name": "MiniMax",
     "models": {
-      "MiniMax-M2": "旗舰模型",
-      "MiniMax-M2-Stable": "稳定版本"
+      "MiniMax-M3": "最新旗舰模型，512K 上下文，最大输出 128K，支持图片输入",
+      "MiniMax-M2.7": "上一代旗舰模型",
+      "MiniMax-M2.7-highspeed": "M2.7 高速版"
     }
   },
   "glm": {

--- a/src/i18n/locales/zh-TW/providers.json
+++ b/src/i18n/locales/zh-TW/providers.json
@@ -24,8 +24,9 @@
   "minimax": {
     "name": "MiniMax",
     "models": {
-      "MiniMax-M2": "旗艦模型",
-      "MiniMax-M2-Stable": "穩定版本"
+      "MiniMax-M3": "最新旗艦模型，512K 上下文，最大輸出 128K，支援圖片輸入",
+      "MiniMax-M2.7": "上一代旗艦模型",
+      "MiniMax-M2.7-highspeed": "M2.7 高速版"
     }
   },
   "glm": {


### PR DESCRIPTION
## Summary

Upgrade the built-in MiniMax provider configuration to make **MiniMax-M3** the
default model.

## Changes

- `packages/core/src/ai/model-catalog.ts` — add `MiniMax-M3` (512K context,
  128K max output, vision-capable) as the first entry of `MINIMAX_MODELS`;
  demote `MiniMax-M2.7` description to "Previous generation flagship"; remove
  the older `MiniMax-M2.5` / `MiniMax-M2.5-highspeed` entries.
- `packages/core/src/ai/provider-registry.ts` — put `MiniMax-M3` first in the
  provider's `modelIds`, drop the M2.5 ids; M2.7 + M2.7-highspeed are kept.
- `src/i18n/locales/{en-US,zh-CN,zh-TW,ja-JP}/providers.json` — refresh the
  stale `MiniMax-M2` / `MiniMax-M2-Stable` description rows so they match the
  models that are actually exposed by the catalog now.

## Why

MiniMax-M3 is the current flagship from MiniMax AI. Compared with M2.7 it
brings a 512K context window, up to 128K of output, and supports image input
on the OpenAI-compatible API. Putting it first makes it the default
selection in the provider picker, while keeping M2.7 and M2.7-highspeed for
users who still want them. The older M2.5 models are dropped because
upstream has deprecated them.

`packages/core/src/ai/thinking.ts` already classifies `minimax-m[123]` as
`deepseek_hybrid`, so M3 inherits the existing thinking-level handling
without any change to that file.

## Test plan

- [x] `git diff` reviewed — only the four catalog/registry/i18n touch points
  changed, no unrelated edits.
- [ ] Manual: open Settings → AI → MiniMax in a desktop build, confirm M3 is
  listed first and selected by default; send a chat with M3 and confirm
  reply, then switch to M2.7 and confirm it still works.