### PR TITLE
fix(ranking): 关键词榜单多色模式下对未知类型取色导致的崩溃

### DIFF
--- a/src/components/analysis/ranking/KeywordRankingTab.vue
+++ b/src/components/analysis/ranking/KeywordRankingTab.vue
@@ -65,7 +65,15 @@ function getKeywordColor(keyword: string) {
     return SINGLE_COLOR
   }
   const index = currentKeywords.value.indexOf(keyword)
-  return KEYWORD_COLORS[index % KEYWORD_COLORS.length]
+  if (index >= 0) {
+    return KEYWORD_COLORS[index % KEYWORD_COLORS.length]
+  }
+  // 未出现在当前关键词列表中的类型（如“其他”），用稳定哈希取色
+  let hash = 0
+  for (let i = 0; i < keyword.length; i++) {
+    hash = (hash * 31 + keyword.charCodeAt(i)) >>> 0
+  }
+  return KEYWORD_COLORS[hash % KEYWORD_COLORS.length]
 }
 
 // 预设模板（使用计算属性以支持国际化）


### PR DESCRIPTION
## 问题

「分析 → 榜单 → 关键词」中开启**多色模式**时页面报错：

<img width="840" height="382" alt="image" src="https://github.com/user-attachments/assets/1009aa57-58a1-4d7c-8ff3-78184fafdb30" />


```
TypeError: Cannot read properties of undefined (reading 'wrapBg')
```

## 原因

`KeywordRankingTab.vue` 的 `getKeywordColor()` 用 `currentKeywords.indexOf(keyword)` 的返回值索引 `KEYWORD_COLORS` 颜色池。

但图例数据 `analysis.typeDistribution` 由后端生成（`packages/core/src/query/advanced/social.ts`），其中包含聚合类型 **「其他」**（一条消息命中多个/无关键词时归入），它不在 `currentKeywords` 列表中，`indexOf` 返回 `-1`：

- JS 中 `-1 % 8 === -1`，`KEYWORD_COLORS[-1]` 为 `undefined`
- 模板中读取 `.wrapBg` / `.bg` / `.text` / `.badge` 随即抛 TypeError

单色模式直接返回 `SINGLE_COLOR` 不查颜色池，所以只有开启多色模式才触发。

## 修复

`indexOf` 返回 `-1` 时，改为对关键词字符串做稳定哈希取色：

- 「其他」等未登记类型获得一个确定且稳定的颜色，多次渲染保持一致
- 堆叠进度条 `getStackedWidths()` 走同一函数，一并修复
- 已登记关键词的取色逻辑不变

## 验证

- 复现：关键词榜单开启多色模式 → 修复前必现 `wrapBg` TypeError，修复后正常渲染，「其他」图例有固定颜色
- `pnpm run type-check:web`、`eslint`、`prettier` 均通过