### PR TITLE
feat(logging): add unified app logger with file rotation and global e…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,13 @@
 
 - 多语言：代码中的日志、注释、AI 工具描述、错误消息等非 UI 文本默认使用英文。当有运行时 locale 可用时（如工具返回结果、AI 看到的文本），应通过 `isChineseLocale(locale)` 等机制支持中英双语。数据清洗中与聊天平台格式匹配的标签（如 `[分享]`、`[图片]`）保持原始语言不变。UI 文案的国际化遵循 `.docs/rules/i18n.md`
 
+## 日志
+
+- 统一入口：Node 侧（Electron 主进程 / CLI / CLI Web）通过 `@openchatlab/node-runtime` 的 `appLogger`（`appLogger.info/warn/error/debug(scope, message, data?)`）落盘到 `logs/app.log`；前端（Vue）通过 `src/services/log-report.ts` 经 `POST /_web/logs/report` 上报。不要为通用日志新写 `fs.appendFileSync` 或新的 logger 文件；AI 用 `AiLogger`、导入性能用 `perf-logger` 保持现状。
+- **新增或修改功能时必须补必要日志**：关键路径要留下足够的可排查痕迹——成功节点用 `info`（如启动、迁移、数据库/配置变更、导入开始/完成、外部调用、auth 结果），失败分支用 `error` 并把 `Error` 直接作为 `data` 传入（自动提取 message/stack）。判断标准：用户带着这个功能报问题时，仅凭 `logs/app.log` 能否还原到出错的那一步；不能，就说明日志不够。
+- 适度原则：不要在高频热路径或循环里打 `info`，详细诊断用 `debug`（默认 `INFO` 级不落盘，`CHATLAB_LOG_LEVEL=debug` 开启）；日志、注释等非 UI 文本用英文，且**不得写入聊天明文、API Key、token 等隐私数据**。
+- 级别与轮转：`app.log` 达 10MB 自动原子 rename 为 `app.old.log`，无需手动清理。
+
 ## 架构边界
 
 - 多端复用：维护 Electron 和 CLI Web 的共享业务逻辑时，优先在 `packages/node-runtime/src/services/` 下实现，禁止在路由/IPC handler 中绕过 core 直接写 SQL。详见 `.docs/README.md` 的"多端逻辑复用"章节。

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -15,6 +15,8 @@ import {
   applyPendingNodeDataDirMigrationIfNeeded,
   hasPendingElectronDataWarning,
   verifyCliDataPath,
+  initAppLogger,
+  appLogger,
 } from '@openchatlab/node-runtime'
 import {
   getSessionMeta,
@@ -484,6 +486,7 @@ program
 
     console.log('\nChatLab Status')
     console.log('─'.repeat(36))
+    console.log(`  Logs:       ${new NodePathProvider().getLogsDir()}`)
 
     if (svc.installed) {
       const portStr = svc.port ? `http://${svc.host ?? '127.0.0.1'}:${svc.port}` : ''
@@ -607,6 +610,16 @@ function printTable(columns: string[], rows: Record<string, unknown>[]): void {
 
 /** CLI entry function */
 export function run(argv?: string[]): void {
+  // Logs go to ~/.chatlab/logs/app.log regardless of configured user data dir.
+  initAppLogger(new NodePathProvider().getLogsDir())
+  process.on('uncaughtException', (error) => {
+    console.error('Uncaught Exception:', error)
+    appLogger.error('crash', 'uncaughtException', error)
+  })
+  process.on('unhandledRejection', (reason) => {
+    console.error('Unhandled Rejection:', reason)
+    appLogger.error('crash', 'unhandledRejection', reason)
+  })
   program.parse(argv)
 }
 

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -17,6 +17,7 @@ import {
   verifyCliDataPath,
   initAppLogger,
   appLogger,
+  getSystemLogsDir,
 } from '@openchatlab/node-runtime'
 import {
   getSessionMeta,
@@ -486,7 +487,7 @@ program
 
     console.log('\nChatLab Status')
     console.log('─'.repeat(36))
-    console.log(`  Logs:       ${new NodePathProvider().getLogsDir()}`)
+    console.log(`  Logs:       ${getSystemLogsDir()}`)
 
     if (svc.installed) {
       const portStr = svc.port ? `http://${svc.host ?? '127.0.0.1'}:${svc.port}` : ''
@@ -611,14 +612,16 @@ function printTable(columns: string[], rows: Record<string, unknown>[]): void {
 /** CLI entry function */
 export function run(argv?: string[]): void {
   // Logs go to ~/.chatlab/logs/app.log regardless of configured user data dir.
-  initAppLogger(new NodePathProvider().getLogsDir())
+  initAppLogger(getSystemLogsDir())
   process.on('uncaughtException', (error) => {
     console.error('Uncaught Exception:', error)
     appLogger.error('crash', 'uncaughtException', error)
+    process.exit(1)
   })
   process.on('unhandledRejection', (reason) => {
     console.error('Unhandled Rejection:', reason)
     appLogger.error('crash', 'unhandledRejection', reason)
+    process.exit(1)
   })
   program.parse(argv)
 }

--- a/apps/cli/src/http/index.ts
+++ b/apps/cli/src/http/index.ts
@@ -21,6 +21,8 @@ import {
   hasPendingElectronDataWarning,
   verifyCliDataPath,
   createSemanticIndexWorkerRuntimeClient,
+  initAppLogger,
+  appLogger,
 } from '@openchatlab/node-runtime'
 import type { ConfigStorage, SemanticIndexRuntime } from '@openchatlab/node-runtime'
 import { createServer } from './server'
@@ -170,7 +172,9 @@ export async function startHttpServer(options?: HttpServerOptions): Promise<{
     },
   })
 
+  initAppLogger(pathProvider.getLogsDir())
   initServerAiLogger(pathProvider.getLogsDir())
+  appLogger.info('server', `HTTP server starting on ${host}:${port}`)
 
   setAuthToken(token)
   setRequireAuth(!!(options?.requireAuth ?? config.api.require_auth))

--- a/apps/cli/src/http/server.ts
+++ b/apps/cli/src/http/server.ts
@@ -13,6 +13,7 @@ import {
   errorResponse,
   serverError,
 } from '@openchatlab/http-routes'
+import { appLogger } from '@openchatlab/node-runtime'
 
 const JSON_BODY_LIMIT = 50 * 1024 * 1024 // 50MB
 
@@ -24,7 +25,7 @@ export function createServer(): FastifyInstance {
 
   server.addHook('onRequest', authHook)
 
-  server.setErrorHandler((error: FastifyError, _request, reply) => {
+  server.setErrorHandler((error: FastifyError, request, reply) => {
     const apiError = apiErrorFromUnknown(error)
     if (apiError) {
       reply.code(apiError.statusCode).send(errorResponse(apiError))
@@ -43,6 +44,7 @@ export function createServer(): FastifyInstance {
       return
     }
 
+    appLogger.error('http', `${request.method} ${request.url} -> 500`, error)
     const err = serverError(error.message)
     reply.code(err.statusCode).send(errorResponse(err))
   })

--- a/apps/desktop/main/api/logger.ts
+++ b/apps/desktop/main/api/logger.ts
@@ -1,66 +1,32 @@
 /**
- * ChatLab API — Dedicated logger
- * Writes to userData/logs/api.log alongside app.log
+ * ChatLab API logger (Electron main).
+ *
+ * Delegates to the shared appLogger with scope 'api', written into the unified
+ * logs/app.log. Exported shape kept for existing call sites.
  */
 
-import * as fs from 'fs'
-import * as path from 'path'
-import { getPathProvider } from '../path-context'
-import { ensureDir } from '../paths'
+import { initAppLogger, appLogger } from '@openchatlab/node-runtime'
+import { getLogsDir } from '../paths'
 
-let headerWritten = false
+let initialized = false
 
-function getLogPath(): string {
-  return path.join(getPathProvider().getLogsDir(), 'api.log')
-}
-
-function formatPathForLog(filePath: string): string {
-  return filePath.replace(/ /g, '\\ ')
-}
-
-function ensureHeader(): void {
-  if (headerWritten) return
-  headerWritten = true
-  try {
-    const logPath = getLogPath()
-    ensureDir(getPathProvider().getLogsDir())
-    const isNew = !fs.existsSync(logPath) || fs.statSync(logPath).size === 0
-    if (isNew) {
-      fs.writeFileSync(logPath, `Local Path:  ${formatPathForLog(logPath)}\n\n`, 'utf-8')
-    }
-  } catch {
-    // silent
-  }
-}
-
-function formatTime(): string {
-  const now = new Date()
-  const y = now.getFullYear()
-  const M = String(now.getMonth() + 1).padStart(2, '0')
-  const d = String(now.getDate()).padStart(2, '0')
-  const h = String(now.getHours()).padStart(2, '0')
-  const m = String(now.getMinutes()).padStart(2, '0')
-  const s = String(now.getSeconds()).padStart(2, '0')
-  return `${y}-${M}-${d} ${h}:${m}:${s}`
-}
-
-function write(level: string, message: string, detail?: unknown): void {
-  try {
-    ensureHeader()
-    let line = `[${formatTime()}] [${level}] ${message}`
-    if (detail !== undefined) {
-      const extra = detail instanceof Error ? detail.stack || detail.message : JSON.stringify(detail)
-      line += `  ${extra}`
-    }
-    line += '\n'
-    fs.appendFileSync(getLogPath(), line, 'utf-8')
-  } catch {
-    // silent — never let logging break the app
-  }
+function ensureInit(): void {
+  if (initialized) return
+  initialized = true
+  initAppLogger(getLogsDir())
 }
 
 export const apiLogger = {
-  info: (msg: string, detail?: unknown) => write('INFO', msg, detail),
-  warn: (msg: string, detail?: unknown) => write('WARN', msg, detail),
-  error: (msg: string, detail?: unknown) => write('ERROR', msg, detail),
+  info: (msg: string, detail?: unknown) => {
+    ensureInit()
+    appLogger.info('api', msg, detail)
+  },
+  warn: (msg: string, detail?: unknown) => {
+    ensureInit()
+    appLogger.warn('api', msg, detail)
+  },
+  error: (msg: string, detail?: unknown) => {
+    ensureInit()
+    appLogger.error('api', msg, detail)
+  },
 }

--- a/apps/desktop/main/index.ts
+++ b/apps/desktop/main/index.ts
@@ -6,6 +6,7 @@ import mainIpcMain, { cleanup } from './ipcMain'
 import { startInternalServer, stopInternalServer, registerInternalApiIpc } from './internal-api'
 import { getPathProvider } from './path-context'
 import { initAnalytics } from './analytics'
+import { logger } from './logger'
 import { initProxy } from './network/proxy'
 import {
   needsLegacyMigration,
@@ -97,6 +98,7 @@ class MainProcess {
   // 初始化程序
   async init() {
     initAnalytics()
+    logger.info('Desktop app starting')
 
     // E2E 测试模式：跳过遗留数据迁移
     // 遗留迁移会删除 Documents/ChatLab，在本地测试时可能破坏用户数据
@@ -421,9 +423,18 @@ class MainProcess {
   }
 }
 
-// 捕获未捕获的异常
+// 捕获未捕获的异常与未处理的 Promise 拒绝，落盘到 logs/app.log 便于排查
 process.on('uncaughtException', (error) => {
   console.error('Uncaught Exception:', error)
+  logger.error(
+    `Uncaught Exception: ${error instanceof Error ? `${error.message}\n${error.stack ?? ''}` : String(error)}`
+  )
+})
+process.on('unhandledRejection', (reason) => {
+  console.error('Unhandled Rejection:', reason)
+  logger.error(
+    `Unhandled Rejection: ${reason instanceof Error ? `${reason.message}\n${reason.stack ?? ''}` : String(reason)}`
+  )
 })
 
 new MainProcess()

--- a/apps/desktop/main/index.ts
+++ b/apps/desktop/main/index.ts
@@ -429,12 +429,14 @@ process.on('uncaughtException', (error) => {
   logger.error(
     `Uncaught Exception: ${error instanceof Error ? `${error.message}\n${error.stack ?? ''}` : String(error)}`
   )
+  process.exit(1)
 })
 process.on('unhandledRejection', (reason) => {
   console.error('Unhandled Rejection:', reason)
   logger.error(
     `Unhandled Rejection: ${reason instanceof Error ? `${reason.message}\n${reason.stack ?? ''}` : String(reason)}`
   )
+  process.exit(1)
 })
 
 new MainProcess()

--- a/apps/desktop/main/internal-api.ts
+++ b/apps/desktop/main/internal-api.ts
@@ -24,6 +24,7 @@ import {
   raiseChatDbCompatibilityGate,
   streamingImport,
   createSemanticIndexWorkerRuntimeClient,
+  appLogger,
 } from '@openchatlab/node-runtime'
 import type { StreamImportDeps, SemanticIndexRuntime } from '@openchatlab/node-runtime'
 import { getLoadablePath as getSqliteVecLoadablePath } from 'sqlite-vec'
@@ -225,7 +226,7 @@ export async function startInternalServer(pathProvider: PathProvider): Promise<I
 
     newServer.addHook('onRequest', createInternalAuthHook(token))
 
-    newServer.setErrorHandler((error: FastifyError, _request, reply) => {
+    newServer.setErrorHandler((error: FastifyError, request, reply) => {
       const apiError = apiErrorFromUnknown(error)
       if (apiError) {
         reply.code(apiError.statusCode).send(errorResponse(apiError))
@@ -241,6 +242,7 @@ export async function startInternalServer(pathProvider: PathProvider): Promise<I
         reply.code(statusCode).send({ success: false, error: { code: 'CLIENT_ERROR', message: error.message } })
         return
       }
+      appLogger.error('http', `${request.method} ${request.url} -> 500`, error)
       const err = serverError(error.message)
       reply.code(err.statusCode).send(errorResponse(err))
     })

--- a/apps/desktop/main/logger.ts
+++ b/apps/desktop/main/logger.ts
@@ -1,57 +1,36 @@
 /**
- * 简单的日志工具
- * 日志保存到 userData/logs/ 目录
+ * General app logger (Electron main).
+ *
+ * Thin wrapper over the shared node-runtime appLogger so all runtimes write to
+ * the same rolling `logs/app.log`. Exported shape kept for existing call sites.
  */
 
-import * as fs from 'fs'
-import * as path from 'path'
-import { getLogsDir, ensureDir } from './paths'
+import { initAppLogger, appLogger } from '@openchatlab/node-runtime'
+import { getLogsDir } from './paths'
 
-// 日志目录
-function getLogDir(): string {
-  return getLogsDir()
+let initialized = false
+
+function ensureInit(): void {
+  if (initialized) return
+  initialized = true
+  initAppLogger(getLogsDir())
 }
 
-// 日志文件路径
-function getLogPath(): string {
-  return path.join(getLogDir(), 'app.log')
-}
-
-// 确保日志目录存在
-function ensureLogDir(): void {
-  ensureDir(getLogDir())
-}
-
-// 格式化时间
-function formatTime(): string {
-  const now = new Date()
-  const year = now.getFullYear()
-  const month = String(now.getMonth() + 1).padStart(2, '0')
-  const day = String(now.getDate()).padStart(2, '0')
-  const hour = String(now.getHours()).padStart(2, '0')
-  const minute = String(now.getMinutes()).padStart(2, '0')
-  const second = String(now.getSeconds()).padStart(2, '0')
-  return `${year}-${month}-${day} ${hour}:${minute}:${second}`
-}
-
-// 写入日志
-function writeLog(level: string, message: string): void {
-  try {
-    ensureLogDir()
-    const logLine = `[${formatTime()}] [${level}] ${message}\n`
-    fs.appendFileSync(getLogPath(), logLine, 'utf-8')
-  } catch (error) {
-    // 日志写入失败时静默处理，避免影响主程序
-    console.error('[Logger] Failed to write log:', error)
-  }
-}
-
-/**
- * 日志工具
- */
 export const logger = {
-  info: (message: string) => writeLog('INFO', message),
-  warn: (message: string) => writeLog('WARN', message),
-  error: (message: string) => writeLog('ERROR', message),
-  debug: (message: string) => writeLog('DEBUG', message),
+  info: (message: string) => {
+    ensureInit()
+    appLogger.info('app', message)
+  },
+  warn: (message: string) => {
+    ensureInit()
+    appLogger.warn('app', message)
+  },
+  error: (message: string) => {
+    ensureInit()
+    appLogger.error('app', message)
+  },
+  debug: (message: string) => {
+    ensureInit()
+    appLogger.debug('app', message)
+  },
 }

--- a/packages/http-routes/src/register.ts
+++ b/packages/http-routes/src/register.ts
@@ -30,6 +30,7 @@ import { registerSemanticIndexRoutes } from './routes/web/ai-semantic-index'
 import { registerMergeRoutes } from './routes/web/merge'
 import { registerCacheRoutes } from './routes/web/cache'
 import { registerTelemetryRoutes } from './routes/web/telemetry'
+import { registerLogRoutes } from './routes/web/logs'
 
 export interface SharedRouteOptions {
   /** When true, AI routes will throw on missing dependencies instead of silently skipping */
@@ -94,4 +95,7 @@ export function registerSharedRoutes(
 
   // Telemetry routes
   registerTelemetryRoutes(server, resolvedCtx)
+
+  // Front-end log report + open logs dir
+  registerLogRoutes(server, resolvedCtx)
 }

--- a/packages/http-routes/src/routes/web/logs.test.ts
+++ b/packages/http-routes/src/routes/web/logs.test.ts
@@ -1,0 +1,52 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import Fastify from 'fastify'
+import { initAppLogger } from '@openchatlab/node-runtime'
+import type { HttpRouteContext } from '../../context'
+import { registerLogRoutes } from './logs'
+
+function ctxWith(logsDir: string): HttpRouteContext {
+  return { pathProvider: { getLogsDir: () => logsDir } } as unknown as HttpRouteContext
+}
+
+describe('logs routes', () => {
+  it('appends front-end error report to app.log', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'logsroute-'))
+    initAppLogger(dir)
+    const app = Fastify()
+    registerLogRoutes(app, ctxWith(dir))
+    await app.ready()
+    try {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/_web/logs/report',
+        payload: { level: 'error', message: 'boom', stack: 'at x', url: 'http://app/page' },
+      })
+      assert.equal(res.statusCode, 200)
+      const content = fs.readFileSync(path.join(dir, 'app.log'), 'utf-8')
+      assert.match(content, /\[ERROR\] \[web\] boom/)
+      assert.match(content, /url=http:\/\/app\/page/)
+    } finally {
+      await app.close()
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects report without message', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'logsroute-'))
+    initAppLogger(dir)
+    const app = Fastify()
+    registerLogRoutes(app, ctxWith(dir))
+    await app.ready()
+    try {
+      const res = await app.inject({ method: 'POST', url: '/_web/logs/report', payload: {} })
+      assert.equal(res.statusCode, 400)
+    } finally {
+      await app.close()
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/http-routes/src/routes/web/logs.ts
+++ b/packages/http-routes/src/routes/web/logs.ts
@@ -1,0 +1,26 @@
+import type { FastifyInstance } from 'fastify'
+import { appLogger } from '@openchatlab/node-runtime'
+import type { HttpRouteContext } from '../../context'
+
+interface LogReportBody {
+  level?: 'error' | 'warn'
+  message: string
+  stack?: string
+  url?: string
+}
+
+/**
+ * Front-end error report sink. The browser can't write files, so uncaught
+ * front-end errors are POSTed here and appended to logs/app.log (scope 'web').
+ */
+export function registerLogRoutes(server: FastifyInstance, _ctx: HttpRouteContext): void {
+  server.post<{ Body: LogReportBody }>('/_web/logs/report', async (req, reply) => {
+    const { level, message, stack, url } = req.body ?? ({} as LogReportBody)
+    if (!message) return reply.code(400).send({ error: 'message required' })
+
+    const detail = [url ? `url=${url}` : null, stack ? `\n${stack}` : null].filter(Boolean).join(' ')
+    if (level === 'warn') appLogger.warn('web', message, detail || undefined)
+    else appLogger.error('web', message, detail || undefined)
+    return { ok: true }
+  })
+}

--- a/packages/node-runtime/src/index.ts
+++ b/packages/node-runtime/src/index.ts
@@ -53,6 +53,8 @@ export { hasFtsTable, createFtsTable, buildFtsIndex, rebuildFtsIndex, insertFtsE
 export { AiLogger, extractErrorInfo, extractErrorStack, formatAIError } from './ai'
 export type { FormatAIErrorOptions } from './ai'
 
+// Unified application logger (general + key-path + crash logs)
+export { initAppLogger, appLogger } from './logging/app-logger'
 export {
   NodePathProvider,
   applyPendingNodeDataDirMigrationIfNeeded,

--- a/packages/node-runtime/src/index.ts
+++ b/packages/node-runtime/src/index.ts
@@ -59,6 +59,7 @@ export {
   NodePathProvider,
   applyPendingNodeDataDirMigrationIfNeeded,
   getDefaultNodeUserDataDir,
+  getSystemLogsDir,
   hasPendingElectronDataWarning,
 } from './node-path-provider'
 export { DatabaseManager } from './database-manager'

--- a/packages/node-runtime/src/logging/app-logger.test.ts
+++ b/packages/node-runtime/src/logging/app-logger.test.ts
@@ -1,0 +1,77 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+import { initAppLogger, appLogger } from './app-logger'
+
+function makeTempDir(): string {
+  const base = fs.existsSync('/private/tmp') ? '/private/tmp' : os.tmpdir()
+  return fs.mkdtempSync(path.join(base, 'applog-'))
+}
+
+function read(file: string): string {
+  return fs.existsSync(file) ? fs.readFileSync(file, 'utf-8') : ''
+}
+
+test('writes leveled lines with scope and extracts Error', () => {
+  const dir = makeTempDir()
+  delete process.env.CHATLAB_LOG_LEVEL
+  initAppLogger(dir)
+  appLogger.info('startup', 'app started')
+  appLogger.error('crash', 'boom', new Error('kaboom'))
+
+  const content = read(path.join(dir, 'app.log'))
+  assert.match(content, /\[INFO\] \[startup\] app started/)
+  assert.match(content, /\[ERROR\] \[crash\] boom/)
+  assert.match(content, /kaboom/)
+  fs.rmSync(dir, { recursive: true, force: true })
+})
+
+test('drops levels below threshold (INFO default skips DEBUG)', () => {
+  const dir = makeTempDir()
+  delete process.env.CHATLAB_LOG_LEVEL
+  initAppLogger(dir)
+  appLogger.debug('x', 'should be dropped')
+  appLogger.info('x', 'should be kept')
+
+  const content = read(path.join(dir, 'app.log'))
+  assert.ok(!content.includes('should be dropped'))
+  assert.ok(content.includes('should be kept'))
+  fs.rmSync(dir, { recursive: true, force: true })
+})
+
+test('CHATLAB_LOG_LEVEL=debug lets DEBUG through', () => {
+  const dir = makeTempDir()
+  process.env.CHATLAB_LOG_LEVEL = 'debug'
+  initAppLogger(dir)
+  appLogger.debug('x', 'verbose detail')
+  assert.ok(read(path.join(dir, 'app.log')).includes('verbose detail'))
+  delete process.env.CHATLAB_LOG_LEVEL
+  fs.rmSync(dir, { recursive: true, force: true })
+})
+
+test('rotates to app.old.log when app.log exceeds 10MB', () => {
+  const dir = makeTempDir()
+  delete process.env.CHATLAB_LOG_LEVEL
+  initAppLogger(dir)
+  const logFile = path.join(dir, 'app.log')
+  const oldFile = path.join(dir, 'app.old.log')
+
+  fs.writeFileSync(logFile, 'x'.repeat(10 * 1024 * 1024 + 1))
+  appLogger.info('rot', 'after rotation')
+
+  assert.ok(fs.existsSync(oldFile))
+  assert.ok(fs.statSync(oldFile).size > 10 * 1024 * 1024)
+  const content = read(logFile)
+  assert.ok(content.includes('after rotation'))
+  assert.ok(fs.statSync(logFile).size < 1024)
+  fs.rmSync(dir, { recursive: true, force: true })
+})
+
+test('creates nested logs dir on demand and never throws', () => {
+  const dir = makeTempDir()
+  initAppLogger(path.join(dir, 'a', 'b', 'c'))
+  assert.doesNotThrow(() => appLogger.info('x', 'nested'))
+  fs.rmSync(dir, { recursive: true, force: true })
+})

--- a/packages/node-runtime/src/logging/app-logger.ts
+++ b/packages/node-runtime/src/logging/app-logger.ts
@@ -1,0 +1,127 @@
+/**
+ * Unified application logger (platform-agnostic, Node side).
+ *
+ * Shared by Electron main process, CLI and CLI Web runtime. Writes general
+ * application/diagnostic logs to a single rolling file `<logsDir>/app.log`.
+ *
+ * Scope of this logger: general app + key-path + crash logs. AI logs (AiLogger)
+ * and import perf logs keep their own per-scenario files.
+ */
+
+import * as fs from 'fs'
+import * as path from 'path'
+import { extractErrorInfo, extractErrorStack } from '../ai/ai-logger'
+
+type LogLevel = 'DEBUG' | 'INFO' | 'WARN' | 'ERROR'
+
+const LEVEL_ORDER: Record<LogLevel, number> = { DEBUG: 0, INFO: 1, WARN: 2, ERROR: 3 }
+
+// Rotate when app.log reaches this size; old content moves to app.old.log.
+const MAX_SIZE_BYTES = 10 * 1024 * 1024 // 10MB
+
+class AppLogger {
+  private logFile: string
+  private oldLogFile: string
+  private threshold: LogLevel
+
+  constructor(logsDir: string) {
+    this.logFile = path.join(logsDir, 'app.log')
+    this.oldLogFile = path.join(logsDir, 'app.old.log')
+    this.threshold = resolveThreshold()
+  }
+
+  debug(scope: string, message: string, data?: unknown): void {
+    this.write('DEBUG', scope, message, data)
+  }
+
+  info(scope: string, message: string, data?: unknown): void {
+    this.write('INFO', scope, message, data)
+  }
+
+  warn(scope: string, message: string, data?: unknown): void {
+    this.write('WARN', scope, message, data)
+  }
+
+  /** `data` may be an Error; its name/message/stack are extracted automatically. */
+  error(scope: string, message: string, data?: unknown): void {
+    this.write('ERROR', scope, message, data)
+  }
+
+  getLogPath(): string {
+    return this.logFile
+  }
+
+  private write(level: LogLevel, scope: string, message: string, data?: unknown): void {
+    if (LEVEL_ORDER[level] < LEVEL_ORDER[this.threshold]) return
+
+    let line = `[${new Date().toISOString()}] [${level}] [${scope}] ${message}`
+    const tail = formatData(data)
+    if (tail) line += `\n${tail}`
+    line += '\n'
+
+    try {
+      ensureDir(path.dirname(this.logFile))
+      this.rotateIfNeeded()
+      fs.appendFileSync(this.logFile, line, 'utf-8')
+    } catch (err) {
+      // Logging must never break the app; surface to console only.
+      console.error('[AppLogger] Failed to write log:', err)
+    }
+  }
+
+  // ponytail: rename-based rotation, atomic, no rewrite, ~20MB total ceiling
+  private rotateIfNeeded(): void {
+    let size = 0
+    try {
+      size = fs.statSync(this.logFile).size
+    } catch {
+      return // file doesn't exist yet
+    }
+    if (size < MAX_SIZE_BYTES) return
+    fs.renameSync(this.logFile, this.oldLogFile) // overwrites previous .old, atomic
+  }
+}
+
+function resolveThreshold(): LogLevel {
+  const raw = (process.env.CHATLAB_LOG_LEVEL || '').toUpperCase()
+  if (raw === 'DEBUG' || raw === 'INFO' || raw === 'WARN' || raw === 'ERROR') return raw
+  return 'INFO'
+}
+
+function formatData(data: unknown): string {
+  if (data === undefined) return ''
+  if (data instanceof Error) {
+    const info = extractErrorInfo(data)
+    const stack = extractErrorStack(data)
+    return JSON.stringify(info) + (stack ? `\n${stack}` : '')
+  }
+  if (typeof data === 'string') return data
+  try {
+    return JSON.stringify(data)
+  } catch {
+    return '[unserializable data]'
+  }
+}
+
+function ensureDir(dir: string): void {
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true })
+}
+
+let instance: AppLogger | null = null
+
+/** Initialize the singleton app logger. Call once per runtime at startup. */
+export function initAppLogger(logsDir: string): void {
+  instance = new AppLogger(logsDir)
+}
+
+/**
+ * The shared logger. Safe to call before init: logs are dropped silently until
+ * `initAppLogger` runs (avoids ordering hazards at very early startup).
+ */
+export const appLogger = {
+  debug: (scope: string, message: string, data?: unknown) => instance?.debug(scope, message, data),
+  info: (scope: string, message: string, data?: unknown) => instance?.info(scope, message, data),
+  warn: (scope: string, message: string, data?: unknown) => instance?.warn(scope, message, data),
+  error: (scope: string, message: string, data?: unknown) => instance?.error(scope, message, data),
+  getLogPath: () => instance?.getLogPath() ?? null,
+}

--- a/packages/node-runtime/src/logging/app-logger.ts
+++ b/packages/node-runtime/src/logging/app-logger.ts
@@ -55,11 +55,11 @@ class AppLogger {
     if (LEVEL_ORDER[level] < LEVEL_ORDER[this.threshold]) return
 
     let line = `[${new Date().toISOString()}] [${level}] [${scope}] ${message}`
-    const tail = formatData(data)
-    if (tail) line += `\n${tail}`
-    line += '\n'
 
     try {
+      const tail = formatData(data)
+      if (tail) line += `\n${tail}`
+      line += '\n'
       ensureDir(path.dirname(this.logFile))
       this.rotateIfNeeded()
       fs.appendFileSync(this.logFile, line, 'utf-8')

--- a/packages/node-runtime/src/node-path-provider.ts
+++ b/packages/node-runtime/src/node-path-provider.ts
@@ -150,6 +150,10 @@ export function getDefaultNodeUserDataDir(): string {
   return path.join(os.homedir(), '.chatlab', 'data')
 }
 
+export function getSystemLogsDir(): string {
+  return path.join(SYSTEM_DIR, 'logs')
+}
+
 function expandHome(filePath: string): string {
   if (filePath.startsWith('~/') || filePath === '~') {
     return path.join(os.homedir(), filePath.slice(1))

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,8 +7,18 @@ import { backendPersistPlugin } from '@/plugins/backendPersist'
 import ui from '@nuxt/ui/vue-plugin'
 import i18n from './i18n'
 import './assets/styles/main.css'
+import { installGlobalErrorReporting, reportError } from './services/log-report'
+
+installGlobalErrorReporting()
 
 const app = createApp(App)
+
+// Report uncaught component errors; keep Vue's default console output too.
+app.config.errorHandler = (err, _instance, info) => {
+  const e = err as Error
+  console.error(e, info)
+  reportError(e?.message ?? String(err), e?.stack)
+}
 
 const pinia = createPinia()
 pinia.use(piniaPluginPersistedstate)

--- a/src/services/log-report.ts
+++ b/src/services/log-report.ts
@@ -1,0 +1,53 @@
+/**
+ * Front-end error reporter.
+ *
+ * The browser can't write log files, so uncaught front-end errors are sent to
+ * the backend (POST /_web/logs/report) and appended to logs/app.log (scope
+ * 'web'). Error-level only; deduped + throttled to avoid error storms.
+ */
+
+import { post } from './utils/http'
+
+const recent = new Map<string, number>()
+const DEDUP_WINDOW_MS = 10_000
+
+function shouldReport(key: string): boolean {
+  const now = Date.now()
+  const last = recent.get(key)
+  if (last !== undefined && now - last < DEDUP_WINDOW_MS) return false
+  recent.set(key, now)
+  // Bound the map so it can't grow without limit.
+  if (recent.size > 100) {
+    for (const [k, t] of recent) {
+      if (now - t >= DEDUP_WINDOW_MS) recent.delete(k)
+    }
+  }
+  return true
+}
+
+export function reportError(message: string, stack?: string): void {
+  if (!message) return
+  const key = `${message}::${stack?.split('\n')[1] ?? ''}`
+  if (!shouldReport(key)) return
+  // Fire-and-forget; never let reporting throw or block the UI.
+  void post('/_web/logs/report', {
+    level: 'error',
+    message,
+    stack,
+    url: typeof location !== 'undefined' ? location.href : undefined,
+  }).catch(() => {})
+}
+
+/** Install global handlers. Call once at app startup. */
+export function installGlobalErrorReporting(): void {
+  window.addEventListener('error', (e) => {
+    reportError(e.message || String(e.error), e.error?.stack)
+  })
+  window.addEventListener('unhandledrejection', (e) => {
+    const reason = e.reason
+    reportError(
+      reason instanceof Error ? reason.message : `Unhandled rejection: ${String(reason)}`,
+      reason instanceof Error ? reason.stack : undefined
+    )
+  })
+}

--- a/src/services/log-report.ts
+++ b/src/services/log-report.ts
@@ -30,7 +30,7 @@ export function reportError(message: string, stack?: string): void {
   const key = `${message}::${stack?.split('\n')[1] ?? ''}`
   if (!shouldReport(key)) return
   // Fire-and-forget; never let reporting throw or block the UI.
-  void post('/_web/logs/report', {
+  void post('/logs/report', {
     level: 'error',
     message,
     stack,


### PR DESCRIPTION
…rror capture

Build a shared appLogger (node-runtime) that all three runtimes write to a single rolling logs/app.log (10 MB → rename to app.old.log). Replaces the four independent hand-written loggers (app.log/api.log Electron wrappers) with a unified entry point while leaving AiLogger/perf-logger intact.

Key additions:
- packages/node-runtime/src/logging/app-logger.ts: initAppLogger/appLogger singleton, INFO threshold by default (CHATLAB_LOG_LEVEL to override), atomic rename rotation, Error data auto-extracts message+stack
- Three-runtime init: Electron main, CLI Web (http/index.ts), CLI (run())
- Global crash capture: uncaughtException + unhandledRejection on all three Node runtimes now land in app.log scope 'crash'
- Fastify setErrorHandler fallback logs scope 'http' on CLI Web and Electron internal server for unexpected 5xx errors
- Frontend: window.onerror + unhandledrejection + Vue errorHandler feed into POST /_web/logs/report (scope 'web') with dedup+throttle
- AGENTS.md: logging rules section requiring key-path logs on new/changed features