### PR TITLE
fix(web): parse markdown responses as text in WebPlatformAdapter.fetchRemoteConfig

### DIFF
--- a/src/services/platform/web.test.ts
+++ b/src/services/platform/web.test.ts
@@ -71,4 +71,35 @@ describe('WebPlatformAdapter', () => {
       globalThis.fetch = originalFetch
     }
   })
+
+  it('parses markdown skill bodies as text instead of JSON', async () => {
+    // Regression: importing a skill from the cloud market failed with
+    // "SyntaxError: No number after minus sign in JSON..." because
+    // fetchRemoteConfig hard-coded res.json() for every response.
+    const originalFetch = globalThis.fetch
+    const md = `---\nid: skill_md\nname: Markdown Skill\ndescription: desc\n---\nbody text`
+    globalThis.fetch = (() =>
+      Promise.resolve(new Response(md, { headers: { 'content-type': 'text/markdown' } }))) as typeof fetch
+
+    try {
+      const result = await new WebPlatformAdapter().fetchRemoteConfig('https://example.com/skills/skill_md.md')
+      assert.equal(result.success, true)
+      assert.equal(result.data, md)
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+
+  it('parses .json URLs as JSON even without an application/json content-type', async () => {
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = (() =>
+      Promise.resolve(new Response('[1,2,3]', { headers: { 'content-type': 'text/plain' } }))) as typeof fetch
+
+    try {
+      const result = await new WebPlatformAdapter().fetchRemoteConfig('https://example.com/cn/skill.json')
+      assert.deepEqual(result.data, [1, 2, 3])
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
 })

--- a/src/services/platform/web.ts
+++ b/src/services/platform/web.ts
@@ -25,7 +25,9 @@ export class WebPlatformAdapter implements PlatformAdapter {
     try {
       const res = await fetch(url)
       if (!res.ok) return { success: false, error: `HTTP ${res.status}` }
-      const data = await res.json()
+      const contentType = res.headers.get('content-type') || ''
+      const isJson = contentType.includes('application/json') || url.split('?')[0].endsWith('.json')
+      const data = isJson ? await res.json() : await res.text()
       return { success: true, data }
     } catch (e) {
       return { success: false, error: String(e) }


### PR DESCRIPTION
## Problem

In the web (CLI Web) build, importing any skill from the cloud market fails with:

> SyntaxError: No number after minus sign in JSON at position 1 (line 1 column 2)

Steps to reproduce:
1. Open ChatLab web build
2. Import chat history (so the AI panel is active)
3. Click AI chat → pick a skill → manage skills
4. Open the cloud market tab and click "Import" on any entry

## Root cause

`src/services/platform/web.ts` had `fetchRemoteConfig` hard-coded to `await res.json()`. The same method is used twice:

- `useSkillStore().fetchCloudCatalog()` → fetches `<site>/<lang>/skill.json` (JSON → works)
- `useSkillStore().importFromCloud(item)` → fetches `<site><item.path>` (a `.md` body → fails)

The Electron path in `apps/desktop/main/ipc/window.ts` already routes by `Content-Type` / `.json` suffix and explicitly supports "JSON 和纯文本/Markdown" — the Web adapter simply missed the text branch.

## Fix

Mirror the Electron routing in `WebPlatformAdapter.fetchRemoteConfig`: treat the response as JSON when `Content-Type` contains `application/json` or the URL path ends with `.json`; otherwise read it as text. `url.split('?')[0]` is used so cache-busting query strings don't accidentally downgrade a JSON URL.

This fixes both call sites at once, with no new abstraction.

## Test

Two new regression tests in `src/services/platform/web.test.ts`:

- markdown body (with `text/markdown`) is returned as a string
- `.json` URL with non-JSON content-type is still parsed as JSON

`pnpm test -- src/services/platform/web.test.ts`: 6/6 pass.
`pnpm exec vue-tsc --noEmit -p tsconfig.web.json` and `pnpm run type-check:node`: clean.