### PR TITLE
fix(parser): support bracketed WhatsApp TXT timestamps

### DIFF
--- a/packages/parser/src/formats/fixture.test.ts
+++ b/packages/parser/src/formats/fixture.test.ts
@@ -210,6 +210,40 @@ const fixtures: ParserFixture[] = [
     },
   },
   {
+    filename: '_chat.txt',
+    content: [
+      '[2026/7/9 23:39:03] Messages and calls are end-to-end encrypted.',
+      '[2026/7/9 02:28:09] Alice: Hey',
+      '[2026/7/9 02:28:37] Bob:Hi without sender-space',
+      '',
+    ].join('\n'),
+    formatId: 'whatsapp-native-txt',
+    expected: {
+      meta: { name: 'Alice', platform: KNOWN_PLATFORMS.WHATSAPP, type: ChatType.PRIVATE },
+      memberIds: ['Alice', 'Bob'],
+      messages: [
+        {
+          senderPlatformId: 'system',
+          timestamp: localTs('2026-07-09T23:39:03'),
+          type: MessageType.SYSTEM,
+          content: 'Messages and calls are end-to-end encrypted.',
+        },
+        {
+          senderPlatformId: 'Alice',
+          timestamp: localTs('2026-07-09T02:28:09'),
+          type: MessageType.TEXT,
+          content: 'Hey',
+        },
+        {
+          senderPlatformId: 'Bob',
+          timestamp: localTs('2026-07-09T02:28:37'),
+          type: MessageType.TEXT,
+          content: 'Hi without sender-space',
+        },
+      ],
+    },
+  },
+  {
     filename: 'chatlab.json',
     content: json({
       chatlab: { version: '1.0.0', exportedAt: 1704164645 },

--- a/packages/parser/src/formats/whatsapp-native-txt.ts
+++ b/packages/parser/src/formats/whatsapp-native-txt.ts
@@ -49,6 +49,16 @@ function extractNameFromFilePath(filePath: string): string {
   return basename.replace(/\.txt$/i, '') || '未知聊天'
 }
 
+function shouldInferPrivateChatName(filePath: string, fallbackName: string): boolean {
+  const basename = path.basename(filePath)
+  return /^_chat\.txt$/i.test(basename) || /^whatsapp(?:[-_\s].*)?$/i.test(fallbackName)
+}
+
+function inferPrivateChatName(memberMap: Map<string, MemberInfo>, fallbackName: string): string {
+  const member = Array.from(memberMap.values()).find((item) => item.platformId !== 'system')
+  return member?.nickname || fallbackName
+}
+
 // ==================== 特征定义 ====================
 
 export const feature: FormatFeature = {
@@ -65,8 +75,8 @@ export const feature: FormatFeature = {
       /訊息與通話已受端對端加密保護/, // 繁体中文加密提示（WhatsApp 独有）
       /Messages and calls are end-to-end encrypted/i, // 英文加密提示（WhatsApp 独有）
       /你发送给自己的消息已进行端到端加密/, // 简体中文自己对话提示（WhatsApp 独有）
-      /\d{1,4}\/\d{1,2}\/\d{2,4},?\s+\d{1,2}:\d{2} - /, // 消息行格式特征（无方括号，含 " - " 分隔符，WhatsApp 独有）
-      /\[\d{1,4}\/\d{1,2}\/\d{2,4}[\s,].*\d{1,2}:\d{2}:\d{2}.*\] /, // 消息行格式特征（方括号 + 含日期和时间的时间戳，兼容各地区变体）
+      /\d{1,4}\/\d{1,2}\/\d{2,4},?\s+\d{1,2}:\d{2}(?::\d{2})?(?:[\s\u2009\u202F]*(?:AM|PM|A\.M\.|P\.M\.|上午|下午|午前|午後|오전|오후))?\s+- /i, // 消息行格式特征（无方括号，含 " - " 分隔符，WhatsApp 独有）
+      /\[\d{1,4}\/\d{1,2}\/\d{1,4}[\s,].*\d{1,2}:\d{2}(?::\d{2})?.*\] /, // 消息行格式特征（方括号 + 含日期和时间的时间戳，兼容各地区变体）
     ],
     // 文件名特征：与xxx的 WhatsApp 聊天.txt
     filename: [/^与.+的\s*WhatsApp\s*聊天\.txt$/i, /^與.+的\s*WhatsApp\s*對話\.txt$/i, /WhatsApp/i],
@@ -88,7 +98,8 @@ function cleanLine(line: string): string {
 
 // 格式1（无方括号）：日期/日期/日期[,] 时:分 - 内容
 // 兼容各地区变体：YYYY/MM/DD HH:MM | DD/MM/YYYY, HH:MM | M/D/YY, HH:MM
-const MESSAGE_LINE_REGEX_V1 = /^(\d{1,4}\/\d{1,2}\/\d{2,4},?\s+\d{1,2}:\d{2}) - (.+)$/
+const MESSAGE_LINE_REGEX_V1 =
+  /^(\d{1,4}\/\d{1,2}\/\d{2,4},?\s+\d{1,2}:\d{2}(?::\d{2})?(?:[\s\u2009\u202F]*(?:AM|PM|A\.M\.|P\.M\.|上午|下午|午前|午後|오전|오후))?) - (.+)$/i
 
 // 格式2（方括号格式）：宽松捕获 [时间戳] 后的内容
 // 时间戳的地区变体由 parseFlexibleV2Timestamp() 弹性解析器处理
@@ -97,7 +108,7 @@ const MESSAGE_LINE_REGEX_V2 = /^\[([^\]]+)\] (.+)$/
 
 // 从消息内容中分离昵称和实际内容
 // 格式：昵称: 内容（冒号后可能是空格、U+200E LTR Mark 或两者组合）
-const SENDER_CONTENT_REGEX = /^(.+?):[\s\u200E]+(.*)$/
+const SENDER_CONTENT_REGEX = /^(.+?):[\s\u200E]*(.*)$/
 
 // ==================== 系统消息识别 ====================
 
@@ -212,7 +223,7 @@ function parseFlexibleV2Timestamp(raw: string): number | null {
   str = str.replace(/,/g, ' ').replace(/\s+/g, ' ').trim()
 
   // 4. 提取日期部分（含 /）和时间部分（含 :）
-  const match = str.match(/^(\d{1,4}\/\d{1,2}\/\d{2,4})\s+(\d{1,2}:\d{2}(?::\d{2})?)$/)
+  const match = str.match(/^(\d{1,4}\/\d{1,2}\/\d{1,4})\s+(\d{1,2}:\d{2}(?::\d{2})?)$/)
   if (!match) return null
 
   const [, datePart, timePart] = match
@@ -315,7 +326,7 @@ async function* parseWhatsApp(options: ParseOptions): AsyncGenerator<ParseEvent,
   onLog?.('info', `开始解析 WhatsApp TXT 文件，大小: ${(totalBytes / 1024 / 1024).toFixed(2)} MB`)
 
   // 收集数据
-  const chatName = extractNameFromFilePath(filePath)
+  const fileChatName = extractNameFromFilePath(filePath)
   const memberMap = new Map<string, MemberInfo>()
   const messages: ParsedMessage[] = []
 
@@ -448,6 +459,10 @@ async function* parseWhatsApp(options: ParseOptions): AsyncGenerator<ParseEvent,
   const realMemberCount = hasSystemMember ? memberMap.size - 1 : memberMap.size
 
   const chatType = realMemberCount > 2 ? ChatType.GROUP : ChatType.PRIVATE
+  const chatName =
+    chatType === ChatType.PRIVATE && shouldInferPrivateChatName(filePath, fileChatName)
+      ? inferPrivateChatName(memberMap, fileChatName)
+      : fileChatName
 
   // 发送 meta
   const meta: ParsedMeta = {


### PR DESCRIPTION
## 摘要

修复 WhatsApp TXT 导入在部分官方导出格式下无法解析的问题，例如：

```text
[2026/7/9 02:28:09] Alice: Hey
[2026/7/9 02:28:37] Bob:Hi
```

同时优化默认 `_chat.txt` 文件导入后的会话名称：当文件名没有有效备注时，使用解析到的第一个真实成员名作为会话名，避免显示 `_chat`。

## 改动

- 支持带方括号的 WhatsApp 时间戳格式。
- 支持一位数月/日和带秒的时间，例如 `2026/7/9 02:28:09`。
- 支持冒号后没有空格的消息行，例如 `Bob:Hi`。
- 对默认 `_chat.txt` 私聊导入，使用解析出的成员名作为会话名称。
- 增加对应 parser fixture 回归测试。

## 验证

- 已通过修改文件的 ESLint 检查。
- 已通过 `packages/parser/src/formats/fixture.test.ts` 回归测试。
- 已手动验证 WhatsApp `_chat.txt` 可成功导入，且会话名称正常显示。
