### PR TITLE
fix(cli): declare sqlite-vec and @huggingface/transformers as runtime dependencies

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -50,6 +50,7 @@
     "@fastify/static": "^9.1.3",
     "@earendil-works/pi-agent-core": "0.74.2",
     "@earendil-works/pi-ai": "0.74.2",
+    "@huggingface/transformers": "^4.2.0",
     "@modelcontextprotocol/sdk": "^1.12.1",
     "better-sqlite3": "^12.4.6",
     "commander": "^13.1.0",
@@ -57,6 +58,7 @@
     "gray-matter": "^4.0.3",
     "js-tiktoken": "^1.0.21",
     "smol-toml": "^1.3.1",
+    "sqlite-vec": "^0.1.9",
     "stream-json": "^1.9.1",
     "zod": "^3.24.4"
   },

--- a/apps/cli/tsup.config.ts
+++ b/apps/cli/tsup.config.ts
@@ -24,7 +24,9 @@ export default defineConfig({
   noExternal: [/^@openchatlab\/(?!parser-native)/, 'chatlab-mcp', 'stream-json'],
   // parser-native 是本地构建的可选 Rust 内核：不打包也不声明依赖，
   // 运行时 require 失败会自动回退 TS 解析器。
-  external: ['better-sqlite3', '@node-rs/jieba', '@openchatlab/parser-native'],
+  // sqlite-vec / @huggingface/transformers 依赖按平台分发的原生包（sqlite-vec-*、onnxruntime-node、sharp），
+  // 必须作为真实依赖随 npm 安装，不能内联进 bundle
+  external: ['better-sqlite3', '@node-rs/jieba', 'sqlite-vec', '@huggingface/transformers', '@openchatlab/parser-native'],
   banner: {
     js: [
       "import { createRequire as __createRequire } from 'module';",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -162,6 +162,9 @@ importers:
       '@fastify/static':
         specifier: ^9.1.3
         version: 9.1.3
+      '@huggingface/transformers':
+        specifier: ^4.2.0
+        version: 4.2.0
       '@modelcontextprotocol/sdk':
         specifier: ^1.12.1
         version: 1.29.0(zod@3.25.76)
@@ -183,6 +186,9 @@ importers:
       smol-toml:
         specifier: ^1.3.1
         version: 1.6.1
+      sqlite-vec:
+        specifier: ^0.1.9
+        version: 0.1.9
       stream-json:
         specifier: ^1.9.1
         version: 1.9.1


### PR DESCRIPTION
## Problem

Configuring the semantic index vector model fails with HTTP 500 in Docker and global npm installs of `chatlab-cli`:

```
Cannot find package 'sqlite-vec-linux-arm64' imported from .../chatlab-cli/dist/chunk-*.mjs
```
<img width="578" height="398" alt="image" src="https://github.com/user-attachments/assets/9d42f2dc-948c-41aa-b9d6-a2f2b793bcd7" />

error：
```
index-YzfjPohq.js:37  PUT http://chatlab.localhost/_web/ai/semantic-index/config 500 (Internal Server Error)
Lw @ index-YzfjPohq.js:37
setConfig @ index-YzfjPohq.js:37
H @ index-YzfjPohq.js:37
Q @ index-YzfjPohq.js:37
Sl @ index-YzfjPohq.js:2
kn @ index-YzfjPohq.js:2
B5 @ index-YzfjPohq.js:2
P @ index-YzfjPohq.js:37
（匿名） @ index-YzfjPohq.js:30
d @ index-YzfjPohq.js:30
a @ index-YzfjPohq.js:30
Sl @ index-YzfjPohq.js:2
kn @ index-YzfjPohq.js:2
a @ index-YzfjPohq.js:2
index-YzfjPohq.js:37 [semantic-index] save config failed: Error: HTTP 500: {"success":false,"error":{"code":"SERVER_ERROR","message":"Cannot find package 'sqlite-vec-linux-arm64' imported from /usr/local/lib/node_modules/chatlab-cli/dist/chunk-RRC6U56Y.mjs"}}
    at Lw (index-YzfjPohq.js:37:8791)
    at async H (index-YzfjPohq.js:37:482322)
    at async Q (index-YzfjPohq.js:37:482647)
    
```    
## Root cause

The CLI tsup build inlines `@openchatlab/node-runtime` into dist chunks. Two packages that load platform-specific native binaries at runtime get pulled into the bundle along with it, but they are not declared in `chatlab-cli`'s `package.json`, so they are never installed:

- `sqlite-vec` — resolves native extensions via platform `optionalDependencies` (`sqlite-vec-linux-arm64`, etc.)
- `@huggingface/transformers` — depends on `onnxruntime-node` / `sharp`; once `sqlite-vec` is fixed, embedding model preload fails with `listSupportedBackends is not a function` because the bundled interop breaks the native binding

`apps/desktop` already declares `sqlite-vec`; the CLI package missed both.

## Fix

- Add `sqlite-vec` and `@huggingface/transformers` to `apps/cli` dependencies
- Mark both as tsup `external` so they install from npm with their native bindings, same as `better-sqlite3` and `@node-rs/jieba`

## Verification

Built from source and installed as a global tarball in a Docker image (`node:24-bookworm-slim`, linux/arm64):

- `import('sqlite-vec')` resolves inside the installed package
- `PUT /_web/ai/semantic-index/config` returns 200 with `configured: true` (previously 500)
- Local embedding model (`onnx-community/Qwen3-Embedding-0.6B-ONNX`) downloads and preloads successfully; `modelStatus: ready`
- `pnpm run type-check:node`, `scripts/check-workspace-dependencies.mjs`, and prettier all pass