### PR TITLE
fix(electron): address post-review issues from #229

### DIFF
--- a/apps/desktop/main/ai/tools/debug-executor.ts
+++ b/apps/desktop/main/ai/tools/debug-executor.ts
@@ -1,4 +1,5 @@
 import { stripAvatarFields } from '@openchatlab/core'
+import type { BatchSegmentOptions, SupportedLocale } from '@openchatlab/core'
 import type { AiToolExecuteRequest, AiToolExecuteResult } from '@openchatlab/http-routes'
 import { batchSegmentWithFrequency } from '@openchatlab/node-runtime'
 import { AGENT_TOOL_REGISTRY } from '@openchatlab/tools'
@@ -15,7 +16,7 @@ function assertNotAborted(signal: AbortSignal): void {
 }
 
 export async function executeElectronAiTool(params: AiToolExecuteRequest): Promise<AiToolExecuteResult> {
-  const { toolName, sessionId, abortSignal } = params
+  const { toolName, params: toolParams, sessionId, abortSignal } = params
   const entry = AGENT_TOOL_REGISTRY.find((tool) => tool.name === toolName)
   if (!entry) {
     return { success: false, error: `Tool not found: ${toolName}` }
@@ -27,7 +28,8 @@ export async function executeElectronAiTool(params: AiToolExecuteRequest): Promi
       sessionId,
       abortSignal,
       dataProvider: new WorkerDataProvider(sessionId, abortSignal),
-      segmentText: (texts, locale, options) => batchSegmentWithFrequency(texts, locale as any, options as any),
+      segmentText: (texts, locale, options) =>
+        batchSegmentWithFrequency(texts, locale as SupportedLocale, options as BatchSegmentOptions),
       translateTemplate: (key: string) => {
         const translated = i18nT(key)
         return translated !== key ? translated : undefined
@@ -35,7 +37,7 @@ export async function executeElectronAiTool(params: AiToolExecuteRequest): Promi
     }
 
     const startTime = Date.now()
-    const result = await entry.handler(params.params, execCtx)
+    const result = await entry.handler(toolParams, execCtx)
     const elapsed = Date.now() - startTime
     assertNotAborted(abortSignal)
 

--- a/apps/desktop/main/worker/workerManager.ts
+++ b/apps/desktop/main/worker/workerManager.ts
@@ -246,6 +246,7 @@ function sendToWorkerWithProgress<T>(
       }
     }
 
+    const requestWorker = worker!
     const id = `req_${++requestIdCounter}`
 
     const timeout = setTimeout(() => {
@@ -257,7 +258,7 @@ function sendToWorkerWithProgress<T>(
 
     pendingRequests.set(id, { resolve, reject, timeout, restartOnTimeout: false, onProgress })
 
-    worker!.postMessage({ id, type, payload })
+    requestWorker.postMessage({ id, type, payload })
   })
 }
 


### PR DESCRIPTION
- capture worker reference in sendToWorkerWithProgress to match sendToWorker and avoid stale-closure risk on worker restart
- replace `as any` casts with typed SupportedLocale / BatchSegmentOptions assertions in debug-executor
- destructure params.params as toolParams to remove unused testId binding