### PR TITLE
fix(cli): download official prebuilds when preparing better-sqlite3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,11 +117,13 @@ jobs:
           workspaces: packages/parser-native
           key: ${{ matrix.arch }}
 
+      # --target 必须直接传给 napi（不能用 -- 透传给 cargo），
+      # 否则 napi 感知不到交叉编译，会按宿主架构（arm64）命名并构建产物
       - name: Build native parser (${{ matrix.arch }})
         shell: bash
         run: |
           if [ "${{ matrix.arch }}" == "x64" ]; then
-            pnpm --filter @openchatlab/parser-native build -- --target x86_64-apple-darwin
+            pnpm --filter @openchatlab/parser-native build --target x86_64-apple-darwin
           else
             pnpm --filter @openchatlab/parser-native build
           fi
@@ -214,9 +216,16 @@ jobs:
         run: |
           echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
+      # 只暴露 System32 的 tar.exe 到 PATH。不能把整个 System32 置前：
+      # 那会让 WSL 的 bash.EXE 遮蔽 Git Bash，导致后续所有 shell: bash 步骤
+      # （含 dtolnay/rust-toolchain 内部脚本）在无 WSL 发行版的 runner 上失败
       - name: Use Windows system tar (fix zstd cache issue)
-        shell: cmd
-        run: echo C:\Windows\System32>>%GITHUB_PATH%
+        shell: pwsh
+        run: |
+          $tarDir = Join-Path $env:RUNNER_TEMP 'system-tar'
+          New-Item -ItemType Directory -Force -Path $tarDir | Out-Null
+          Copy-Item "$env:SystemRoot\System32\tar.exe" -Destination $tarDir
+          Add-Content -Path $env:GITHUB_PATH -Value $tarDir
 
       - name: Setup pnpm cache
         uses: actions/cache@v5

--- a/apps/cli/scripts/rebuild-native.sh
+++ b/apps/cli/scripts/rebuild-native.sh
@@ -24,8 +24,9 @@ npm init -y > /dev/null 2>&1
 npm install "better-sqlite3@${BS3_VERSION}" --ignore-scripts > /dev/null 2>&1
 
 cd "node_modules/better-sqlite3"
-# better-sqlite3 按 Node ABI 发布预编译（无 napi 变体），与其自身 install 脚本保持一致
-npx --yes prebuild-install || npm run build-release 2>/dev/null || npx --yes node-gyp rebuild --release
+# better-sqlite3 按 Node ABI 发布预编译（无 napi 变体）。显式钉死 runtime/target 到系统 Node，
+# 避免环境残留的 npm_config_runtime=electron 等配置让它"成功"下载 Electron ABI 产物
+npx --yes prebuild-install -r node -t "$(node --version)" || npm run build-release 2>/dev/null || npx --yes node-gyp rebuild --release
 
 BUILT="$TEMP_DIR/node_modules/better-sqlite3/build/Release/better_sqlite3.node"
 if [ ! -f "$BUILT" ]; then

--- a/apps/cli/scripts/rebuild-native.sh
+++ b/apps/cli/scripts/rebuild-native.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 #
-# 在隔离目录中编译 better-sqlite3 的系统 Node.js 原生模块，
+# 在隔离目录中准备 better-sqlite3 的系统 Node.js 原生模块，
 # 避免与 electron-rebuild 产生冲突。
 #
+# 优先下载官方 Node ABI 预编译包（秒级），无可用预编译时回退源码编译。
 # 产物：apps/cli/native/better_sqlite3.node
 #
 set -e
@@ -23,7 +24,8 @@ npm init -y > /dev/null 2>&1
 npm install "better-sqlite3@${BS3_VERSION}" --ignore-scripts > /dev/null 2>&1
 
 cd "node_modules/better-sqlite3"
-npx --yes prebuild-install -r napi || npm run build-release 2>/dev/null || npx --yes node-gyp rebuild --release
+# better-sqlite3 按 Node ABI 发布预编译（无 napi 变体），与其自身 install 脚本保持一致
+npx --yes prebuild-install || npm run build-release 2>/dev/null || npx --yes node-gyp rebuild --release
 
 BUILT="$TEMP_DIR/node_modules/better-sqlite3/build/Release/better_sqlite3.node"
 if [ ! -f "$BUILT" ]; then


### PR DESCRIPTION
prebuild-install was invoked with -r napi, but better-sqlite3 only publishes per-ABI node/electron prebuilds, so the download branch always failed and every run fell back to a ~1.5min node-gyp source build.