### PR TITLE
fix(analysis): filter reply placeholders from catchphrases

### DIFF
--- a/packages/core/src/query/advanced/languagePreference.ts
+++ b/packages/core/src/query/advanced/languagePreference.ts
@@ -106,6 +106,8 @@ export function getLanguagePreferenceAnalysis(db: DatabaseAdapter, params: Langu
 
   const memberMessages = new Map<number, { name: string; messages: string[] }>()
   for (const row of rows) {
+    if (isSystemPlaceholderContent(row.content)) continue
+
     let entry = memberMessages.get(row.memberId)
     if (!entry) {
       entry = { name: row.name, messages: [] }
@@ -134,7 +136,6 @@ export function getLanguagePreferenceAnalysis(db: DatabaseAdapter, params: Langu
       punct.tilde += countMatches(content, RE_TILDE)
       punct.period += countMatches(content, RE_PERIOD)
       const trimmed = content.trim()
-      if (isSystemPlaceholderContent(trimmed)) continue
 
       if (trimmed.length > 0 && !RE_ENDS_WITH_PUNCT.test(trimmed)) punct.noPunct++
       punct.total++

--- a/packages/core/src/query/advanced/languagePreference.ts
+++ b/packages/core/src/query/advanced/languagePreference.ts
@@ -8,6 +8,7 @@
 import type { TimeFilter } from '@openchatlab/shared-types'
 import type { DatabaseAdapter } from '../../interfaces'
 import { buildTimeFilter } from '../filters'
+import { isSystemPlaceholderContent } from './text-filters'
 
 // ==================== NLP Provider 接口 ====================
 
@@ -133,6 +134,8 @@ export function getLanguagePreferenceAnalysis(db: DatabaseAdapter, params: Langu
       punct.tilde += countMatches(content, RE_TILDE)
       punct.period += countMatches(content, RE_PERIOD)
       const trimmed = content.trim()
+      if (isSystemPlaceholderContent(trimmed)) continue
+
       if (trimmed.length > 0 && !RE_ENDS_WITH_PUNCT.test(trimmed)) punct.noPunct++
       punct.total++
 

--- a/packages/core/src/query/advanced/repeat.test.ts
+++ b/packages/core/src/query/advanced/repeat.test.ts
@@ -59,12 +59,15 @@ describe('getLanguagePreferenceAnalysis', () => {
     const db = createRowsDb([
       { memberId: 1, name: 'Alice', content: '[回复消息]' },
       { memberId: 1, name: 'Alice', content: '[回复消息]' },
-      { memberId: 1, name: 'Alice', content: 'noted' },
-      { memberId: 1, name: 'Alice', content: 'noted' },
+      { memberId: 2, name: 'Bob', content: 'noted' },
+      { memberId: 2, name: 'Bob', content: 'noted' },
     ])
 
     const result = getLanguagePreferenceAnalysis(db, { locale: 'en-US' })
 
+    assert.equal(result.members.length, 1)
+    assert.equal(result.members[0]?.name, 'Bob')
+    assert.equal(result.members[0]?.totalMessages, 2)
     assert.deepEqual(result.members[0]?.catchphrases, [{ content: 'noted', count: 2 }])
   })
 })

--- a/packages/core/src/query/advanced/repeat.test.ts
+++ b/packages/core/src/query/advanced/repeat.test.ts
@@ -1,0 +1,70 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import type { DatabaseAdapter, PreparedStatement } from '../../interfaces'
+import { getLanguagePreferenceAnalysis } from './languagePreference'
+import { getCatchphraseAnalysis } from './repeat'
+
+interface MockRow {
+  [key: string]: unknown
+  memberId: number
+  platformId?: string
+  name: string
+  content: string
+  count?: number
+}
+
+function createRowsDb(rows: MockRow[]): DatabaseAdapter {
+  return {
+    prepare(): PreparedStatement {
+      return {
+        get() {
+          return undefined
+        },
+        all() {
+          return rows
+        },
+        run() {
+          return { changes: 0, lastInsertRowid: 0 }
+        },
+      }
+    },
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    exec() {},
+    transaction<T>(fn: () => T) {
+      return fn()
+    },
+    pragma() {
+      return undefined
+    },
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    close() {},
+  }
+}
+
+describe('getCatchphraseAnalysis', () => {
+  it('filters QQ reply placeholders from catchphrase results', () => {
+    const db = createRowsDb([
+      { memberId: 1, platformId: 'alice', name: 'Alice', content: '[回复消息]', count: 10 },
+      { memberId: 1, platformId: 'alice', name: 'Alice', content: '收到', count: 3 },
+    ])
+
+    const result = getCatchphraseAnalysis(db)
+
+    assert.deepEqual(result.members[0]?.catchphrases, [{ content: '收到', count: 3 }])
+  })
+})
+
+describe('getLanguagePreferenceAnalysis', () => {
+  it('filters QQ reply placeholders from phrase frequency results', () => {
+    const db = createRowsDb([
+      { memberId: 1, name: 'Alice', content: '[回复消息]' },
+      { memberId: 1, name: 'Alice', content: '[回复消息]' },
+      { memberId: 1, name: 'Alice', content: 'noted' },
+      { memberId: 1, name: 'Alice', content: 'noted' },
+    ])
+
+    const result = getLanguagePreferenceAnalysis(db, { locale: 'en-US' })
+
+    assert.deepEqual(result.members[0]?.catchphrases, [{ content: 'noted', count: 2 }])
+  })
+})

--- a/packages/core/src/query/advanced/repeat.ts
+++ b/packages/core/src/query/advanced/repeat.ts
@@ -5,6 +5,7 @@
 import type { TimeFilter } from '@openchatlab/shared-types'
 import type { DatabaseAdapter } from '../../interfaces'
 import { buildTimeFilter } from '../filters'
+import { isSystemPlaceholderContent } from './text-filters'
 
 export interface CatchphraseItem {
   content: string
@@ -61,6 +62,8 @@ export function getCatchphraseAnalysis(db: DatabaseAdapter, filter?: TimeFilter)
   const memberMap = new Map<number, MemberCatchphrase>()
 
   for (const row of rows) {
+    if (isSystemPlaceholderContent(row.content)) continue
+
     if (!memberMap.has(row.memberId)) {
       memberMap.set(row.memberId, {
         memberId: row.memberId,

--- a/packages/core/src/query/advanced/text-filters.ts
+++ b/packages/core/src/query/advanced/text-filters.ts
@@ -1,0 +1,28 @@
+const SYSTEM_PLACEHOLDER_CONTENTS = new Set([
+  '[图片]',
+  '[视频]',
+  '[语音]',
+  '[文件]',
+  '[动画表情]',
+  '[表情]',
+  '[链接]',
+  '[位置]',
+  '[地理位置]',
+  '[名片]',
+  '[红包]',
+  '[转账]',
+  '[音乐]',
+  '[回复消息]',
+  '[Image]',
+  '[Photo]',
+  '[Video]',
+  '[Voice]',
+  '[File]',
+  '[Sticker]',
+  '[Link]',
+  '[Location]',
+])
+
+export function isSystemPlaceholderContent(content: string): boolean {
+  return SYSTEM_PLACEHOLDER_CONTENTS.has(content.trim())
+}


### PR DESCRIPTION
## Summary
- filter system placeholder-only messages such as `[回复消息]` out of catchphrase analysis
- reuse the same filter for language preference catchphrase frequency
- add focused regression coverage for the QQ reply placeholder case

Fixes #141

## Tests
- `pnpm exec prettier --check packages/core/src/query/advanced/text-filters.ts packages/core/src/query/advanced/repeat.ts packages/core/src/query/advanced/languagePreference.ts packages/core/src/query/advanced/repeat.test.ts`
- `pnpm exec eslint packages/core/src/query/advanced/text-filters.ts packages/core/src/query/advanced/repeat.ts packages/core/src/query/advanced/languagePreference.ts packages/core/src/query/advanced/repeat.test.ts`
- `node scripts/run-tests.mjs packages/core/src/query/advanced/repeat.test.ts`
- `pnpm run type-check:node`