### PR TITLE
feat(ranking): show member avatars on group leaderboards

### DIFF
--- a/packages/core/src/query/advanced/__tests__/ranking.test.ts
+++ b/packages/core/src/query/advanced/__tests__/ranking.test.ts
@@ -240,6 +240,8 @@ describe('ranking analytics (ported algorithms)', () => {
     assert.equal(res.breakers[0].memberId, 4)
     assert.equal(res.hotContents[0].content, 'haha')
     assert.equal(res.hotContents[0].maxChainLength, 3)
+    assert.equal(res.hotContents[0].originatorId, 1)
+    assert.equal(res.hotContents[0].originatorName, 'A')
   })
 
   it('excludes system messages for system-filtered analyses', () => {

--- a/packages/core/src/query/advanced/ranking.ts
+++ b/packages/core/src/query/advanced/ranking.ts
@@ -117,6 +117,7 @@ export interface HotRepeatContent {
   content: string
   count: number
   maxChainLength: number
+  originatorId: number
   originatorName: string
   lastTs: number
   firstMessageId: number
@@ -1022,6 +1023,7 @@ function computeRepeat(
       content,
       count: stats.count,
       maxChainLength: stats.maxChainLength,
+      originatorId: stats.originatorId,
       originatorName: originatorInfo?.name || '未知',
       lastTs: stats.lastTs,
       firstMessageId: stats.firstMessageId,

--- a/packages/http-routes/src/routes/web/analytics.ts
+++ b/packages/http-routes/src/routes/web/analytics.ts
@@ -348,7 +348,9 @@ export function registerAnalyticsRoutes(server: FastifyInstance, ctx: AnalyticsR
     async (request) => {
       const id = request.params.id
       const filter = parseTimeFilter(request.query)
-      return cached('repeat', id, { ...filter }, () => getRepeatAnalysis(adapter.ensureReadonly(id), filter))
+      return cached('repeat', id, { ...filter }, () => getRepeatAnalysis(adapter.ensureReadonly(id), filter), {
+        extraVersion: 'originator-id-v1',
+      })
     }
   )
 }

--- a/src/components/analysis/quotes/CatchphraseTab.vue
+++ b/src/components/analysis/quotes/CatchphraseTab.vue
@@ -2,16 +2,23 @@
 import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import type { CatchphraseAnalysis, MemberCatchphrase } from '@/types/analysis'
+import LazyAvatar from '@/components/common/avatar/LazyAvatar.vue'
 import { useDataService } from '@/services'
 import { ListPro } from '@/components/charts'
 import { EmptyState, LoadingState, SectionCard } from '@/components/UI'
 import { useLayoutStore } from '@/stores/layout'
 import { formatRankNumber, getRankNumberClass } from '@/utils'
+import { getRankAvatarText, resolveRankAvatar, useRankAvatarMap } from '@/utils/rankAvatars'
 import type { TimeFilter } from '@openchatlab/shared-types'
 import { buildCatchphraseRecordQuery } from './catchphrase-record-query'
 
 const { t } = useI18n()
 const layoutStore = useLayoutStore()
+const avatarMap = useRankAvatarMap()
+
+function memberAvatar(member: MemberCatchphrase): string | null {
+  return resolveRankAvatar(member.memberId, undefined, avatarMap.value)
+}
 
 const props = defineProps<{
   sessionId: string
@@ -74,6 +81,17 @@ watch(
       :top-n="10"
       :count-label="t('quotes.catchphrase.phraseCount', { count: selectedMember.catchphrases.length })"
     >
+      <template #headerRight>
+        <LazyAvatar
+          v-if="selectedMember"
+          :src="memberAvatar(selectedMember)"
+          :alt="selectedMember.name"
+          :text="getRankAvatarText(selectedMember.name)"
+          root-class="h-8 w-8 shrink-0"
+          image-class="h-8 w-8 rounded-full object-cover"
+          fallback-class="flex h-8 w-8 items-center justify-center rounded-full bg-linear-to-br from-pink-100 to-rose-100 text-[10px] font-medium text-pink-600 dark:from-pink-900/30 dark:to-rose-900/30 dark:text-pink-400"
+        />
+      </template>
       <template #item="{ item, index }">
         <button
           type="button"
@@ -116,7 +134,7 @@ watch(
     >
       <template #item="{ item: member, index }">
         <div
-          class="grid w-full grid-cols-[2rem_minmax(0,1fr)] items-start gap-x-3 sm:grid-cols-[2rem_minmax(7.5rem,0.65fr)_minmax(0,1.35fr)]"
+          class="grid w-full grid-cols-[2rem_2rem_minmax(0,1fr)] items-start gap-x-3 sm:grid-cols-[2rem_2rem_minmax(7.5rem,0.65fr)_minmax(0,1.35fr)]"
         >
           <span
             class="row-span-2 w-8 shrink-0 pt-0.5 text-center font-mono text-sm font-black tabular-nums sm:row-span-1"
@@ -125,15 +143,24 @@ watch(
             {{ formatRankNumber(index) }}
           </span>
 
+          <LazyAvatar
+            :src="memberAvatar(member)"
+            :alt="member.name"
+            :text="getRankAvatarText(member.name)"
+            root-class="col-start-2 row-span-2 h-8 w-8 shrink-0 sm:row-span-1"
+            image-class="h-8 w-8 rounded-full object-cover"
+            fallback-class="flex h-8 w-8 items-center justify-center rounded-full bg-linear-to-br from-pink-100 to-rose-100 text-[10px] font-medium text-pink-600 dark:from-pink-900/30 dark:to-rose-900/30 dark:text-pink-400"
+          />
+
           <p
-            class="col-start-2 row-start-1 min-w-0 truncate pt-0.5 text-sm font-semibold text-gray-900 dark:text-white"
+            class="col-start-3 row-start-1 min-w-0 truncate pt-0.5 text-sm font-semibold text-gray-900 dark:text-white"
             :title="member.name"
           >
             {{ member.name }}
           </p>
 
           <div
-            class="col-start-2 row-start-2 mt-1.5 flex min-w-0 flex-wrap items-center gap-x-4 gap-y-1.5 sm:col-start-3 sm:row-start-1 sm:mt-0"
+            class="col-start-3 row-start-2 mt-1.5 flex min-w-0 flex-wrap items-center gap-x-4 gap-y-1.5 sm:col-start-4 sm:row-start-1 sm:mt-0"
           >
             <button
               v-for="phrase in getOverviewPhrases(member)"

--- a/src/components/analysis/quotes/HotRepeatTab.vue
+++ b/src/components/analysis/quotes/HotRepeatTab.vue
@@ -1,11 +1,13 @@
 <script setup lang="ts">
 import { ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
-import type { RepeatAnalysis } from '@openchatlab/core'
+import type { HotRepeatContent, RepeatAnalysis } from '@openchatlab/core'
+import LazyAvatar from '@/components/common/avatar/LazyAvatar.vue'
 import { useDataService } from '@/services/data/service'
 import { ListPro } from '@/components/charts'
 import { LoadingState, EmptyState, SectionCard } from '@/components/UI'
 import { formatDate, formatRankNumber, getRankNumberClass } from '@/utils'
+import { getRankAvatarText, resolveRankAvatar, useRankAvatarIndex } from '@/utils/rankAvatars'
 import { useLayoutStore } from '@/stores/layout'
 import type { TimeFilter } from '@openchatlab/shared-types'
 
@@ -17,6 +19,14 @@ const props = defineProps<{
 }>()
 
 const layoutStore = useLayoutStore()
+const avatarIndex = useRankAvatarIndex()
+
+function originatorAvatar(item: HotRepeatContent): string | null {
+  return resolveRankAvatar(item.originatorId, undefined, avatarIndex.value.byId, {
+    name: item.originatorName,
+    byName: avatarIndex.value.byName,
+  })
+}
 
 // ==================== 最火复读内容 ====================
 const repeatAnalysis = ref<RepeatAnalysis | null>(null)
@@ -71,16 +81,24 @@ watch(
       <template #item="{ item, index }">
         <button
           type="button"
-          class="group/item grid w-full grid-cols-[2rem_minmax(0,1fr)_auto] items-center gap-3 rounded-lg text-left outline-none focus-visible:ring-2 focus-visible:ring-primary-500/40"
+          class="group/item grid w-full grid-cols-[2rem_2rem_minmax(0,1fr)_auto] items-start gap-3 rounded-lg text-left outline-none focus-visible:ring-2 focus-visible:ring-primary-500/40"
           :aria-label="`${t('quotes.hotRepeat.viewChat')}: ${item.content}`"
           @click="viewRepeatContext(item)"
         >
           <span
-            class="w-8 shrink-0 text-center font-mono text-sm font-black tabular-nums"
+            class="w-8 shrink-0 pt-0.5 text-center font-mono text-sm font-black tabular-nums"
             :class="getRankNumberClass(index)"
           >
             {{ formatRankNumber(index) }}
           </span>
+          <LazyAvatar
+            :src="originatorAvatar(item)"
+            :alt="item.originatorName"
+            :text="getRankAvatarText(item.originatorName)"
+            root-class="h-8 w-8 shrink-0"
+            image-class="h-8 w-8 rounded-full object-cover"
+            fallback-class="flex h-8 w-8 items-center justify-center rounded-full bg-linear-to-br from-pink-100 to-rose-100 text-[10px] font-medium text-pink-600 dark:from-pink-900/30 dark:to-rose-900/30 dark:text-pink-400"
+          />
           <div class="min-w-0">
             <p class="line-clamp-2 text-sm font-medium leading-5 text-gray-900 dark:text-white" :title="item.content">
               {{ item.content }}

--- a/src/components/analysis/ranking/RankingView.vue
+++ b/src/components/analysis/ranking/RankingView.vue
@@ -1,11 +1,13 @@
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
+import { computed, provide, ref, shallowRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { SectionTabs } from '@/components/navigation'
 import UserSelect from '@/components/common/UserSelect.vue'
 import { CatchphraseTab, HotRepeatTab } from '@/components/analysis/quotes'
 import { isFeatureSupported, type LocaleType } from '@/i18n'
+import { useDataService } from '@/services'
 import type { TimeFilter } from '@openchatlab/shared-types'
+import { RANKING_AVATAR_MAP_KEY, buildRankAvatarIndex, type RankAvatarIndex } from '@/utils/rankAvatars'
 import KeywordRankingTab from './KeywordRankingTab.vue'
 import OverallRankingTab from './OverallRankingTab.vue'
 import InteractionRankingTab from './InteractionRankingTab.vue'
@@ -23,6 +25,25 @@ const { t, locale } = useI18n()
 
 const activeSubTab = ref('overall')
 const selectedMemberId = ref<number | null>(null)
+const avatarIndex = shallowRef<RankAvatarIndex>({ byId: new Map(), byName: new Map() })
+
+provide(RANKING_AVATAR_MAP_KEY, avatarIndex)
+
+watch(
+  () => props.sessionId,
+  async (sessionId) => {
+    avatarIndex.value = { byId: new Map(), byName: new Map() }
+    if (!sessionId) return
+    try {
+      const members = await useDataService().getMembers(sessionId)
+      if (props.sessionId !== sessionId) return
+      avatarIndex.value = buildRankAvatarIndex(members)
+    } catch (error) {
+      console.error('Failed to load ranking avatars:', error)
+    }
+  },
+  { immediate: true }
+)
 
 const supportsGroupRanking = computed(() => isFeatureSupported('groupRanking', locale.value as LocaleType))
 const isTabVisible = (id: RankingTabId) => !props.visibleTabIds || props.visibleTabIds.includes(id)

--- a/src/components/analysis/ranking/charts/EChartConsecutiveRank.vue
+++ b/src/components/analysis/ranking/charts/EChartConsecutiveRank.vue
@@ -7,7 +7,8 @@ import { computed } from 'vue'
 import type { EChartsOption, BarSeriesOption } from 'echarts'
 import { EChart } from '@/components/charts'
 import { SectionCard, ScrollableChart } from '@/components/UI'
-import { truncateRankName, useRankingLayout } from '@/utils/rankingChartLayout'
+import { useCircularRankAvatarMap } from '@/utils/rankAvatars'
+import { buildRankYAxis, useRankingLayout } from '@/utils/rankingChartLayout'
 
 interface ConsecutiveItem {
   memberId: number
@@ -42,6 +43,7 @@ const rankingLayout = useRankingLayout()
 const displayData = computed(() => {
   return [...props.items].sort((a, b) => b.maxConsecutiveDays - a.maxConsecutiveDays).slice(0, props.topN)
 })
+const avatarMap = useCircularRankAvatarMap(() => displayData.value)
 
 // 计算图表高度
 const chartHeight = computed(() => {
@@ -79,7 +81,11 @@ const option = computed<EChartsOption>(() => {
   if (displayData.value.length === 0) return {}
 
   const reversedData = [...displayData.value].reverse()
-  const names = reversedData.map((item) => truncateRankName(item.name, rankingLayout.value.labelMaxLength))
+  const rankAxis = buildRankYAxis(reversedData, {
+    totalCount: displayData.value.length,
+    labelMaxLength: rankingLayout.value.labelMaxLength,
+    avatars: avatarMap.value,
+  })
   const maxValue = Math.max(...displayData.value.map((item) => item.maxConsecutiveDays), 1)
 
   return {
@@ -126,20 +132,10 @@ const option = computed<EChartsOption>(() => {
     },
     yAxis: {
       type: 'category',
-      data: names,
+      data: rankAxis.data,
       axisLine: { show: false },
       axisTick: { show: false },
-      axisLabel: {
-        fontSize: 12,
-        color: '#4b5563',
-        margin: 12,
-        formatter: (value: string, index: number) => {
-          const originalIndex = displayData.value.length - 1 - index
-          const rank = originalIndex + 1
-          const prefix = rank === 1 ? '🥇' : rank === 2 ? '🥈' : rank === 3 ? '🥉' : `${rank}.`
-          return `${prefix} ${value}`
-        },
-      },
+      axisLabel: rankAxis.axisLabel,
     },
     series: [
       {

--- a/src/components/analysis/ranking/charts/EChartDivingRank.vue
+++ b/src/components/analysis/ranking/charts/EChartDivingRank.vue
@@ -8,7 +8,8 @@ import type { EChartsOption, BarSeriesOption } from 'echarts'
 import { EChart } from '@/components/charts'
 import { SectionCard, Tabs, TopNSelect } from '@/components/UI'
 import { formatFullDateTime } from '@/utils/dateFormat'
-import { truncateRankName, useRankingLayout } from '@/utils/rankingChartLayout'
+import { useCircularRankAvatarMap } from '@/utils/rankAvatars'
+import { buildRankYAxis, useRankingLayout } from '@/utils/rankingChartLayout'
 
 interface DivingItem {
   memberId: number
@@ -56,6 +57,7 @@ const displayData = computed(() => {
   })
   return sorted.slice(0, topN.value)
 })
+const avatarMap = useCircularRankAvatarMap(() => displayData.value)
 
 // 动态标题
 const dynamicTitle = computed(() => {
@@ -98,7 +100,11 @@ const option = computed<EChartsOption>(() => {
   if (displayData.value.length === 0) return {}
 
   const reversedData = [...displayData.value].reverse()
-  const names = reversedData.map((item) => truncateRankName(item.name, rankingLayout.value.labelMaxLength))
+  const rankAxis = buildRankYAxis(reversedData, {
+    totalCount: displayData.value.length,
+    labelMaxLength: rankingLayout.value.labelMaxLength,
+    avatars: avatarMap.value,
+  })
   const maxDays = Math.max(...displayData.value.map((item) => item.daysSinceLastMessage), 1)
 
   const dataWithStyle = reversedData.map((item) => ({
@@ -151,20 +157,10 @@ const option = computed<EChartsOption>(() => {
     },
     yAxis: {
       type: 'category',
-      data: names,
+      data: rankAxis.data,
       axisLine: { show: false },
       axisTick: { show: false },
-      axisLabel: {
-        fontSize: 12,
-        color: '#4b5563',
-        margin: 12,
-        formatter: (value: string, index: number) => {
-          const originalIndex = displayData.value.length - 1 - index
-          const rank = originalIndex + 1
-          const prefix = rank === 1 ? '🥇' : rank === 2 ? '🥈' : rank === 3 ? '🥉' : `${rank}.`
-          return `${prefix} ${value}`
-        },
-      },
+      axisLabel: rankAxis.axisLabel,
     },
     series: [
       {

--- a/src/components/analysis/ranking/charts/EChartNightOwlRank.vue
+++ b/src/components/analysis/ranking/charts/EChartNightOwlRank.vue
@@ -7,7 +7,8 @@ import { computed } from 'vue'
 import type { EChartsOption, BarSeriesOption } from 'echarts'
 import { EChart } from '@/components/charts'
 import { SectionCard, ScrollableChart } from '@/components/UI'
-import { truncateRankName, useRankingLayout } from '@/utils/rankingChartLayout'
+import { useCircularRankAvatarMap } from '@/utils/rankAvatars'
+import { buildRankYAxis, useRankingLayout } from '@/utils/rankingChartLayout'
 
 interface NightOwlItem {
   memberId: number
@@ -50,6 +51,7 @@ const rankingLayout = useRankingLayout()
 const displayData = computed(() => {
   return props.items.slice(0, props.topN)
 })
+const avatarMap = useCircularRankAvatarMap(() => displayData.value)
 
 // 计算图表高度
 const chartHeight = computed(() => {
@@ -71,7 +73,11 @@ const option = computed<EChartsOption>(() => {
   if (displayData.value.length === 0) return {}
 
   const reversedData = [...displayData.value].reverse()
-  const names = reversedData.map((item) => truncateRankName(item.name, rankingLayout.value.labelMaxLength))
+  const rankAxis = buildRankYAxis(reversedData, {
+    totalCount: displayData.value.length,
+    labelMaxLength: rankingLayout.value.labelMaxLength,
+    avatars: avatarMap.value,
+  })
   const maxValue = Math.max(...displayData.value.map((item) => item.totalNightMessages), 1)
 
   return {
@@ -129,20 +135,10 @@ const option = computed<EChartsOption>(() => {
     },
     yAxis: {
       type: 'category',
-      data: names,
+      data: rankAxis.data,
       axisLine: { show: false },
       axisTick: { show: false },
-      axisLabel: {
-        fontSize: 12,
-        color: '#4b5563',
-        margin: 12,
-        formatter: (value: string, index: number) => {
-          const originalIndex = displayData.value.length - 1 - index
-          const rank = originalIndex + 1
-          const prefix = rank === 1 ? '🥇' : rank === 2 ? '🥈' : rank === 3 ? '🥉' : `${rank}.`
-          return `${prefix} ${value}`
-        },
-      },
+      axisLabel: rankAxis.axisLabel,
     },
     series: [
       {

--- a/src/components/analysis/ranking/charts/EChartStreakRank.vue
+++ b/src/components/analysis/ranking/charts/EChartStreakRank.vue
@@ -7,7 +7,8 @@ import { computed } from 'vue'
 import type { EChartsOption, BarSeriesOption } from 'echarts'
 import { EChart } from '@/components/charts'
 import { SectionCard, ScrollableChart } from '@/components/UI'
-import { truncateRankName, useRankingLayout } from '@/utils/rankingChartLayout'
+import { useCircularRankAvatarMap } from '@/utils/rankAvatars'
+import { buildRankYAxis, useRankingLayout } from '@/utils/rankingChartLayout'
 
 interface StreakItem {
   memberId: number
@@ -55,6 +56,7 @@ const displayData = computed(() => {
   // 最长连续模式：显示全部，按 maxStreak 排序
   return props.items.slice(0, props.topN)
 })
+const avatarMap = useCircularRankAvatarMap(() => displayData.value)
 
 // 计算图表高度
 const chartHeight = computed(() => {
@@ -101,7 +103,11 @@ function getValue(item: StreakItem): number {
 // 生成 ECharts 配置
 const option = computed<EChartsOption>(() => {
   const reversedData = [...displayData.value].reverse()
-  const names = reversedData.map((item) => truncateRankName(item.name, rankingLayout.value.labelMaxLength))
+  const rankAxis = buildRankYAxis(reversedData, {
+    totalCount: displayData.value.length,
+    labelMaxLength: rankingLayout.value.labelMaxLength,
+    avatars: avatarMap.value,
+  })
   const values = reversedData.map((item) => getValue(item))
   const maxValue = Math.max(...values, 1)
 
@@ -172,20 +178,10 @@ const option = computed<EChartsOption>(() => {
     },
     yAxis: {
       type: 'category',
-      data: names,
+      data: rankAxis.data,
       axisLine: { show: false },
       axisTick: { show: false },
-      axisLabel: {
-        fontSize: 12,
-        color: '#4b5563',
-        margin: 12,
-        formatter: (value: string, index: number) => {
-          const originalIndex = displayData.value.length - 1 - index
-          const rank = originalIndex + 1
-          const prefix = rank === 1 ? '🥇' : rank === 2 ? '🥈' : rank === 3 ? '🥉' : `${rank}.`
-          return `${prefix} ${value}`
-        },
-      },
+      axisLabel: rankAxis.axisLabel,
     },
     series: [
       {

--- a/src/components/analysis/ranking/charts/EChartTimeRank.vue
+++ b/src/components/analysis/ranking/charts/EChartTimeRank.vue
@@ -7,7 +7,8 @@ import { computed } from 'vue'
 import type { EChartsOption, BarSeriesOption } from 'echarts'
 import { EChart } from '@/components/charts'
 import { SectionCard, ScrollableChart } from '@/components/UI'
-import { truncateRankName, useRankingLayout } from '@/utils/rankingChartLayout'
+import { useCircularRankAvatarMap } from '@/utils/rankAvatars'
+import { buildRankYAxis, useRankingLayout } from '@/utils/rankingChartLayout'
 
 interface TimeRankItem {
   memberId: number
@@ -42,6 +43,7 @@ const rankingLayout = useRankingLayout()
 const displayData = computed(() => {
   return props.items.slice(0, props.topN)
 })
+const avatarMap = useCircularRankAvatarMap(() => displayData.value)
 
 // 计算图表高度
 const chartHeight = computed(() => {
@@ -72,7 +74,11 @@ const option = computed<EChartsOption>(() => {
   if (displayData.value.length === 0) return {}
 
   const reversedData = [...displayData.value].reverse()
-  const names = reversedData.map((item) => truncateRankName(item.name, rankingLayout.value.labelMaxLength))
+  const rankAxis = buildRankYAxis(reversedData, {
+    totalCount: displayData.value.length,
+    labelMaxLength: rankingLayout.value.labelMaxLength,
+    avatars: avatarMap.value,
+  })
 
   // 计算相对值：第一名时间最短，进度条最长（100%）
   // 使用反比例：第一名时间 / 当前时间 * 100
@@ -128,20 +134,10 @@ const option = computed<EChartsOption>(() => {
     },
     yAxis: {
       type: 'category',
-      data: names,
+      data: rankAxis.data,
       axisLine: { show: false },
       axisTick: { show: false },
-      axisLabel: {
-        fontSize: 12,
-        color: '#4b5563',
-        margin: 12,
-        formatter: (value: string, index: number) => {
-          const originalIndex = displayData.value.length - 1 - index
-          const rank = originalIndex + 1
-          const prefix = rank === 1 ? '🥇' : rank === 2 ? '🥈' : rank === 3 ? '🥉' : `${rank}.`
-          return `${prefix} ${value}`
-        },
-      },
+      axisLabel: rankAxis.axisLabel,
     },
     series: [
       {

--- a/src/components/charts/EChartRank.vue
+++ b/src/components/charts/EChartRank.vue
@@ -8,7 +8,8 @@ import type { EChartsOption, BarSeriesOption } from 'echarts'
 import EChart from './EChart.vue'
 import type { RankItem } from './RankList.vue'
 import { SectionCard, ScrollableChart } from '@/components/UI'
-import { truncateRankName, useRankingLayout } from '@/utils/rankingChartLayout'
+import { useCircularRankAvatarMap } from '@/utils/rankAvatars'
+import { buildRankYAxis, useRankingLayout } from '@/utils/rankingChartLayout'
 
 interface Props {
   /** 排名数据 */
@@ -42,6 +43,7 @@ const rankingLayout = useRankingLayout()
 const displayData = computed(() => {
   return props.members.slice(0, props.topN)
 })
+const avatarMap = useCircularRankAvatarMap(() => displayData.value)
 
 // 计算图表高度
 const chartHeight = computed(() => {
@@ -67,12 +69,15 @@ const barColor = {
   ],
 }
 
-// 截断名字（最多8个字符）
 // 生成 ECharts 配置
 const option = computed<EChartsOption>(() => {
   // 数据需要反转，因为柱状图 Y 轴从下到上
   const reversedData = [...displayData.value].reverse()
-  const names = reversedData.map((item) => truncateRankName(item.name, rankingLayout.value.labelMaxLength))
+  const rankAxis = buildRankYAxis(reversedData, {
+    totalCount: displayData.value.length,
+    labelMaxLength: rankingLayout.value.labelMaxLength,
+    avatars: avatarMap.value,
+  })
   const values = reversedData.map((item) => item.value)
   const maxValue = Math.max(...values, 1)
 
@@ -126,21 +131,10 @@ const option = computed<EChartsOption>(() => {
     },
     yAxis: {
       type: 'category',
-      data: names,
+      data: rankAxis.data,
       axisLine: { show: false },
       axisTick: { show: false },
-      axisLabel: {
-        fontSize: 12,
-        color: '#4b5563',
-        margin: 12,
-        formatter: (value: string, index: number) => {
-          const originalIndex = displayData.value.length - 1 - index
-          const rank = originalIndex + 1
-          // 前三名添加奖牌 emoji，其他用数字
-          const prefix = rank === 1 ? '🥇' : rank === 2 ? '🥈' : rank === 3 ? '🥉' : `${rank}.`
-          return `${prefix} ${value}`
-        },
-      },
+      axisLabel: rankAxis.axisLabel,
     },
     series: [
       {

--- a/src/components/charts/RankList.vue
+++ b/src/components/charts/RankList.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
+import LazyAvatar from '@/components/common/avatar/LazyAvatar.vue'
 import { formatRankNumber, getRankBarColor, getRankNumberClass } from '@/utils'
+import { getRankAvatarText, resolveRankAvatar, useRankAvatarMap } from '@/utils/rankAvatars'
 
 const { t } = useI18n()
 
@@ -10,6 +12,7 @@ export interface RankItem {
   name: string
   value: number
   percentage: number
+  avatar?: string | null
 }
 
 interface Props {
@@ -27,9 +30,15 @@ const props = withDefaults(defineProps<Props>(), {
 // 获取单位，优先使用 props，否则使用默认翻译
 const displayUnit = computed(() => props.unit || t('views.charts.rankList.unit'))
 
+const avatarMap = useRankAvatarMap()
+
 const displayMembers = computed(() => {
   return props.rankLimit > 0 ? props.members.slice(0, props.rankLimit) : props.members
 })
+
+function memberAvatar(member: RankItem): string | null {
+  return resolveRankAvatar(member.id, member.avatar, avatarMap.value)
+}
 
 // 获取相对于第一名的百分比
 function getRelativePercentage(index: number): number {
@@ -55,13 +64,15 @@ function getRelativePercentage(index: number): number {
         {{ formatRankNumber(index) }}
       </span>
 
-      <!-- 头像占位 -->
-      <div
+      <LazyAvatar
         v-if="showAvatar"
-        class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-linear-to-br from-pink-100 to-rose-100 text-sm font-medium text-pink-600 dark:from-pink-900/30 dark:to-rose-900/30 dark:text-pink-400"
-      >
-        {{ member.name.slice(0, 1) }}
-      </div>
+        :src="memberAvatar(member)"
+        :alt="member.name"
+        :text="getRankAvatarText(member.name)"
+        root-class="h-10 w-10 shrink-0"
+        image-class="h-10 w-10 rounded-full object-cover"
+        fallback-class="flex h-10 w-10 items-center justify-center rounded-full bg-linear-to-br from-pink-100 to-rose-100 text-sm font-medium text-pink-600 dark:from-pink-900/30 dark:to-rose-900/30 dark:text-pink-400"
+      />
 
       <div class="min-w-0 flex-1">
         <div class="flex items-baseline justify-between gap-3">

--- a/src/components/charts/RankListPro.vue
+++ b/src/components/charts/RankListPro.vue
@@ -48,9 +48,9 @@ const showViewAll = computed(() => {
     </template>
 
     <template #full>
-      <RankList :members="members" :unit="unit" />
+      <RankList :members="members" :unit="unit" show-avatar />
     </template>
 
-    <RankList :members="topNData" :unit="unit" />
+    <RankList :members="topNData" :unit="unit" show-avatar />
   </ExpandableListCard>
 </template>

--- a/src/utils/rankAvatars.test.ts
+++ b/src/utils/rankAvatars.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Run: pnpm test -- src/utils/rankAvatars.test.ts
+ */
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  attachRankAvatars,
+  buildRankAvatarIndex,
+  buildRankAvatarMap,
+  buildRankAvatarNameMap,
+  chartSafeAvatarSrc,
+  clipAvatarToCircle,
+  getRankAvatarText,
+  resolveRankAvatar,
+} from './rankAvatars'
+
+test('buildRankAvatarMap keeps ids and drops empty avatars', () => {
+  const map = buildRankAvatarMap([
+    { id: 1, avatar: 'https://a.png' },
+    { id: 2, avatar: '  ' },
+    { id: 3, avatar: null },
+    { id: 4 },
+  ])
+
+  assert.equal(map.get(1), 'https://a.png')
+  assert.equal(map.get(2), null)
+  assert.equal(map.get(3), null)
+  assert.equal(map.get(4), null)
+  assert.equal(map.get(99), undefined)
+})
+
+test('resolveRankAvatar prefers explicit avatar then the member map', () => {
+  const avatars = buildRankAvatarMap([
+    { id: 1, avatar: 'https://from-map.png' },
+    { id: 2, avatar: null },
+  ])
+
+  const cases: Array<{
+    memberId: number | string | undefined
+    explicit: string | null | undefined
+    expected: string | null
+  }> = [
+    { memberId: 1, explicit: 'https://explicit.png', expected: 'https://explicit.png' },
+    { memberId: 1, explicit: '  ', expected: 'https://from-map.png' },
+    { memberId: '1', explicit: null, expected: 'https://from-map.png' },
+    { memberId: 2, explicit: undefined, expected: null },
+    { memberId: 9, explicit: undefined, expected: null },
+    { memberId: '', explicit: undefined, expected: null },
+    { memberId: undefined, explicit: undefined, expected: null },
+    { memberId: 'abc', explicit: undefined, expected: null },
+  ]
+
+  for (const row of cases) {
+    assert.equal(resolveRankAvatar(row.memberId, row.explicit, avatars), row.expected)
+  }
+})
+
+test('getRankAvatarText uses the first visible character', () => {
+  assert.equal(getRankAvatarText('Alice'), 'A')
+  assert.equal(getRankAvatarText('  张三'), '张')
+  assert.equal(getRankAvatarText('   '), '?')
+  assert.equal(getRankAvatarText(''), '?')
+})
+
+test('attachRankAvatars copies avatar onto ranking rows by member id', () => {
+  const avatars = buildRankAvatarMap([{ id: 7, avatar: 'data:image/png;base64,abc' }])
+  const attached = attachRankAvatars(
+    [
+      { memberId: 7, name: 'Ada' },
+      { memberId: 8, name: 'Bob', avatar: 'https://bob.png' },
+    ],
+    (item) => item.memberId,
+    avatars
+  )
+
+  assert.equal(attached[0]?.avatar, 'data:image/png;base64,abc')
+  assert.equal(attached[1]?.avatar, 'https://bob.png')
+})
+
+test('chart avatars wait for a circular bitmap so ECharts never paints a square photo', () => {
+  const cache = new Map([['https://a.png', 'data:image/png;base64,CIRCLE']])
+  assert.equal(chartSafeAvatarSrc(null, cache), null)
+  assert.equal(chartSafeAvatarSrc('https://missing.png', cache), null)
+  assert.equal(chartSafeAvatarSrc('https://a.png', cache), 'data:image/png;base64,CIRCLE')
+})
+
+test('clipAvatarToCircle does not run without a DOM image loader', async () => {
+  assert.equal(await clipAvatarToCircle('https://a.png'), null)
+})
+
+test('buildRankAvatarNameMap indexes nicknames and prefers a real photo', () => {
+  const byName = buildRankAvatarNameMap([
+    { groupNickname: 'Ada', accountName: 'ada', platformId: 'u1', avatar: null },
+    { groupNickname: 'Ada', accountName: 'ada-2', platformId: 'u2', avatar: 'https://ada.png' },
+    { groupNickname: null, accountName: 'Bob', platformId: 'u3', aliases: ['鲍勃'], avatar: 'https://bob.png' },
+  ])
+
+  assert.equal(byName.get('Ada'), 'https://ada.png')
+  assert.equal(byName.get('ada'), null)
+  assert.equal(byName.get('Bob'), 'https://bob.png')
+  assert.equal(byName.get('鲍勃'), 'https://bob.png')
+})
+
+test('resolveRankAvatar falls back to originator name when member id is missing', () => {
+  const index = buildRankAvatarIndex([
+    { id: 1, groupNickname: 'Ada', accountName: 'ada', platformId: 'u1', avatar: 'https://ada.png' },
+  ])
+
+  assert.equal(
+    resolveRankAvatar(undefined, undefined, index.byId, { name: 'Ada', byName: index.byName }),
+    'https://ada.png'
+  )
+  assert.equal(resolveRankAvatar(1, undefined, index.byId, { name: 'Other', byName: index.byName }), 'https://ada.png')
+  assert.equal(resolveRankAvatar(undefined, undefined, index.byId, { name: 'Missing', byName: index.byName }), null)
+})

--- a/src/utils/rankAvatars.ts
+++ b/src/utils/rankAvatars.ts
@@ -16,6 +16,8 @@ const CHART_AVATAR_SIZE = 36
 const circularBySrc = new Map<string, string>()
 const inflightSrcs = new Set<string>()
 const failedSrcs = new Set<string>()
+/** Shared so every mounted ranking chart rerenders when any avatar clip finishes. */
+const circularClipRevision = ref(0)
 
 export type RankAvatarMember = {
   memberId?: number
@@ -187,7 +189,6 @@ export function clipAvatarToCircle(src: string, size = CHART_AVATAR_SIZE): Promi
 
 export function useCircularRankAvatarMap(members: () => RankAvatarMember[]): ComputedRef<RankAvatarMap> {
   const rawMap = useRankAvatarMap()
-  const revision = ref(0)
 
   watchEffect(() => {
     const raw = rawMap.value
@@ -199,13 +200,13 @@ export function useCircularRankAvatarMap(members: () => RankAvatarMember[]): Com
         inflightSrcs.delete(src)
         if (circular) circularBySrc.set(src, circular)
         else failedSrcs.add(src)
-        revision.value += 1
+        circularClipRevision.value += 1
       })
     }
   })
 
   return computed(() => {
-    void revision.value
+    void circularClipRevision.value
     const raw = rawMap.value
     const prepared = new Map<number, string | null>()
     for (const member of members()) {

--- a/src/utils/rankAvatars.ts
+++ b/src/utils/rankAvatars.ts
@@ -1,0 +1,220 @@
+import { computed, inject, ref, watchEffect, type ComputedRef, type InjectionKey } from 'vue'
+
+export type RankAvatarMap = ReadonlyMap<number, string | null>
+export type RankAvatarNameMap = ReadonlyMap<string, string | null>
+
+export interface RankAvatarIndex {
+  byId: RankAvatarMap
+  byName: RankAvatarNameMap
+}
+
+export const RANKING_AVATAR_MAP_KEY: InjectionKey<{ value: RankAvatarIndex }> = Symbol('ranking-avatar-map')
+
+const EMPTY_AVATAR_MAP: RankAvatarMap = new Map()
+const EMPTY_AVATAR_INDEX: RankAvatarIndex = { byId: EMPTY_AVATAR_MAP, byName: new Map() }
+const CHART_AVATAR_SIZE = 36
+const circularBySrc = new Map<string, string>()
+const inflightSrcs = new Set<string>()
+const failedSrcs = new Set<string>()
+
+export type RankAvatarMember = {
+  memberId?: number
+  id?: string | number
+  avatar?: string | null
+}
+
+export function buildRankAvatarMap(members: Array<{ id: number; avatar?: string | null }>): RankAvatarMap {
+  const map = new Map<number, string | null>()
+  for (const member of members) {
+    const avatar = member.avatar?.trim()
+    map.set(member.id, avatar ? avatar : null)
+  }
+  return map
+}
+
+function normalizedAvatar(avatar?: string | null): string | null {
+  const trimmed = avatar?.trim()
+  return trimmed ? trimmed : null
+}
+
+function rememberAvatarName(map: Map<string, string | null>, name: string | null | undefined, avatar: string | null) {
+  const key = name?.trim()
+  if (!key) return
+  const existing = map.get(key)
+  if (existing) return
+  if (avatar) map.set(key, avatar)
+  else if (!map.has(key)) map.set(key, null)
+}
+
+export function buildRankAvatarNameMap(
+  members: Array<{
+    groupNickname?: string | null
+    accountName?: string | null
+    platformId?: string | null
+    aliases?: string[]
+    avatar?: string | null
+  }>
+): RankAvatarNameMap {
+  const map = new Map<string, string | null>()
+  for (const member of members) {
+    const avatar = normalizedAvatar(member.avatar)
+    rememberAvatarName(map, member.groupNickname, avatar)
+    rememberAvatarName(map, member.accountName, avatar)
+    rememberAvatarName(map, member.platformId, avatar)
+    rememberAvatarName(map, member.groupNickname || member.accountName || member.platformId, avatar)
+    for (const alias of member.aliases ?? []) rememberAvatarName(map, alias, avatar)
+  }
+  return map
+}
+
+export function buildRankAvatarIndex(
+  members: Array<{
+    id: number
+    groupNickname?: string | null
+    accountName?: string | null
+    platformId?: string | null
+    aliases?: string[]
+    avatar?: string | null
+  }>
+): RankAvatarIndex {
+  return {
+    byId: buildRankAvatarMap(members),
+    byName: buildRankAvatarNameMap(members),
+  }
+}
+
+export function resolveRankAvatar(
+  memberId: number | string | undefined,
+  explicit: string | null | undefined,
+  avatars: RankAvatarMap,
+  fallback?: { name?: string | null; byName?: RankAvatarNameMap }
+): string | null {
+  const trimmed = explicit?.trim()
+  if (trimmed) return trimmed
+  if (memberId != null && memberId !== '') {
+    const id = typeof memberId === 'number' ? memberId : Number(memberId)
+    if (Number.isFinite(id)) {
+      const fromId = avatars.get(id)
+      if (fromId) return fromId
+    }
+  }
+  const name = fallback?.name?.trim()
+  if (name && fallback?.byName) return fallback.byName.get(name) ?? null
+  if (memberId == null || memberId === '') return null
+  const id = typeof memberId === 'number' ? memberId : Number(memberId)
+  if (!Number.isFinite(id)) return null
+  return avatars.get(id) ?? null
+}
+
+export function getRankAvatarText(name: string): string {
+  const trimmed = name.trim()
+  return trimmed ? trimmed.slice(0, 1) : '?'
+}
+
+export function attachRankAvatars<T>(
+  items: T[],
+  getMemberId: (item: T) => number | string,
+  avatars: RankAvatarMap
+): Array<T & { avatar: string | null }> {
+  return items.map((item) => ({
+    ...item,
+    avatar: resolveRankAvatar(getMemberId(item), (item as { avatar?: string | null }).avatar, avatars),
+  }))
+}
+
+export function useRankAvatarIndex(): ComputedRef<RankAvatarIndex> {
+  const provided = inject(RANKING_AVATAR_MAP_KEY, null)
+  return computed(() => provided?.value ?? EMPTY_AVATAR_INDEX)
+}
+
+export function useRankAvatarMap(): ComputedRef<RankAvatarMap> {
+  const index = useRankAvatarIndex()
+  return computed(() => index.value.byId)
+}
+
+/** ECharts cannot clip `backgroundColor.image` to a circle; only a pre-clipped bitmap looks round. */
+export function chartSafeAvatarSrc(
+  src: string | null | undefined,
+  circularCache: ReadonlyMap<string, string>
+): string | null {
+  if (!src) return null
+  return circularCache.get(src) ?? null
+}
+
+export function clipAvatarToCircle(src: string, size = CHART_AVATAR_SIZE): Promise<string | null> {
+  if (typeof Image === 'undefined' || typeof document === 'undefined') return Promise.resolve(null)
+
+  return new Promise((resolve) => {
+    const image = new Image()
+    if (/^https?:/i.test(src)) image.crossOrigin = 'anonymous'
+
+    image.onload = () => {
+      try {
+        const canvas = document.createElement('canvas')
+        canvas.width = size
+        canvas.height = size
+        const context = canvas.getContext('2d')
+        if (!context) {
+          resolve(null)
+          return
+        }
+
+        context.beginPath()
+        context.arc(size / 2, size / 2, size / 2, 0, Math.PI * 2)
+        context.closePath()
+        context.clip()
+
+        const width = image.naturalWidth || image.width
+        const height = image.naturalHeight || image.height
+        if (width <= 0 || height <= 0) {
+          resolve(null)
+          return
+        }
+
+        const scale = Math.max(size / width, size / height)
+        const drawWidth = width * scale
+        const drawHeight = height * scale
+        context.drawImage(image, (size - drawWidth) / 2, (size - drawHeight) / 2, drawWidth, drawHeight)
+        resolve(canvas.toDataURL('image/png'))
+      } catch {
+        resolve(null)
+      }
+    }
+    image.onerror = () => resolve(null)
+    image.src = src
+  })
+}
+
+export function useCircularRankAvatarMap(members: () => RankAvatarMember[]): ComputedRef<RankAvatarMap> {
+  const rawMap = useRankAvatarMap()
+  const revision = ref(0)
+
+  watchEffect(() => {
+    const raw = rawMap.value
+    for (const member of members()) {
+      const src = resolveRankAvatar(member.memberId ?? member.id, member.avatar, raw)
+      if (!src || circularBySrc.has(src) || failedSrcs.has(src) || inflightSrcs.has(src)) continue
+      inflightSrcs.add(src)
+      void clipAvatarToCircle(src).then((circular) => {
+        inflightSrcs.delete(src)
+        if (circular) circularBySrc.set(src, circular)
+        else failedSrcs.add(src)
+        revision.value += 1
+      })
+    }
+  })
+
+  return computed(() => {
+    void revision.value
+    const raw = rawMap.value
+    const prepared = new Map<number, string | null>()
+    for (const member of members()) {
+      const key = member.memberId ?? member.id
+      const id = typeof key === 'number' ? key : Number(key)
+      if (!Number.isFinite(id)) continue
+      const src = resolveRankAvatar(key, member.avatar, raw)
+      prepared.set(id, chartSafeAvatarSrc(src, circularBySrc))
+    }
+    return prepared
+  })
+}

--- a/src/utils/rankingChartLayout.test.ts
+++ b/src/utils/rankingChartLayout.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Run: pnpm test -- src/utils/rankingChartLayout.test.ts
+ */
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { buildRankAvatarMap } from './rankAvatars'
+import {
+  RANKING_LAYOUTS,
+  RANK_AVATAR_AXIS_GUTTER,
+  buildRankYAxis,
+  formatRankPrefix,
+  truncateRankName,
+} from './rankingChartLayout'
+
+test('ranking layouts reserve Y-axis space for avatars', () => {
+  assert.equal(RANKING_LAYOUTS.standard.gridLeft, 110 + RANK_AVATAR_AXIS_GUTTER)
+  assert.equal(RANKING_LAYOUTS.wide.gridLeft, 180 + RANK_AVATAR_AXIS_GUTTER)
+  assert.equal(RANKING_LAYOUTS.full.gridLeft, 260 + RANK_AVATAR_AXIS_GUTTER)
+})
+
+test('formatRankPrefix keeps medals for the top three', () => {
+  assert.deepEqual([1, 2, 3, 4, 10].map(formatRankPrefix), ['🥇', '🥈', '🥉', '4.', '10.'])
+})
+
+test('buildRankYAxis paints avatars and fallback initials on reversed rows', () => {
+  const avatars = buildRankAvatarMap([
+    { id: 1, avatar: 'https://alice.png' },
+    { id: 2, avatar: null },
+  ])
+  const axis = buildRankYAxis(
+    [
+      { memberId: 2, name: '非常长的群昵称会被截断' },
+      { id: '1', name: 'Alice' },
+    ],
+    {
+      totalCount: 2,
+      labelMaxLength: 8,
+      avatars,
+    }
+  )
+
+  assert.deepEqual(axis.data, [truncateRankName('非常长的群昵称会被截断', 8), 'Alice'])
+  assert.equal(axis.axisLabel.formatter('', 0), `{av0|非}{rank|🥈}{name|${axis.data[0]}}`)
+  assert.equal(axis.axisLabel.formatter('', 1), '{av1|}{rank|🥇}{name|Alice}')
+  assert.deepEqual(axis.axisLabel.rich.av1?.backgroundColor, { image: 'https://alice.png' })
+  assert.equal(axis.axisLabel.rich.av0?.backgroundColor, '#fce7f3')
+})
+
+test('buildRankYAxis ignores raw member photos and only uses the prepared map', () => {
+  const axis = buildRankYAxis([{ memberId: 1, name: 'Alice', avatar: 'https://square.png' }], {
+    totalCount: 1,
+    labelMaxLength: 8,
+    avatars: buildRankAvatarMap([{ id: 1, avatar: 'data:image/png;base64,CIRCLE' }]),
+  })
+
+  assert.deepEqual(axis.axisLabel.rich.av0?.backgroundColor, { image: 'data:image/png;base64,CIRCLE' })
+})

--- a/src/utils/rankingChartLayout.ts
+++ b/src/utils/rankingChartLayout.ts
@@ -1,4 +1,5 @@
 import { computed, inject, type ComputedRef, type InjectionKey, type Ref } from 'vue'
+import { getRankAvatarText, resolveRankAvatar, type RankAvatarMap } from './rankAvatars'
 
 export type RankingWidthMode = 'standard' | 'wide' | 'full'
 
@@ -8,24 +9,54 @@ interface RankingLayoutConfig {
   labelMaxLength: number
 }
 
+/** Extra Y-axis space for the 18px avatar plus gap before the rank prefix. */
+export const RANK_AVATAR_AXIS_GUTTER = 28
+const RANK_AXIS_AVATAR_SIZE = 18
+const RANK_AXIS_LABEL_COLOR = '#4b5563'
+
 export const RANKING_WIDTH_MODE_KEY: InjectionKey<Ref<RankingWidthMode>> = Symbol('ranking-width-mode')
 
 export const RANKING_LAYOUTS: Record<RankingWidthMode, RankingLayoutConfig> = {
   standard: {
     contentClass: 'max-w-3xl',
-    gridLeft: 110,
+    gridLeft: 110 + RANK_AVATAR_AXIS_GUTTER,
     labelMaxLength: 8,
   },
   wide: {
     contentClass: 'max-w-5xl',
-    gridLeft: 180,
+    gridLeft: 180 + RANK_AVATAR_AXIS_GUTTER,
     labelMaxLength: 16,
   },
   full: {
     contentClass: 'max-w-none',
-    gridLeft: 260,
+    gridLeft: 260 + RANK_AVATAR_AXIS_GUTTER,
     labelMaxLength: 28,
   },
+}
+
+export interface RankYAxisMember {
+  name: string
+  memberId?: number
+  id?: string | number
+  avatar?: string | null
+}
+
+export interface RankYAxisLabelConfig {
+  data: string[]
+  axisLabel: {
+    fontSize: number
+    color: string
+    margin: number
+    formatter: (value: string, index: number) => string
+    rich: Record<string, Record<string, unknown>>
+  }
+}
+
+export function formatRankPrefix(rank: number): string {
+  if (rank === 1) return '🥇'
+  if (rank === 2) return '🥈'
+  if (rank === 3) return '🥉'
+  return `${rank}.`
 }
 
 export function useRankingLayout(): ComputedRef<RankingLayoutConfig> {
@@ -36,4 +67,75 @@ export function useRankingLayout(): ComputedRef<RankingLayoutConfig> {
 export function truncateRankName(name: string, maxLength: number): string {
   if (name.length <= maxLength) return name
   return `${name.slice(0, maxLength)}…`
+}
+
+function avatarRichStyle(avatar: string | null): Record<string, unknown> {
+  if (avatar) {
+    return {
+      width: RANK_AXIS_AVATAR_SIZE,
+      height: RANK_AXIS_AVATAR_SIZE,
+      borderRadius: RANK_AXIS_AVATAR_SIZE / 2,
+      backgroundColor: { image: avatar },
+      align: 'center',
+      verticalAlign: 'middle',
+    }
+  }
+
+  return {
+    width: RANK_AXIS_AVATAR_SIZE,
+    height: RANK_AXIS_AVATAR_SIZE,
+    borderRadius: RANK_AXIS_AVATAR_SIZE / 2,
+    backgroundColor: '#fce7f3',
+    color: '#db2777',
+    fontSize: 10,
+    fontWeight: 600,
+    align: 'center',
+    verticalAlign: 'middle',
+    lineHeight: RANK_AXIS_AVATAR_SIZE,
+  }
+}
+
+export function buildRankYAxis(
+  reversedMembers: RankYAxisMember[],
+  options: {
+    totalCount: number
+    labelMaxLength: number
+    avatars: RankAvatarMap
+  }
+): RankYAxisLabelConfig {
+  const names = reversedMembers.map((member) => truncateRankName(member.name, options.labelMaxLength))
+  const rich: Record<string, Record<string, unknown>> = {
+    rank: {
+      fontSize: 12,
+      color: RANK_AXIS_LABEL_COLOR,
+      padding: [0, 4, 0, 4],
+    },
+    name: {
+      fontSize: 12,
+      color: RANK_AXIS_LABEL_COLOR,
+    },
+  }
+
+  reversedMembers.forEach((member, index) => {
+    const avatar = resolveRankAvatar(member.memberId ?? member.id, undefined, options.avatars)
+    rich[`av${index}`] = avatarRichStyle(avatar)
+  })
+
+  return {
+    data: names,
+    axisLabel: {
+      fontSize: 12,
+      color: RANK_AXIS_LABEL_COLOR,
+      margin: 8,
+      formatter: (_value: string, index: number) => {
+        const member = reversedMembers[index]
+        if (!member) return ''
+        const rank = options.totalCount - index
+        const avatar = resolveRankAvatar(member.memberId ?? member.id, undefined, options.avatars)
+        const avatarText = avatar ? '' : getRankAvatarText(member.name)
+        return `{av${index}|${avatarText}}{rank|${formatRankPrefix(rank)}}{name|${names[index] ?? ''}}`
+      },
+      rich,
+    },
+  }
 }


### PR DESCRIPTION
Render circular member avatars on ranking lists, person-based charts, hot-repeat originators, and catchphrase rows. Look up avatars from the member table instead of bloating ranking queries, and clip ECharts photos so they match the HTML lists.