### PR TITLE
fix(data-dir): keep AI cache and logs with user data

### DIFF
--- a/apps/cli/src/http/routes/web/index.ts
+++ b/apps/cli/src/http/routes/web/index.ts
@@ -84,11 +84,11 @@ export function registerWebRoutes(
     getUserDataDir: () => path.join(os.homedir(), '.chatlab', 'data'),
     getDatabaseDir: () => path.join(os.homedir(), '.chatlab', 'data', 'databases'),
     getVectorDir: () => path.join(os.homedir(), '.chatlab', 'data', 'vector'),
-    getAiDataDir: () => path.join(os.homedir(), '.chatlab', 'ai'),
+    getAiDataDir: () => path.join(os.homedir(), '.chatlab', 'data', 'ai'),
     getSettingsDir: () => path.join(os.homedir(), '.chatlab', 'settings'),
-    getCacheDir: () => path.join(os.homedir(), '.chatlab', 'cache'),
+    getCacheDir: () => path.join(os.homedir(), '.chatlab', 'data', 'cache'),
     getTempDir: () => path.join(os.homedir(), '.chatlab', 'temp'),
-    getLogsDir: () => path.join(os.homedir(), '.chatlab', 'logs'),
+    getLogsDir: () => path.join(os.homedir(), '.chatlab', 'data', 'logs'),
     getDownloadsDir: () => path.join(os.homedir(), 'Downloads'),
   }
   const resolvedPathProvider = options?.pathProvider ?? fallbackPathProvider

--- a/apps/desktop/main/paths.ts
+++ b/apps/desktop/main/paths.ts
@@ -399,7 +399,10 @@ export function ensureDir(dirPath: string): void {
 export function ensureAppDirs(): void {
   ensureDir(getSystemDataDir())
   ensureDir(getUserDataDir())
-  copyLegacyUserScopedSystemDirs(getUserDataDir())
+  const userScopedCopy = copyLegacyUserScopedSystemDirs(getUserDataDir())
+  if (userScopedCopy.errors.length > 0) {
+    throw new Error(`Failed to copy legacy user-scoped system directories: ${userScopedCopy.errors.join('; ')}`)
+  }
   ensureDir(getDatabaseDir())
   ensureDir(getVectorDir())
   ensureDir(getAiDataDir())

--- a/apps/desktop/main/paths.ts
+++ b/apps/desktop/main/paths.ts
@@ -3,9 +3,9 @@
  *
  * 目录分为两类：
  * 1. 系统数据（~/.chatlab/）— 固定位置，不可更改
- *    配置、日志、缓存、AI 数据、设置偏好等
+ *    配置、设置偏好等
  * 2. 用户核心数据（userDataDir）— 可通过 config.toml 配置
- *    聊天记录数据库、向量库（未来）
+ *    聊天记录数据库、向量库（未来）、AI 数据、缓存、日志
  *
  * userDataDir 解析优先级：
  *   CHATLAB_DATA_DIR 环境变量 > config.toml [data] user_data_dir > 平台默认
@@ -236,6 +236,11 @@ export function applyPendingDataDirMigration(): { success: boolean; skipped?: bo
   const pending = config.pendingDataDirMigration
   if (!pending) return { success: true, skipped: true }
 
+  const userScopedCopy = copyLegacyUserScopedSystemDirs(getUserDataDir())
+  if (userScopedCopy.errors.length > 0) {
+    return { success: false, error: userScopedCopy.errors.join('; ') }
+  }
+
   const result = runPendingDataDirMigration(pending, {
     writeUserDataDir(dir) {
       writeConfigField('data', 'user_data_dir', dir)
@@ -360,7 +365,7 @@ export function getVectorDir(): string {
 }
 
 export function getAiDataDir(): string {
-  return path.join(getSystemDataDir(), 'ai')
+  return path.join(getUserDataDir(), 'ai')
 }
 
 export function getSettingsDir(): string {
@@ -368,7 +373,7 @@ export function getSettingsDir(): string {
 }
 
 export function getCacheDir(): string {
-  return path.join(getSystemDataDir(), 'cache')
+  return path.join(getUserDataDir(), 'cache')
 }
 
 export function getTempDir(): string {
@@ -376,7 +381,7 @@ export function getTempDir(): string {
 }
 
 export function getLogsDir(): string {
-  return path.join(getSystemDataDir(), 'logs')
+  return path.join(getUserDataDir(), 'logs')
 }
 
 /**
@@ -394,6 +399,7 @@ export function ensureDir(dirPath: string): void {
 export function ensureAppDirs(): void {
   ensureDir(getSystemDataDir())
   ensureDir(getUserDataDir())
+  copyLegacyUserScopedSystemDirs(getUserDataDir())
   ensureDir(getDatabaseDir())
   ensureDir(getVectorDir())
   ensureDir(getAiDataDir())
@@ -572,7 +578,29 @@ export function removeLegacyDir(): boolean {
 
 // ==================== Electron 旧目录结构 → 新目录结构迁移 ====================
 
-const SYSTEM_SUBDIRS = ['ai', 'settings', 'cache', 'logs', 'temp', 'nlp']
+const SYSTEM_SUBDIRS = ['settings', 'temp', 'nlp']
+const USER_SCOPED_LEGACY_SYSTEM_SUBDIRS = ['ai', 'cache', 'logs']
+
+function copyLegacyUserScopedSystemDirs(userDataDir: string): { errors: string[] } {
+  const systemDir = getSystemDataDir()
+  const errors: string[] = []
+
+  for (const subDir of USER_SCOPED_LEGACY_SYSTEM_SUBDIRS) {
+    const srcDir = path.join(systemDir, subDir)
+    const destDir = path.join(userDataDir, subDir)
+    if (!fs.existsSync(srcDir) || path.resolve(srcDir) === path.resolve(destDir)) continue
+
+    try {
+      ensureDir(destDir)
+      errors.push(...copyDirMerge(srcDir, destDir, ensureDir).errors)
+    } catch (error) {
+      errors.push(error instanceof Error ? error.message : String(error))
+      console.warn(`[Paths] Failed to copy legacy ${subDir} into user data dir:`, error)
+    }
+  }
+
+  return { errors }
+}
 
 /**
  * 检测是否需要从 Electron 旧目录结构迁移到新的双根目录结构

--- a/packages/core/src/interfaces/path-provider.ts
+++ b/packages/core/src/interfaces/path-provider.ts
@@ -10,16 +10,16 @@
  * 1. 系统数据（固定在 ~/.chatlab/，不可更改）：
  *    ~/.chatlab/
  *      ├── config.toml
- *      ├── ai/            AI 对话历史、助手/技能/LLM 配置
  *      ├── settings/      用户界面偏好
- *      ├── cache/         派生数据缓存（可再生）
- *      ├── temp/          临时文件
- *      └── logs/          日志
+ *      └── temp/          临时文件
  *
  * 2. 用户核心数据（可配置位置）：
  *    {userDataDir}/
  *      ├── databases/     聊天记录 SQLite 文件（{uuid}.db）
  *      ├── vector/        向量数据库（预留）
+ *      ├── ai/            AI 对话历史、助手/技能/LLM 配置
+ *      ├── cache/         派生数据缓存（可再生）
+ *      ├── logs/          日志
  *      └── media/         媒体文件（预留）
  */
 export interface PathProvider {
@@ -35,19 +35,19 @@ export interface PathProvider {
   /** 向量库目录（存放 embedding_index.db 等可再生派生索引），基于 userDataDir */
   getVectorDir(): string
 
-  /** AI 数据目录（对话历史、LLM 配置），基于 systemDir */
+  /** AI 数据目录（对话历史、LLM 配置），基于 userDataDir */
   getAiDataDir(): string
 
   /** 设置目录，基于 systemDir */
   getSettingsDir(): string
 
-  /** 缓存目录（存放可再生的派生数据），基于 systemDir */
+  /** 缓存目录（存放可再生的派生数据），基于 userDataDir */
   getCacheDir(): string
 
   /** 临时文件目录，基于 systemDir */
   getTempDir(): string
 
-  /** 日志目录，基于 systemDir */
+  /** 日志目录，基于 userDataDir */
   getLogsDir(): string
 
   /** 下载目录（导出文件的默认保存位置） */

--- a/packages/node-runtime/src/data-dir-switch.test.ts
+++ b/packages/node-runtime/src/data-dir-switch.test.ts
@@ -261,6 +261,34 @@ test('applyPendingNodeDataDirMigration deletes old data directory after successf
   ])
 })
 
+test('applyPendingNodeDataDirMigration preserves missing-source failures before copying legacy dirs', () => {
+  const root = makeTempDir()
+  const systemDir = path.join(root, 'system')
+  const currentDir = path.join(root, 'missing-current')
+  const targetDir = path.join(root, 'target')
+  writeFile(path.join(systemDir, 'ai', 'ai-chats.db'), 'ai')
+
+  const switchResult = createNodeDataDirSwitch({
+    systemDir,
+    currentDir,
+    targetDir,
+    migrate: true,
+    defaultDir: targetDir,
+  })
+  assert.equal(switchResult.success, true)
+
+  const result = applyPendingNodeDataDirMigration(systemDir, {
+    writeConfigField() {
+      throw new Error('writeConfigField should not be called')
+    },
+  })
+
+  assert.equal(result.success, false)
+  assert.match(result.error ?? '', /源数据目录不存在/)
+  assert.equal(fs.existsSync(currentDir), false)
+  assert.equal(fs.existsSync(targetDir), false)
+})
+
 test('applyPendingNodeDataDirMigration includes legacy AI data, cache, and logs in the switched data directory', () => {
   const root = makeTempDir()
   const systemDir = path.join(root, 'system')

--- a/packages/node-runtime/src/data-dir-switch.test.ts
+++ b/packages/node-runtime/src/data-dir-switch.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path'
 import test from 'node:test'
 import {
   applyPendingNodeDataDirMigration,
+  copyUserScopedSystemDirs,
   createPendingDataDirMigration,
   createNodeDataDirSwitch,
   getPendingNodeDataDirMigration,
@@ -163,6 +164,59 @@ test('NodePathProvider marks CLI-created data directories', () => {
   assert.equal(fs.readFileSync(path.join(dataDir, '.chatlab'), 'utf-8'), 'ChatLab Data Directory')
 })
 
+test('NodePathProvider keeps AI data, cache, and logs under the configured data directory', () => {
+  const root = makeTempDir()
+  const dataDir = path.join(root, 'data')
+  const provider = new NodePathProvider(dataDir)
+
+  assert.equal(provider.getAiDataDir(), path.join(dataDir, 'ai'))
+  assert.equal(provider.getCacheDir(), path.join(dataDir, 'cache'))
+  assert.equal(provider.getLogsDir(), path.join(dataDir, 'logs'))
+})
+
+test('copyUserScopedSystemDirs copies legacy AI data, cache, and logs into the user data directory', () => {
+  const root = makeTempDir()
+  const systemDir = path.join(root, 'system')
+  const dataDir = path.join(root, 'data')
+  writeFile(path.join(systemDir, 'ai', 'ai-chats.db'), 'ai')
+  writeFile(path.join(systemDir, 'cache', 'cache.db'), 'cache')
+  writeFile(path.join(systemDir, 'logs', 'app.log'), 'log')
+
+  const result = copyUserScopedSystemDirs(systemDir, dataDir)
+
+  assert.equal(result.errors.length, 0)
+  assert.equal(fs.readFileSync(path.join(dataDir, 'ai', 'ai-chats.db'), 'utf-8'), 'ai')
+  assert.equal(fs.readFileSync(path.join(dataDir, 'cache', 'cache.db'), 'utf-8'), 'cache')
+  assert.equal(fs.readFileSync(path.join(dataDir, 'logs', 'app.log'), 'utf-8'), 'log')
+})
+
+test('copyUserScopedSystemDirs is a no-op when legacy system dirs are missing', () => {
+  const root = makeTempDir()
+  const systemDir = path.join(root, 'system')
+  const dataDir = path.join(root, 'data')
+
+  const result = copyUserScopedSystemDirs(systemDir, dataDir)
+
+  assert.deepEqual(result, { copied: 0, skipped: 0, errors: [] })
+  assert.equal(fs.existsSync(dataDir), false)
+})
+
+test('copyUserScopedSystemDirs is idempotent', () => {
+  const root = makeTempDir()
+  const systemDir = path.join(root, 'system')
+  const dataDir = path.join(root, 'data')
+  writeFile(path.join(systemDir, 'ai', 'ai-chats.db'), 'ai')
+  writeFile(path.join(systemDir, 'cache', 'cache.db'), 'cache')
+  writeFile(path.join(systemDir, 'logs', 'app.log'), 'log')
+
+  const first = copyUserScopedSystemDirs(systemDir, dataDir)
+  const second = copyUserScopedSystemDirs(systemDir, dataDir)
+
+  assert.equal(first.errors.length, 0)
+  assert.equal(first.copied, 3)
+  assert.deepEqual(second, { copied: 0, skipped: 3, errors: [] })
+})
+
 test('createNodeDataDirSwitch writes pending migration under the system settings directory', () => {
   const root = makeTempDir()
   const systemDir = path.join(root, 'system')
@@ -205,6 +259,34 @@ test('applyPendingNodeDataDirMigration deletes old data directory after successf
     { section: 'data', key: 'user_data_dir', value: targetDir },
     { section: 'data', key: 'electron_migration_done', value: true },
   ])
+})
+
+test('applyPendingNodeDataDirMigration includes legacy AI data, cache, and logs in the switched data directory', () => {
+  const root = makeTempDir()
+  const systemDir = path.join(root, 'system')
+  const currentDir = path.join(root, 'current')
+  const targetDir = path.join(root, 'target')
+  writeFile(path.join(currentDir, '.chatlab'), 'ChatLab Data Directory')
+  writeFile(path.join(currentDir, 'databases', 'session.db'), 'sqlite')
+  writeFile(path.join(systemDir, 'ai', 'ai-chats.db'), 'ai')
+  writeFile(path.join(systemDir, 'cache', 'cache.db'), 'cache')
+  writeFile(path.join(systemDir, 'logs', 'app.log'), 'log')
+
+  const switchResult = createNodeDataDirSwitch({ systemDir, currentDir, targetDir, migrate: true })
+  assert.equal(switchResult.success, true)
+
+  const writes: Array<{ section: string; key: string; value: unknown }> = []
+  const result = applyPendingNodeDataDirMigration(systemDir, {
+    writeConfigField(section, key, value) {
+      writes.push({ section, key, value })
+    },
+  })
+
+  assert.equal(result.success, true)
+  assert.equal(fs.readFileSync(path.join(targetDir, 'databases', 'session.db'), 'utf-8'), 'sqlite')
+  assert.equal(fs.readFileSync(path.join(targetDir, 'ai', 'ai-chats.db'), 'utf-8'), 'ai')
+  assert.equal(fs.readFileSync(path.join(targetDir, 'cache', 'cache.db'), 'utf-8'), 'cache')
+  assert.equal(fs.readFileSync(path.join(targetDir, 'logs', 'app.log'), 'utf-8'), 'log')
 })
 
 test('createNodeDataDirSwitch rejects data directory changes while CHATLAB_DATA_DIR is active', () => {

--- a/packages/node-runtime/src/data-dir-switch.ts
+++ b/packages/node-runtime/src/data-dir-switch.ts
@@ -370,9 +370,15 @@ export function applyPendingNodeDataDirMigration(
   if (!pending) return { success: true, skipped: true }
   const writeConfig = deps.writeConfigField ?? writeConfigField
 
-  const userScopedCopy = copyUserScopedSystemDirs(systemDir, pending.from)
-  if (userScopedCopy.errors.length > 0) {
-    return { success: false, error: userScopedCopy.errors.join('; ') }
+  if (pending.migrate && path.resolve(pending.from) !== path.resolve(pending.to)) {
+    if (!fs.existsSync(pending.from)) {
+      return { success: false, error: `源数据目录不存在: ${pending.from}` }
+    }
+
+    const userScopedCopy = copyUserScopedSystemDirs(systemDir, pending.from)
+    if (userScopedCopy.errors.length > 0) {
+      return { success: false, error: userScopedCopy.errors.join('; ') }
+    }
   }
 
   const result = runPendingDataDirMigration(pending, {

--- a/packages/node-runtime/src/data-dir-switch.ts
+++ b/packages/node-runtime/src/data-dir-switch.ts
@@ -4,6 +4,7 @@ import { writeConfigField } from '@openchatlab/config'
 
 const CHATLAB_MARKER_FILE = '.chatlab'
 const USER_DATA_REQUIRED_DIRS = ['databases']
+const USER_SCOPED_SYSTEM_DIRS = ['ai', 'cache', 'logs']
 const PENDING_MIGRATION_FILE = 'data-dir-migration.json'
 
 const DANGEROUS_PATHS = [
@@ -186,6 +187,19 @@ export function copyDirMerge(
   return stats
 }
 
+export function copyUserScopedSystemDirs(systemDir: string, userDataDir: string): CopyStats {
+  const stats: CopyStats = { copied: 0, skipped: 0, errors: [] }
+
+  for (const dirName of USER_SCOPED_SYSTEM_DIRS) {
+    const src = path.join(systemDir, dirName)
+    const dest = path.join(userDataDir, dirName)
+    if (path.resolve(src) === path.resolve(dest)) continue
+    copyDirMerge(src, dest, ensureDir, stats)
+  }
+
+  return stats
+}
+
 export function createPendingDataDirMigration(input: {
   from: string
   to: string
@@ -355,6 +369,11 @@ export function applyPendingNodeDataDirMigration(
   const pending = getPendingNodeDataDirMigration(systemDir)
   if (!pending) return { success: true, skipped: true }
   const writeConfig = deps.writeConfigField ?? writeConfigField
+
+  const userScopedCopy = copyUserScopedSystemDirs(systemDir, pending.from)
+  if (userScopedCopy.errors.length > 0) {
+    return { success: false, error: userScopedCopy.errors.join('; ') }
+  }
 
   const result = runPendingDataDirMigration(pending, {
     writeUserDataDir(dir) {

--- a/packages/node-runtime/src/migrations/electron-data-migration.ts
+++ b/packages/node-runtime/src/migrations/electron-data-migration.ts
@@ -8,7 +8,8 @@
  * Migration behavior:
  * 1. Detect Electron legacy data directory (platform-specific)
  * 2. If databases exist there, write user_data_dir to config.toml pointing to old path
- * 3. Copy system data (ai, settings, cache, logs, temp, nlp) from old path to ~/.chatlab/
+ * 3. Copy system data (settings, temp, nlp) from old path to ~/.chatlab/
+ *    AI data, cache, and logs stay with user_data_dir so they follow data directory switches.
  */
 
 import * as fs from 'fs'
@@ -16,7 +17,7 @@ import * as os from 'os'
 import * as path from 'path'
 import { writeConfigField } from '@openchatlab/config'
 
-const SYSTEM_SUBDIRS = ['ai', 'settings', 'cache', 'logs', 'temp', 'nlp']
+const SYSTEM_SUBDIRS = ['settings', 'temp', 'nlp']
 const STORAGE_CONFIG_FILE = 'storage.json'
 
 interface StorageConfig {

--- a/packages/node-runtime/src/node-path-provider.ts
+++ b/packages/node-runtime/src/node-path-provider.ts
@@ -4,8 +4,8 @@
  * 为 CLI / npm 服务版提供路径管理，不依赖 Electron。
  *
  * 目录分为两类：
- * - 系统数据：固定在 ~/.chatlab/，存放配置、日志、缓存、AI 数据等
- * - 用户数据：可配置位置，存放聊天记录数据库等核心资产
+ * - 系统数据：固定在 ~/.chatlab/，存放配置、设置等
+ * - 用户数据：可配置位置，存放聊天记录数据库、AI 数据、缓存、日志等核心资产
  *
  * 用户数据目录（userDataDir）解析优先级：
  * 1. 构造函数传入的 userDataDir 参数
@@ -20,7 +20,7 @@ import * as path from 'path'
 import type { PathProvider } from '@openchatlab/core'
 import { writeConfigField, loadConfig } from '@openchatlab/config'
 import { migrateFromElectronIfNeeded } from './migrations/electron-data-migration'
-import { applyPendingNodeDataDirMigration } from './data-dir-switch'
+import { applyPendingNodeDataDirMigration, copyUserScopedSystemDirs } from './data-dir-switch'
 
 const SYSTEM_DIR = path.join(os.homedir(), '.chatlab')
 
@@ -65,7 +65,7 @@ export class NodePathProvider implements PathProvider {
   }
 
   getAiDataDir(): string {
-    return path.join(this.systemDir, 'ai')
+    return path.join(this.userDataDir, 'ai')
   }
 
   getSettingsDir(): string {
@@ -73,7 +73,7 @@ export class NodePathProvider implements PathProvider {
   }
 
   getCacheDir(): string {
-    return path.join(this.systemDir, 'cache')
+    return path.join(this.userDataDir, 'cache')
   }
 
   getTempDir(): string {
@@ -81,7 +81,7 @@ export class NodePathProvider implements PathProvider {
   }
 
   getLogsDir(): string {
-    return path.join(this.systemDir, 'logs')
+    return path.join(this.userDataDir, 'logs')
   }
 
   getDownloadsDir(): string {
@@ -92,6 +92,8 @@ export class NodePathProvider implements PathProvider {
    * 确保系统目录和用户数据目录都存在
    */
   ensureAllDirs(): void {
+    copyUserScopedSystemDirs(this.systemDir, this.userDataDir)
+
     const dirs = [
       this.systemDir,
       this.userDataDir,

--- a/packages/node-runtime/src/node-path-provider.ts
+++ b/packages/node-runtime/src/node-path-provider.ts
@@ -92,7 +92,10 @@ export class NodePathProvider implements PathProvider {
    * 确保系统目录和用户数据目录都存在
    */
   ensureAllDirs(): void {
-    copyUserScopedSystemDirs(this.systemDir, this.userDataDir)
+    const userScopedCopy = copyUserScopedSystemDirs(this.systemDir, this.userDataDir)
+    if (userScopedCopy.errors.length > 0) {
+      throw new Error(`Failed to copy legacy user-scoped system directories: ${userScopedCopy.errors.join('; ')}`)
+    }
 
     const dirs = [
       this.systemDir,


### PR DESCRIPTION
## Summary
- keep AI data, cache, and logs under the configured user data directory
- copy legacy `~/.chatlab/{ai,cache,logs}` into the active user data directory before directory-switch migration
- update path-provider docs and CLI fallback paths to match the new canonical layout

Fixes #241.

## Tests
- `pnpm test -- packages/node-runtime/src/data-dir-switch.test.ts`
- `pnpm exec eslint packages/core/src/interfaces/path-provider.ts packages/node-runtime/src/data-dir-switch.ts packages/node-runtime/src/node-path-provider.ts packages/node-runtime/src/migrations/electron-data-migration.ts apps/cli/src/http/routes/web/index.ts apps/desktop/main/paths.ts packages/node-runtime/src/data-dir-switch.test.ts --fix`
- `pnpm exec prettier --write packages/core/src/interfaces/path-provider.ts packages/node-runtime/src/data-dir-switch.ts packages/node-runtime/src/node-path-provider.ts packages/node-runtime/src/migrations/electron-data-migration.ts apps/cli/src/http/routes/web/index.ts apps/desktop/main/paths.ts packages/node-runtime/src/data-dir-switch.test.ts`
- `pnpm run type-check:node`
- `git diff --check`