### PR TITLE
fix(parser): validate QCE private chat type

### DIFF
--- a/packages/parser/src/formats/shuakami-qq-exporter.test.ts
+++ b/packages/parser/src/formats/shuakami-qq-exporter.test.ts
@@ -106,6 +106,25 @@ describe('shuakami-qq-exporter parser', () => {
     assert.equal(result.meta.type, ChatType.PRIVATE)
   })
 
+  it('overrides an incorrect private type when more than two real senders exist', async () => {
+    const content = makeExport({
+      chatInfoType: 'private',
+      senders: [
+        { uid: 'u_100', name: 'Alice' },
+        { uid: 'u_200', name: 'Bob' },
+        { uid: 'u_300', name: 'Carol' },
+      ],
+      messages: [
+        textMessage('100', 'Alice', 'hello'),
+        textMessage('200', 'Bob', 'hi'),
+        textMessage('300', 'Carol', 'welcome'),
+      ],
+    })
+
+    const result = await parseContent(content)
+    assert.equal(result.meta.type, ChatType.GROUP)
+  })
+
   it('supports current system/recalled field names alongside legacy ones', async () => {
     const content = makeExport({
       chatInfoType: 'group',

--- a/packages/parser/src/formats/shuakami-qq-exporter.ts
+++ b/packages/parser/src/formats/shuakami-qq-exporter.ts
@@ -207,13 +207,15 @@ function countSenders(content: string): number {
 }
 
 /**
- * 判断聊天类型：优先使用 chatInfo.type，senders 计数仅作兜底
+ * 判断聊天类型：优先使用可信的 chatInfo.type，并用真实发送者数量纠正冲突的私聊标记。
  */
 function resolveChatType(chatInfoType: string | undefined, headContent: string): ChatType {
-  if (chatInfoType === 'private') return ChatType.PRIVATE
   if (chatInfoType === 'group') return ChatType.GROUP
 
   const sendersCount = countSenders(headContent)
+  // QQ 私聊最多只有两个真实发送者；出现更多发送者时，显式 private 标记不可信。
+  if (chatInfoType === 'private') return sendersCount > 2 ? ChatType.GROUP : ChatType.PRIVATE
+
   return sendersCount > 2 ? ChatType.GROUP : sendersCount > 0 ? ChatType.PRIVATE : ChatType.GROUP
 }
 


### PR DESCRIPTION
Treat more than two real senders as stronger evidence than a conflicting private marker while preserving genuine private chats with system placeholders.