### PR TITLE
feat(ai): persist global conversations

### DIFF
--- a/apps/desktop/main/ai/chats.ts
+++ b/apps/desktop/main/ai/chats.ts
@@ -10,7 +10,15 @@ import { getPathProvider } from '../paths/provider'
 import { resolveDesktopNativeBinding } from '../runtime/native-sqlite'
 import { aiLogger } from './logger'
 
-export type { AIChat, AIMessage, AIMessageRole, ContentBlock, TokenUsageData } from '@openchatlab/node-runtime'
+export type {
+  AIChat,
+  AIChatKind,
+  AIEntityRef,
+  AIMessage,
+  AIMessageRole,
+  ContentBlock,
+  TokenUsageData,
+} from '@openchatlab/node-runtime'
 
 let manager: AIChatManager | null = null
 
@@ -47,12 +55,20 @@ export function createAIChat(sessionId: string, title: string | undefined, assis
   return getManager().createAIChat(sessionId, title, assistantId)
 }
 
+export function createGlobalAIChat(title: string | undefined, assistantId: string) {
+  return getManager().createGlobalAIChat(title, assistantId)
+}
+
 export function getAIChatCountsBySession() {
   return getManager().getAIChatCountsBySession()
 }
 
 export function getAIChats(sessionId: string) {
   return getManager().getAIChats(sessionId)
+}
+
+export function getGlobalAIChats() {
+  return getManager().getGlobalAIChats()
 }
 
 export function getAIChat(aiChatId: string) {
@@ -74,9 +90,19 @@ export function addMessage(
   dataKeywords?: string[],
   dataMessageCount?: number,
   contentBlocks?: import('@openchatlab/node-runtime').ContentBlock[],
-  tokenUsage?: import('@openchatlab/node-runtime').TokenUsageData
+  tokenUsage?: import('@openchatlab/node-runtime').TokenUsageData,
+  entityRefs?: import('@openchatlab/node-runtime').AIEntityRef[]
 ) {
-  return getManager().addMessage(aiChatId, role, content, dataKeywords, dataMessageCount, contentBlocks, tokenUsage)
+  return getManager().addMessage(
+    aiChatId,
+    role,
+    content,
+    dataKeywords,
+    dataMessageCount,
+    contentBlocks,
+    tokenUsage,
+    entityRefs
+  )
 }
 
 export function getMessages(aiChatId: string) {
@@ -109,9 +135,10 @@ export function insertMessageAfter(
   role: import('@openchatlab/node-runtime').AIMessageRole,
   content: string,
   contentBlocks?: import('@openchatlab/node-runtime').ContentBlock[],
-  tokenUsage?: import('@openchatlab/node-runtime').TokenUsageData
+  tokenUsage?: import('@openchatlab/node-runtime').TokenUsageData,
+  entityRefs?: import('@openchatlab/node-runtime').AIEntityRef[]
 ) {
-  return getManager().insertMessageAfter(aiChatId, afterMessageId, role, content, contentBlocks, tokenUsage)
+  return getManager().insertMessageAfter(aiChatId, afterMessageId, role, content, contentBlocks, tokenUsage, entityRefs)
 }
 
 export function setPendingDebugContext(aiChatId: string, debugContext: string) {

--- a/apps/desktop/main/ai/chats.ts
+++ b/apps/desktop/main/ai/chats.ts
@@ -121,8 +121,12 @@ export function forkAIChat(sourceAIChatId: string, upToMessageId: string, title?
   return getManager().forkAIChat(sourceAIChatId, upToMessageId, title)
 }
 
-export function updateMessageContent(messageId: string, newContent: string) {
-  return getManager().updateMessageContent(messageId, newContent)
+export function updateMessageContent(
+  messageId: string,
+  newContent: string,
+  entityRefs?: import('@openchatlab/node-runtime').AIEntityRef[]
+) {
+  return getManager().updateMessageContent(messageId, newContent, entityRefs)
 }
 
 export function deleteAndRelinkMessage(aiChatId: string, messageId: string) {

--- a/packages/http-routes/src/routes/web/ai-chats.test.ts
+++ b/packages/http-routes/src/routes/web/ai-chats.test.ts
@@ -56,6 +56,20 @@ test('global AI chat routes keep global history separate and persist entity refe
   assert.equal(messageResponse.statusCode, 200)
   assert.deepEqual(messageResponse.json<{ entityRefs: unknown[] }>().entityRefs, refs)
 
+  const assistantResponse = await app.inject({
+    method: 'POST',
+    url: `/_web/ai/chats/${globalChat.id}/messages`,
+    payload: { role: 'assistant', content: 'I will compare them', entityRefs: refs },
+  })
+  assert.equal(assistantResponse.statusCode, 200)
+  assert.equal(assistantResponse.json<{ entityRefs?: unknown[] }>().entityRefs, undefined)
+
+  const messageList = await app.inject({
+    method: 'GET',
+    url: `/_web/ai/chats/${globalChat.id}/messages`,
+  })
+  assert.equal(messageList.json<Array<{ entityRefs?: unknown[] }>>()[1]?.entityRefs, undefined)
+
   const globalList = await app.inject({ method: 'GET', url: '/_web/ai/global-chats' })
   assert.deepEqual(
     globalList.json<Array<{ id: string }>>().map((chat) => chat.id),

--- a/packages/http-routes/src/routes/web/ai-chats.test.ts
+++ b/packages/http-routes/src/routes/web/ai-chats.test.ts
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import test from 'node:test'
+import Fastify from 'fastify'
+import { AIChatManager } from '@openchatlab/node-runtime'
+import { registerAiChatRoutes } from './ai-chats'
+
+const sqliteNativeBinding = process.env.CHATLAB_TEST_SQLITE_NATIVE_BINDING
+
+test('global AI chat routes keep global history separate and persist entity references', async (t) => {
+  const dir = mkdtempSync(join(tmpdir(), 'chatlab-global-ai-routes-'))
+  const manager = sqliteNativeBinding
+    ? new AIChatManager(dir, { nativeBinding: sqliteNativeBinding })
+    : new AIChatManager(dir)
+  const app = Fastify()
+  registerAiChatRoutes(app, { aiChatManager: manager })
+
+  t.after(async () => {
+    await app.close()
+    manager.close()
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  const sessionResponse = await app.inject({
+    method: 'POST',
+    url: '/_web/ai/chats',
+    payload: { sessionId: 'session-1', title: 'Session chat', assistantId: 'general_cn' },
+  })
+  assert.equal(sessionResponse.statusCode, 200)
+
+  const globalResponse = await app.inject({
+    method: 'POST',
+    url: '/_web/ai/global-chats',
+    payload: { title: 'Global chat', assistantId: 'general_cn' },
+  })
+  assert.equal(globalResponse.statusCode, 200)
+  const globalChat = globalResponse.json<{ id: string; kind: string }>()
+  assert.equal(globalChat.kind, 'global')
+
+  const refs = [
+    { type: 'contact' as const, contactKey: 'qq:10001', displayName: 'Alice' },
+    {
+      type: 'session' as const,
+      sessionId: 'group-1',
+      displayName: 'Project Group',
+      sessionType: 'group' as const,
+    },
+  ]
+  const messageResponse = await app.inject({
+    method: 'POST',
+    url: `/_web/ai/chats/${globalChat.id}/messages`,
+    payload: { role: 'user', content: 'Compare them', entityRefs: refs },
+  })
+  assert.equal(messageResponse.statusCode, 200)
+  assert.deepEqual(messageResponse.json<{ entityRefs: unknown[] }>().entityRefs, refs)
+
+  const globalList = await app.inject({ method: 'GET', url: '/_web/ai/global-chats' })
+  assert.deepEqual(
+    globalList.json<Array<{ id: string }>>().map((chat) => chat.id),
+    [globalChat.id]
+  )
+
+  const sessionList = await app.inject({ method: 'GET', url: '/_web/ai/chats?sessionId=session-1' })
+  assert.equal(sessionList.json<Array<{ kind: string }>>()[0]?.kind, 'session')
+  assert.equal(
+    sessionList.json<Array<{ id: string }>>().some((chat) => chat.id === globalChat.id),
+    false
+  )
+})

--- a/packages/http-routes/src/routes/web/ai-chats.test.ts
+++ b/packages/http-routes/src/routes/web/ai-chats.test.ts
@@ -70,6 +70,41 @@ test('global AI chat routes keep global history separate and persist entity refe
   })
   assert.equal(messageList.json<Array<{ entityRefs?: unknown[] }>>()[1]?.entityRefs, undefined)
 
+  const replacementRefs = [
+    {
+      type: 'session' as const,
+      sessionId: 'group-2',
+      displayName: 'New Group',
+      sessionType: 'group' as const,
+    },
+  ]
+  const userMessageId = messageResponse.json<{ id: string }>().id
+  const replaceResponse = await app.inject({
+    method: 'PUT',
+    url: `/_web/ai/messages/${userMessageId}/content`,
+    payload: { content: 'Compare the new group', entityRefs: replacementRefs },
+  })
+  assert.equal(replaceResponse.statusCode, 200)
+
+  const replacedMessageList = await app.inject({
+    method: 'GET',
+    url: `/_web/ai/chats/${globalChat.id}/messages`,
+  })
+  assert.deepEqual(replacedMessageList.json<Array<{ entityRefs?: unknown[] }>>()[0]?.entityRefs, replacementRefs)
+
+  const clearResponse = await app.inject({
+    method: 'PUT',
+    url: `/_web/ai/messages/${userMessageId}/content`,
+    payload: { content: 'Compare without named entities' },
+  })
+  assert.equal(clearResponse.statusCode, 200)
+
+  const clearedMessageList = await app.inject({
+    method: 'GET',
+    url: `/_web/ai/chats/${globalChat.id}/messages`,
+  })
+  assert.equal(clearedMessageList.json<Array<{ entityRefs?: unknown[] }>>()[0]?.entityRefs, undefined)
+
   const globalList = await app.inject({ method: 'GET', url: '/_web/ai/global-chats' })
   assert.deepEqual(
     globalList.json<Array<{ id: string }>>().map((chat) => chat.id),

--- a/packages/http-routes/src/routes/web/ai-chats.ts
+++ b/packages/http-routes/src/routes/web/ai-chats.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance } from 'fastify'
 import type { AiRouteContext } from '../../context/ai'
 import { countMessagesTokens } from '@openchatlab/node-runtime'
+import type { AIEntityRef } from '@openchatlab/node-runtime'
 
 type AiChatRouteContext = Pick<AiRouteContext, 'aiChatManager'>
 
@@ -23,6 +24,17 @@ export function registerAiChatRoutes(server: FastifyInstance, ctx: AiChatRouteCo
     const { sessionId } = request.query
     if (!sessionId) return []
     return cm.getAIChats(sessionId)
+  })
+
+  server.post<{
+    Body: { title?: string; assistantId: string }
+  }>('/_web/ai/global-chats', async (request) => {
+    const { title, assistantId } = request.body
+    return cm.createGlobalAIChat(title, assistantId)
+  })
+
+  server.get('/_web/ai/global-chats', async () => {
+    return cm.getGlobalAIChats()
   })
 
   server.get<{ Params: { id: string } }>('/_web/ai/chats/:id', async (request, reply) => {
@@ -59,9 +71,10 @@ export function registerAiChatRoutes(server: FastifyInstance, ctx: AiChatRouteCo
         cacheReadTokens?: number
         cacheWriteTokens?: number
       }
+      entityRefs?: AIEntityRef[]
     }
   }>('/_web/ai/chats/:id/messages', async (request) => {
-    const { role, content, dataKeywords, dataMessageCount, contentBlocks, tokenUsage } = request.body
+    const { role, content, dataKeywords, dataMessageCount, contentBlocks, tokenUsage, entityRefs } = request.body
     return cm.addMessage(
       request.params.id,
       role,
@@ -69,7 +82,8 @@ export function registerAiChatRoutes(server: FastifyInstance, ctx: AiChatRouteCo
       dataKeywords,
       dataMessageCount,
       contentBlocks as any,
-      tokenUsage
+      tokenUsage,
+      entityRefs
     )
   })
 
@@ -136,13 +150,22 @@ export function registerAiChatRoutes(server: FastifyInstance, ctx: AiChatRouteCo
         cacheReadTokens?: number
         cacheWriteTokens?: number
       }
+      entityRefs?: AIEntityRef[]
     }
   }>('/_web/ai/chats/:id/messages/insert-after', async (request, reply) => {
-    const { afterMessageId, role, content, contentBlocks, tokenUsage } = request.body
+    const { afterMessageId, role, content, contentBlocks, tokenUsage, entityRefs } = request.body
     if (!afterMessageId || typeof afterMessageId !== 'string') {
       return reply.code(400).send({ error: 'afterMessageId is required' })
     }
-    return cm.insertMessageAfter(request.params.id, afterMessageId, role, content, contentBlocks as any, tokenUsage)
+    return cm.insertMessageAfter(
+      request.params.id,
+      afterMessageId,
+      role,
+      content,
+      contentBlocks as any,
+      tokenUsage,
+      entityRefs
+    )
   })
 
   server.get<{ Params: { id: string } }>('/_web/ai/chats/:id/token-usage', async (request) => {

--- a/packages/http-routes/src/routes/web/ai-chats.ts
+++ b/packages/http-routes/src/routes/web/ai-chats.ts
@@ -115,13 +115,13 @@ export function registerAiChatRoutes(server: FastifyInstance, ctx: AiChatRouteCo
 
   server.put<{
     Params: { messageId: string }
-    Body: { content: string }
+    Body: { content: string; entityRefs?: AIEntityRef[] }
   }>('/_web/ai/messages/:messageId/content', async (request, reply) => {
-    const { content } = request.body
+    const { content, entityRefs } = request.body
     if (!content || typeof content !== 'string') {
       return reply.code(400).send({ error: 'content is required' })
     }
-    cm.updateMessageContent(request.params.messageId, content)
+    cm.updateMessageContent(request.params.messageId, content, entityRefs)
     return { success: true }
   })
 

--- a/packages/node-runtime/src/ai/__tests__/chats.test.ts
+++ b/packages/node-runtime/src/ai/__tests__/chats.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import Database from 'better-sqlite3'
 import { AIChatManager } from '../chats'
+import type { AIEntityRef } from '../chats'
 import type { ChartPayload } from '@openchatlab/core'
 
 const sqliteNativeBinding = process.env.CHATLAB_TEST_SQLITE_NATIVE_BINDING
@@ -277,6 +278,132 @@ describe('AIChatManager legacy migration', () => {
       assert.equal(messages[0]?.parentId, null)
       assert.equal(messages[1]?.parentId, 'pm1')
       assert.equal(manager.getAIChat('conv-partial')?.activeMessageId, 'pm2')
+      manager.close()
+    } finally {
+      cleanup(dir)
+    }
+  })
+
+  it('adds global chat and entity reference columns to the previously released schema', () => {
+    const dir = createTempDir()
+    try {
+      const db = createTestDatabase(join(dir, 'conversations.db'))
+      db.exec(`
+        CREATE TABLE ai_chat (
+          id TEXT PRIMARY KEY,
+          session_id TEXT NOT NULL,
+          title TEXT,
+          assistant_id TEXT DEFAULT 'general_cn',
+          active_message_id TEXT,
+          created_at INTEGER NOT NULL,
+          updated_at INTEGER NOT NULL
+        );
+        CREATE TABLE ai_message (
+          id TEXT PRIMARY KEY,
+          ai_chat_id TEXT NOT NULL,
+          role TEXT NOT NULL,
+          content TEXT NOT NULL,
+          timestamp INTEGER NOT NULL,
+          data_keywords TEXT,
+          data_message_count INTEGER,
+          content_blocks TEXT,
+          parent_id TEXT,
+          sibling_group_id TEXT,
+          branch_index INTEGER DEFAULT 0,
+          debug_context TEXT,
+          token_usage TEXT
+        );
+      `)
+      db.prepare('INSERT INTO ai_chat VALUES (?, ?, ?, ?, ?, ?, ?)').run(
+        'existing-chat',
+        'session-existing',
+        'Existing',
+        'general_cn',
+        'existing-message',
+        1,
+        1
+      )
+      db.prepare('INSERT INTO ai_message VALUES (?, ?, ?, ?, ?, NULL, NULL, NULL, NULL, ?, 0, NULL, NULL)').run(
+        'existing-message',
+        'existing-chat',
+        'user',
+        'hello',
+        1,
+        'existing-message'
+      )
+      db.close()
+
+      const manager = createManager(dir)
+      assert.equal(manager.getAIChats('session-existing')[0]?.kind, 'session')
+      assert.equal(manager.getMessages('existing-chat')[0]?.entityRefs, undefined)
+      manager.close()
+
+      const migrated = createTestDatabase(join(dir, 'conversations.db'))
+      const chatColumns = migrated.pragma('table_info(ai_chat)') as Array<{ name: string }>
+      const messageColumns = migrated.pragma('table_info(ai_message)') as Array<{ name: string }>
+      assert.ok(chatColumns.some((column) => column.name === 'kind'))
+      assert.ok(messageColumns.some((column) => column.name === 'entity_refs'))
+      migrated.close()
+    } finally {
+      cleanup(dir)
+    }
+  })
+})
+
+describe('AIChatManager global chats and entity references', () => {
+  const entityRefs: AIEntityRef[] = [
+    { type: 'contact', contactKey: 'qq:10001', displayName: 'Alice' },
+    { type: 'session', sessionId: 'group-1', displayName: 'Project Group', sessionType: 'group' },
+  ]
+
+  it('keeps global chats out of session lists and counts', () => {
+    const dir = createTempDir()
+    try {
+      const manager = createManager(dir)
+      const sessionChat = manager.createAIChat('session-1', 'Session', 'general_cn')
+      const globalChat = manager.createGlobalAIChat('Global', 'general_cn')
+
+      assert.equal(sessionChat.kind, 'session')
+      assert.equal(globalChat.kind, 'global')
+      assert.equal(globalChat.sessionId, '')
+      assert.deepEqual(
+        manager.getAIChats('session-1').map((chat) => chat.id),
+        [sessionChat.id]
+      )
+      assert.deepEqual(
+        manager.getGlobalAIChats().map((chat) => chat.id),
+        [globalChat.id]
+      )
+      assert.deepEqual([...manager.getAIChatCountsBySession()], [['session-1', 1]])
+      manager.close()
+    } finally {
+      cleanup(dir)
+    }
+  })
+
+  it('persists entity references with their user message and preserves them when forking', () => {
+    const dir = createTempDir()
+    try {
+      const manager = createManager(dir)
+      const globalChat = manager.createGlobalAIChat('Global', 'general_cn')
+      const userMessage = manager.addMessage(
+        globalChat.id,
+        'user',
+        'Compare them',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        entityRefs
+      )
+      manager.addMessage(globalChat.id, 'assistant', 'I will compare them.')
+
+      assert.deepEqual(manager.getMessages(globalChat.id)[0]?.entityRefs, entityRefs)
+      assert.deepEqual(manager.getHistoryForAgent(globalChat.id)[0]?.entityRefs, entityRefs)
+
+      const fork = manager.forkAIChat(globalChat.id, userMessage.id)
+      assert.equal(fork.kind, 'global')
+      assert.deepEqual(manager.getMessages(fork.id)[0]?.entityRefs, entityRefs)
       manager.close()
     } finally {
       cleanup(dir)

--- a/packages/node-runtime/src/ai/__tests__/chats.test.ts
+++ b/packages/node-runtime/src/ai/__tests__/chats.test.ts
@@ -435,19 +435,40 @@ describe('AIChatManager global chats and entity references', () => {
 })
 
 describe('AIChatManager message editing', () => {
-  it('updateMessageContent updates message text in place', () => {
+  it('updateMessageContent atomically replaces or clears user entity references', () => {
     const dir = createTempDir()
     try {
       const manager = createManager(dir)
       const conv = manager.createAIChat('s1', 'Test', 'general_cn')
-      const msg = manager.addMessage(conv.id, 'user', 'original text')
+      const originalRefs: AIEntityRef[] = [{ type: 'contact', contactKey: 'qq:10001', displayName: 'Alice' }]
+      const replacementRefs: AIEntityRef[] = [
+        { type: 'session', sessionId: 'group-2', displayName: 'New Group', sessionType: 'group' },
+      ]
+      const msg = manager.addMessage(
+        conv.id,
+        'user',
+        'original text',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        originalRefs
+      )
       manager.addMessage(conv.id, 'assistant', 'reply')
 
-      manager.updateMessageContent(msg.id, 'edited text')
+      manager.updateMessageContent(msg.id, 'edited text', replacementRefs)
 
-      const messages = manager.getMessages(conv.id)
-      assert.equal(messages[0]?.content, 'edited text')
-      assert.equal(messages[1]?.content, 'reply')
+      assert.equal(manager.getMessages(conv.id)[0]?.content, 'edited text')
+      assert.deepEqual(manager.getMessages(conv.id)[0]?.entityRefs, replacementRefs)
+      assert.deepEqual(manager.getHistoryForAgent(conv.id)[0]?.entityRefs, replacementRefs)
+
+      manager.updateMessageContent(msg.id, 'edited without entities')
+
+      const messagesAfterClear = manager.getMessages(conv.id)
+      assert.equal(messagesAfterClear[0]?.content, 'edited without entities')
+      assert.equal(messagesAfterClear[0]?.entityRefs, undefined)
+      assert.equal(manager.getHistoryForAgent(conv.id)[0]?.entityRefs, undefined)
+      assert.equal(messagesAfterClear[1]?.content, 'reply')
       manager.close()
     } finally {
       cleanup(dir)

--- a/packages/node-runtime/src/ai/__tests__/chats.test.ts
+++ b/packages/node-runtime/src/ai/__tests__/chats.test.ts
@@ -396,10 +396,33 @@ describe('AIChatManager global chats and entity references', () => {
         undefined,
         entityRefs
       )
-      manager.addMessage(globalChat.id, 'assistant', 'I will compare them.')
+      const assistantMessage = manager.addMessage(
+        globalChat.id,
+        'assistant',
+        'I will compare them.',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        entityRefs
+      )
 
       assert.deepEqual(manager.getMessages(globalChat.id)[0]?.entityRefs, entityRefs)
       assert.deepEqual(manager.getHistoryForAgent(globalChat.id)[0]?.entityRefs, entityRefs)
+      assert.equal(assistantMessage.entityRefs, undefined)
+      assert.equal(manager.getMessages(globalChat.id)[1]?.entityRefs, undefined)
+      assert.equal(manager.getHistoryForAgent(globalChat.id)[1]?.entityRefs, undefined)
+
+      const insertedAssistant = manager.insertMessageAfter(
+        globalChat.id,
+        userMessage.id,
+        'assistant',
+        'Updated comparison',
+        undefined,
+        undefined,
+        entityRefs
+      )
+      assert.equal(insertedAssistant.entityRefs, undefined)
 
       const fork = manager.forkAIChat(globalChat.id, userMessage.id)
       assert.equal(fork.kind, 'global')

--- a/packages/node-runtime/src/ai/agent/__tests__/history.test.ts
+++ b/packages/node-runtime/src/ai/agent/__tests__/history.test.ts
@@ -49,6 +49,26 @@ describe('toPiHistoryMessages — legacy plain history', () => {
     assert.deepEqual(out[0].content, [{ type: 'text', text: 'compressed context' }])
   })
 
+  it('replays stable entity references next to their originating message', () => {
+    const out = toPiHistoryMessages([
+      {
+        role: 'user',
+        content: 'compare them',
+        entityRefs: [{ type: 'contact', contactKey: 'qq:10001', displayName: 'Alice' }],
+      },
+    ])
+    assert.equal(out[0]?.role, 'user')
+    if (out[0]?.role !== 'user') return
+    assert.ok(Array.isArray(out[0].content))
+    if (!Array.isArray(out[0].content)) return
+    const text = out[0].content[0]
+    assert.equal(typeof text, 'object')
+    if (!text || typeof text !== 'object') return
+    assert.equal(text?.type, 'text')
+    assert.ok(text?.type === 'text' && text.text.startsWith('compare them\n\n<chatlab_entity_refs>'))
+    assert.ok(text?.type === 'text' && text.text.includes('"contactKey":"qq:10001"'))
+  })
+
   it('falls back to plain text when tool blocks lack persisted toolCallId/result (legacy rows)', () => {
     const history: SimpleHistoryMessage[] = [
       {

--- a/packages/node-runtime/src/ai/agent/__tests__/history.test.ts
+++ b/packages/node-runtime/src/ai/agent/__tests__/history.test.ts
@@ -69,6 +69,34 @@ describe('toPiHistoryMessages — legacy plain history', () => {
     assert.ok(text?.type === 'text' && text.text.includes('"contactKey":"qq:10001"'))
   })
 
+  it('does not replay entity references attached to assistant messages', () => {
+    const out = toPiHistoryMessages([
+      {
+        role: 'assistant',
+        content: 'comparison result',
+        entityRefs: [{ type: 'contact', contactKey: 'qq:10001', displayName: 'Alice' }],
+      },
+    ])
+
+    assert.equal(out[0]?.role, 'assistant')
+    assert.deepEqual(out[0]?.content, [{ type: 'text', text: 'comparison result' }])
+  })
+
+  it('replays entity references retained by a compressed summary', () => {
+    const out = toPiHistoryMessages([
+      {
+        role: 'summary',
+        content: 'compressed context',
+        entityRefs: [{ type: 'contact', contactKey: 'qq:10001', displayName: 'Alice' }],
+      },
+    ])
+
+    assert.equal(out[0]?.role, 'assistant')
+    if (out[0]?.role !== 'assistant') return
+    const text = out[0].content[0]
+    assert.ok(text?.type === 'text' && text.text.startsWith('compressed context\n\n<chatlab_entity_refs>'))
+  })
+
   it('falls back to plain text when tool blocks lack persisted toolCallId/result (legacy rows)', () => {
     const history: SimpleHistoryMessage[] = [
       {

--- a/packages/node-runtime/src/ai/agent/history.ts
+++ b/packages/node-runtime/src/ai/agent/history.ts
@@ -17,7 +17,7 @@ import type { Message as PiMessage, AssistantMessage, Usage as PiUsage } from '@
 import { truncateToolResultText } from '@openchatlab/core'
 
 import type { SimpleHistoryMessage } from './types'
-import type { ContentBlock } from '../chats'
+import type { AIEntityRef, ContentBlock } from '../chats'
 
 type ToolBlock = Extract<ContentBlock, { type: 'tool' }>
 export type ReplayableToolBlock = ToolBlock & { tool: ToolBlock['tool'] & { toolCallId: string; result: string } }
@@ -42,6 +42,11 @@ export interface ReplayOptions {
    * pi-ai ThinkingContent blocks with this signature.
    */
   thinkingSignature?: string
+}
+
+export function appendEntityRefsForModel(text: string, entityRefs?: AIEntityRef[]): string {
+  if (!entityRefs?.length) return text
+  return `${text}\n\n<chatlab_entity_refs>${JSON.stringify(entityRefs)}</chatlab_entity_refs>`
 }
 
 function createEmptyPiUsage(): PiUsage {
@@ -137,7 +142,7 @@ export function toPiHistoryMessages(messages: SimpleHistoryMessage[], options?: 
     if (msg.role === 'user') {
       out.push({
         role: 'user',
-        content: [{ type: 'text', text: msg.content || '' }],
+        content: [{ type: 'text', text: appendEntityRefsForModel(msg.content || '', msg.entityRefs) }],
         timestamp: Date.now(),
       })
       continue
@@ -148,7 +153,13 @@ export function toPiHistoryMessages(messages: SimpleHistoryMessage[], options?: 
     if (replayable) {
       replayAssistantBlocks(msg.contentBlocks!, out, options)
     } else {
-      out.push(makeAssistantMessage([{ type: 'text', text: msg.content || '' }], 'stop', options?.modelInfo))
+      out.push(
+        makeAssistantMessage(
+          [{ type: 'text', text: appendEntityRefsForModel(msg.content || '', msg.entityRefs) }],
+          'stop',
+          options?.modelInfo
+        )
+      )
     }
   }
 

--- a/packages/node-runtime/src/ai/agent/history.ts
+++ b/packages/node-runtime/src/ai/agent/history.ts
@@ -155,7 +155,12 @@ export function toPiHistoryMessages(messages: SimpleHistoryMessage[], options?: 
     } else {
       out.push(
         makeAssistantMessage(
-          [{ type: 'text', text: appendEntityRefsForModel(msg.content || '', msg.entityRefs) }],
+          [
+            {
+              type: 'text',
+              text: appendEntityRefsForModel(msg.content || '', msg.role === 'summary' ? msg.entityRefs : undefined),
+            },
+          ],
           'stop',
           options?.modelInfo
         )

--- a/packages/node-runtime/src/ai/agent/types.ts
+++ b/packages/node-runtime/src/ai/agent/types.ts
@@ -9,7 +9,7 @@ import type { AgentTool } from '@earendil-works/pi-agent-core'
 import type { Model, Api, Message } from '@earendil-works/pi-ai'
 import type { ThinkingLevel } from '@openchatlab/core'
 import type { ToolProgress } from '@openchatlab/shared-types'
-import type { ContentBlock } from '../chats'
+import type { AIEntityRef, ContentBlock } from '../chats'
 
 export interface AgentTokenUsage {
   promptTokens: number
@@ -24,6 +24,8 @@ export interface SimpleHistoryMessage {
   content: string
   /** Persisted content blocks; tool blocks with toolCallId+result are replayed as real toolCall/toolResult pairs. */
   contentBlocks?: ContentBlock[]
+  /** Stable entities selected on the originating user message or retained by a compressed summary. */
+  entityRefs?: AIEntityRef[]
 }
 
 export type AgentCoreEvent =

--- a/packages/node-runtime/src/ai/chats.ts
+++ b/packages/node-runtime/src/ai/chats.ts
@@ -842,9 +842,17 @@ export class AIChatManager {
     }
   }
 
-  updateMessageContent(messageId: string, newContent: string): void {
+  /** Replace message text and user entity references atomically; omitted references clear the previous value. */
+  updateMessageContent(messageId: string, newContent: string, entityRefs?: AIEntityRef[]): void {
     const db = this.getDb()
-    const result = db.prepare('UPDATE ai_message SET content = ? WHERE id = ?').run(newContent, messageId)
+    const serializedEntityRefs = entityRefs?.length ? JSON.stringify(entityRefs) : null
+    const result = db
+      .prepare(
+        `UPDATE ai_message
+         SET content = ?, entity_refs = CASE WHEN role = 'user' THEN ? ELSE NULL END
+         WHERE id = ?`
+      )
+      .run(newContent, serializedEntityRefs, messageId)
     if (result.changes === 0) throw new Error('Message not found')
   }
 

--- a/packages/node-runtime/src/ai/chats.ts
+++ b/packages/node-runtime/src/ai/chats.ts
@@ -19,12 +19,28 @@ const DEFAULT_GENERAL_ID = DEFAULT_GENERAL_ASSISTANT_ID
 export interface AIChat {
   id: string
   sessionId: string
+  kind: AIChatKind
   title: string | null
   assistantId: string
   activeMessageId?: string | null
   createdAt: number
   updatedAt: number
 }
+
+export type AIChatKind = 'session' | 'global'
+
+export type AIEntityRef =
+  | {
+      type: 'contact'
+      contactKey: string
+      displayName: string
+    }
+  | {
+      type: 'session'
+      sessionId: string
+      displayName: string
+      sessionType: 'private' | 'group'
+    }
 
 export type ContentBlock =
   | { type: 'text'; text: string; processDurationMs?: number }
@@ -78,6 +94,14 @@ export interface AIMessage {
   dataMessageCount?: number
   contentBlocks?: ContentBlock[]
   tokenUsage?: TokenUsageData
+  entityRefs?: AIEntityRef[]
+}
+
+export interface AIHistoryMessage {
+  role: 'user' | 'assistant' | 'summary'
+  content: string
+  contentBlocks?: ContentBlock[]
+  entityRefs?: AIEntityRef[]
 }
 
 interface AIMessageRow {
@@ -93,6 +117,7 @@ interface AIMessageRow {
   dataMessageCount: number | null
   contentBlocks: string | null
   tokenUsage: string | null
+  entityRefs: string | null
 }
 
 export interface AIChatManagerLogger {
@@ -138,6 +163,7 @@ export class AIChatManager {
       CREATE TABLE IF NOT EXISTS ai_chat (
         id TEXT PRIMARY KEY,
         session_id TEXT NOT NULL,
+        kind TEXT NOT NULL DEFAULT 'session',
         title TEXT,
         assistant_id TEXT DEFAULT '${DEFAULT_GENERAL_ID}',
         active_message_id TEXT,
@@ -159,6 +185,7 @@ export class AIChatManager {
         branch_index INTEGER DEFAULT 0,
         debug_context TEXT,
         token_usage TEXT,
+        entity_refs TEXT,
         FOREIGN KEY(ai_chat_id) REFERENCES ai_chat(id) ON DELETE CASCADE
       );
 
@@ -200,10 +227,21 @@ export class AIChatManager {
     if (!messageColumns.includes('branch_index')) {
       db.exec(`ALTER TABLE ${tableName} ADD COLUMN branch_index INTEGER DEFAULT 0`)
     }
+    if (!messageColumns.includes('entity_refs')) {
+      db.exec(`ALTER TABLE ${tableName} ADD COLUMN entity_refs TEXT`)
+    }
+  }
+
+  private ensureChatMigrationColumns(db: Database.Database): void {
+    const chatColumns = this.getTableColumns(db, 'ai_chat')
+    if (!chatColumns.includes('kind')) {
+      db.exec(`ALTER TABLE ai_chat ADD COLUMN kind TEXT NOT NULL DEFAULT 'session'`)
+    }
   }
 
   private migrateDatabase(db: Database.Database): void {
     try {
+      this.ensureChatMigrationColumns(db)
       const hasLegacyConversationTable = this.tableExists(db, 'ai_conversation')
 
       if (hasLegacyConversationTable) {
@@ -254,15 +292,16 @@ export class AIChatManager {
             branch_index INTEGER DEFAULT 0,
             debug_context TEXT,
             token_usage TEXT,
+            entity_refs TEXT,
             FOREIGN KEY(ai_chat_id) REFERENCES ai_chat(id) ON DELETE CASCADE
           );
 
           INSERT INTO ai_message (
             id, ai_chat_id, role, content, timestamp, data_keywords, data_message_count,
-            content_blocks, parent_id, sibling_group_id, branch_index, debug_context, token_usage
+            content_blocks, parent_id, sibling_group_id, branch_index, debug_context, token_usage, entity_refs
           )
           SELECT id, conversation_id, role, content, timestamp, data_keywords, data_message_count,
-                 content_blocks, parent_id, sibling_group_id, branch_index, debug_context, token_usage
+                 content_blocks, parent_id, sibling_group_id, branch_index, debug_context, token_usage, entity_refs
           FROM ai_message_legacy;
 
           DROP TABLE ai_message_legacy;
@@ -365,6 +404,7 @@ export class AIChatManager {
       dataMessageCount: row.dataMessageCount ?? undefined,
       contentBlocks: row.contentBlocks ? JSON.parse(row.contentBlocks) : undefined,
       tokenUsage: row.tokenUsage ? JSON.parse(row.tokenUsage) : undefined,
+      entityRefs: row.entityRefs ? JSON.parse(row.entityRefs) : undefined,
     }
   }
 
@@ -375,7 +415,7 @@ export class AIChatManager {
         `SELECT id, ai_chat_id as aiChatId, role, content, timestamp,
                 parent_id as parentId, sibling_group_id as siblingGroupId, branch_index as branchIndex,
                 data_keywords as dataKeywords, data_message_count as dataMessageCount,
-                content_blocks as contentBlocks, token_usage as tokenUsage
+                content_blocks as contentBlocks, token_usage as tokenUsage, entity_refs as entityRefs
          FROM ai_message WHERE id = ?`
       )
       .get(messageId) as AIMessageRow | undefined
@@ -408,7 +448,7 @@ export class AIChatManager {
         `SELECT id, ai_chat_id as aiChatId, role, content, timestamp,
                 parent_id as parentId, sibling_group_id as siblingGroupId, branch_index as branchIndex,
                 data_keywords as dataKeywords, data_message_count as dataMessageCount,
-                content_blocks as contentBlocks, token_usage as tokenUsage
+                content_blocks as contentBlocks, token_usage as tokenUsage, entity_refs as entityRefs
          FROM ai_message WHERE ai_chat_id = ? ORDER BY timestamp ASC, id ASC`
       )
       .all(aiChatId) as AIMessageRow[]
@@ -515,23 +555,42 @@ export class AIChatManager {
   // ==================== 对话管理 ====================
 
   createAIChat(sessionId: string, title: string | undefined, assistantId: string): AIChat {
+    return this.createChat('session', sessionId, title, assistantId)
+  }
+
+  createGlobalAIChat(title: string | undefined, assistantId: string): AIChat {
+    return this.createChat('global', '', title, assistantId)
+  }
+
+  private createChat(kind: AIChatKind, sessionId: string, title: string | undefined, assistantId: string): AIChat {
     const db = this.getDb()
     const now = Math.floor(Date.now() / 1000)
     const id = this.generateId('conv')
 
     db.prepare(
-      `INSERT INTO ai_chat (id, session_id, title, assistant_id, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?)`
-    ).run(id, sessionId, title || null, assistantId, now, now)
+      `INSERT INTO ai_chat (id, session_id, kind, title, assistant_id, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`
+    ).run(id, sessionId, kind, title || null, assistantId, now, now)
 
-    return { id, sessionId, title: title || null, assistantId, activeMessageId: null, createdAt: now, updatedAt: now }
+    return {
+      id,
+      sessionId,
+      kind,
+      title: title || null,
+      assistantId,
+      activeMessageId: null,
+      createdAt: now,
+      updatedAt: now,
+    }
   }
 
   getAIChatCountsBySession(): Map<string, number> {
     const result = new Map<string, number>()
     try {
       const db = this.getDb()
-      const rows = db.prepare('SELECT session_id, COUNT(*) as count FROM ai_chat GROUP BY session_id').all() as Array<{
+      const rows = db
+        .prepare("SELECT session_id, COUNT(*) as count FROM ai_chat WHERE kind = 'session' GROUP BY session_id")
+        .all() as Array<{
         session_id: string
         count: number
       }>
@@ -548,19 +607,30 @@ export class AIChatManager {
     const db = this.getDb()
     return db
       .prepare(
-        `SELECT id, session_id as sessionId, title, assistant_id as assistantId,
+        `SELECT id, session_id as sessionId, kind, title, assistant_id as assistantId,
                 active_message_id as activeMessageId,
                 created_at as createdAt, updated_at as updatedAt
-         FROM ai_chat WHERE session_id = ? ORDER BY updated_at DESC`
+         FROM ai_chat WHERE kind = 'session' AND session_id = ? ORDER BY updated_at DESC`
       )
       .all(sessionId) as AIChat[]
+  }
+
+  getGlobalAIChats(): AIChat[] {
+    return this.getDb()
+      .prepare(
+        `SELECT id, session_id as sessionId, kind, title, assistant_id as assistantId,
+                active_message_id as activeMessageId,
+                created_at as createdAt, updated_at as updatedAt
+         FROM ai_chat WHERE kind = 'global' ORDER BY updated_at DESC`
+      )
+      .all() as AIChat[]
   }
 
   getAIChat(aiChatId: string): AIChat | null {
     const db = this.getDb()
     const row = db
       .prepare(
-        `SELECT id, session_id as sessionId, title, assistant_id as assistantId,
+        `SELECT id, session_id as sessionId, kind, title, assistant_id as assistantId,
                 active_message_id as activeMessageId,
                 created_at as createdAt, updated_at as updatedAt
          FROM ai_chat WHERE id = ?`
@@ -592,7 +662,8 @@ export class AIChatManager {
     dataKeywords?: string[],
     dataMessageCount?: number,
     contentBlocks?: ContentBlock[],
-    tokenUsage?: TokenUsageData
+    tokenUsage?: TokenUsageData,
+    entityRefs?: AIEntityRef[]
   ): AIMessage {
     const db = this.getDb()
     const now = Math.floor(Date.now() / 1000)
@@ -609,9 +680,9 @@ export class AIChatManager {
     db.prepare(
       `INSERT INTO ai_message (
          id, ai_chat_id, role, content, timestamp, data_keywords, data_message_count,
-         content_blocks, token_usage, debug_context, parent_id, sibling_group_id, branch_index
+         content_blocks, token_usage, debug_context, parent_id, sibling_group_id, branch_index, entity_refs
        )
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
     ).run(
       id,
       aiChatId,
@@ -625,7 +696,8 @@ export class AIChatManager {
       pendingDebug ?? null,
       parentId,
       siblingGroupId,
-      branchIndex
+      branchIndex,
+      entityRefs?.length ? JSON.stringify(entityRefs) : null
     )
 
     db.prepare('UPDATE ai_chat SET active_message_id = ?, updated_at = ? WHERE id = ?').run(id, now, aiChatId)
@@ -641,6 +713,7 @@ export class AIChatManager {
       dataMessageCount,
       contentBlocks,
       tokenUsage,
+      entityRefs: entityRefs?.length ? entityRefs : undefined,
     }
   }
 
@@ -695,9 +768,9 @@ export class AIChatManager {
     const forkTitle = title || `${source.title || 'Untitled'} (fork)`
 
     db.prepare(
-      `INSERT INTO ai_chat (id, session_id, title, assistant_id, active_message_id, created_at, updated_at)
-       VALUES (?, ?, ?, ?, NULL, ?, ?)`
-    ).run(newConvId, source.sessionId, forkTitle, source.assistantId, now, now)
+      `INSERT INTO ai_chat (id, session_id, kind, title, assistant_id, active_message_id, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, NULL, ?, ?)`
+    ).run(newConvId, source.sessionId, source.kind, forkTitle, source.assistantId, now, now)
 
     const idMap = new Map<string, string>()
     let lastNewId: string | null = null
@@ -710,9 +783,9 @@ export class AIChatManager {
       db.prepare(
         `INSERT INTO ai_message (
            id, ai_chat_id, role, content, timestamp, data_keywords, data_message_count,
-           content_blocks, token_usage, debug_context, parent_id, sibling_group_id, branch_index
+           content_blocks, token_usage, debug_context, parent_id, sibling_group_id, branch_index, entity_refs
          )
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, 0)`
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, 0, ?)`
       ).run(
         newMsgId,
         newConvId,
@@ -724,7 +797,8 @@ export class AIChatManager {
         row.contentBlocks,
         row.tokenUsage,
         newParentId,
-        newMsgId
+        newMsgId,
+        row.entityRefs
       )
       lastNewId = newMsgId
     }
@@ -736,6 +810,7 @@ export class AIChatManager {
     return {
       id: newConvId,
       sessionId: source.sessionId,
+      kind: source.kind,
       title: forkTitle,
       assistantId: source.assistantId,
       activeMessageId: lastNewId,
@@ -782,7 +857,8 @@ export class AIChatManager {
     role: AIMessageRole,
     content: string,
     contentBlocks?: ContentBlock[],
-    tokenUsage?: TokenUsageData
+    tokenUsage?: TokenUsageData,
+    entityRefs?: AIEntityRef[]
   ): AIMessage {
     const db = this.getDb()
     const now = Math.floor(Date.now() / 1000)
@@ -800,9 +876,9 @@ export class AIChatManager {
     db.prepare(
       `INSERT INTO ai_message (
          id, ai_chat_id, role, content, timestamp, data_keywords, data_message_count,
-         content_blocks, token_usage, debug_context, parent_id, sibling_group_id, branch_index
+         content_blocks, token_usage, debug_context, parent_id, sibling_group_id, branch_index, entity_refs
        )
-       VALUES (?, ?, ?, ?, ?, NULL, NULL, ?, ?, ?, ?, ?, 0)`
+       VALUES (?, ?, ?, ?, ?, NULL, NULL, ?, ?, ?, ?, ?, 0, ?)`
     ).run(
       id,
       aiChatId,
@@ -813,7 +889,8 @@ export class AIChatManager {
       tokenUsage ? JSON.stringify(tokenUsage) : null,
       pendingDebug ?? null,
       afterMessageId,
-      id
+      id,
+      entityRefs?.length ? JSON.stringify(entityRefs) : null
     )
 
     if (childRow) {
@@ -832,6 +909,7 @@ export class AIChatManager {
       parentId: afterMessageId,
       contentBlocks,
       tokenUsage,
+      entityRefs: entityRefs?.length ? entityRefs : undefined,
     }
   }
 
@@ -876,11 +954,7 @@ export class AIChatManager {
 
   // ==================== Agent 专用 ====================
 
-  getHistoryForAgent(
-    aiChatId: string,
-    maxMessages?: number,
-    leafMessageId?: string | null
-  ): Array<{ role: 'user' | 'assistant' | 'summary'; content: string; contentBlocks?: ContentBlock[] }> {
+  getHistoryForAgent(aiChatId: string, maxMessages?: number, leafMessageId?: string | null): AIHistoryMessage[] {
     const messages = this.getActivePathRows(aiChatId, leafMessageId).map((row) => this.parseMessageRow(row))
     const validMessages = messages.filter(
       (m) =>
@@ -896,7 +970,7 @@ export class AIChatManager {
       }
     }
 
-    let result: Array<{ role: 'user' | 'assistant' | 'summary'; content: string; contentBlocks?: ContentBlock[] }>
+    let result: AIHistoryMessage[]
 
     if (summaryMsg) {
       const metaBlock = summaryMsg.contentBlocks?.find(
@@ -916,11 +990,26 @@ export class AIChatManager {
         : []
 
       result = [
-        { role: 'summary' as const, content: summaryMsg.content },
-        ...contextMessages.map((m) => ({ role: m.role, content: m.content, contentBlocks: m.contentBlocks })),
+        {
+          role: 'summary' as const,
+          content: summaryMsg.content,
+          contentBlocks: summaryMsg.contentBlocks,
+          entityRefs: summaryMsg.entityRefs,
+        },
+        ...contextMessages.map((m) => ({
+          role: m.role,
+          content: m.content,
+          contentBlocks: m.contentBlocks,
+          entityRefs: m.entityRefs,
+        })),
       ]
     } else {
-      result = validMessages.map((m) => ({ role: m.role, content: m.content, contentBlocks: m.contentBlocks }))
+      result = validMessages.map((m) => ({
+        role: m.role,
+        content: m.content,
+        contentBlocks: m.contentBlocks,
+        entityRefs: m.entityRefs,
+      }))
     }
 
     if (maxMessages && result.length > maxMessages) {
@@ -939,7 +1028,8 @@ export class AIChatManager {
   addSummaryMessage(
     aiChatId: string,
     content: string,
-    meta: { bufferBoundaryTimestamp: number; compressedMessageCount: number }
+    meta: { bufferBoundaryTimestamp: number; compressedMessageCount: number },
+    entityRefs?: AIEntityRef[]
   ): AIMessage {
     const contentBlocks: ContentBlock[] = [
       {
@@ -949,7 +1039,7 @@ export class AIChatManager {
       },
     ]
 
-    return this.addMessage(aiChatId, 'summary', content, undefined, undefined, contentBlocks)
+    return this.addMessage(aiChatId, 'summary', content, undefined, undefined, contentBlocks, undefined, entityRefs)
   }
 
   getLatestSummary(aiChatId: string): AIMessage | null {
@@ -960,15 +1050,25 @@ export class AIChatManager {
   getMessagesAfterSummary(
     aiChatId: string,
     summaryTimestamp: number
-  ): Array<{ role: AIMessageRole; content: string; timestamp: number; contentBlocks?: ContentBlock[] }> {
+  ): Array<{
+    role: AIMessageRole
+    content: string
+    timestamp: number
+    contentBlocks?: ContentBlock[]
+    entityRefs?: AIEntityRef[]
+  }> {
     return this.getActivePathRows(aiChatId)
       .filter((row) => row.timestamp > summaryTimestamp && (row.role === 'user' || row.role === 'assistant'))
       .map((row) => this.toCompressionMessage(row))
   }
 
-  getAllUserAssistantMessages(
-    aiChatId: string
-  ): Array<{ role: AIMessageRole; content: string; timestamp: number; contentBlocks?: ContentBlock[] }> {
+  getAllUserAssistantMessages(aiChatId: string): Array<{
+    role: AIMessageRole
+    content: string
+    timestamp: number
+    contentBlocks?: ContentBlock[]
+    entityRefs?: AIEntityRef[]
+  }> {
     return this.getActivePathRows(aiChatId)
       .filter((row) => row.role === 'user' || row.role === 'assistant')
       .map((row) => this.toCompressionMessage(row))
@@ -979,12 +1079,14 @@ export class AIChatManager {
     content: string
     timestamp: number
     contentBlocks?: ContentBlock[]
+    entityRefs?: AIEntityRef[]
   } {
     return {
       role: row.role as AIMessageRole,
       content: row.content,
       timestamp: row.timestamp,
       contentBlocks: row.contentBlocks ? JSON.parse(row.contentBlocks) : undefined,
+      entityRefs: row.entityRefs ? JSON.parse(row.entityRefs) : undefined,
     }
   }
 

--- a/packages/node-runtime/src/ai/chats.ts
+++ b/packages/node-runtime/src/ai/chats.ts
@@ -665,12 +665,35 @@ export class AIChatManager {
     tokenUsage?: TokenUsageData,
     entityRefs?: AIEntityRef[]
   ): AIMessage {
+    return this.addMessageWithEntityRefs(
+      aiChatId,
+      role,
+      content,
+      dataKeywords,
+      dataMessageCount,
+      contentBlocks,
+      tokenUsage,
+      role === 'user' ? entityRefs : undefined
+    )
+  }
+
+  private addMessageWithEntityRefs(
+    aiChatId: string,
+    role: AIMessageRole,
+    content: string,
+    dataKeywords?: string[],
+    dataMessageCount?: number,
+    contentBlocks?: ContentBlock[],
+    tokenUsage?: TokenUsageData,
+    entityRefs?: AIEntityRef[]
+  ): AIMessage {
     const db = this.getDb()
     const now = Math.floor(Date.now() / 1000)
     const id = this.generateId('msg')
     const parentId = this.getActiveMessageId(aiChatId)
     const siblingGroupId = id
     const branchIndex = 0
+    const persistedEntityRefs = entityRefs?.length ? entityRefs : undefined
 
     const pendingDebug = role === 'assistant' ? this.pendingDebugContextMap.get(aiChatId) : undefined
     if (pendingDebug) {
@@ -697,7 +720,7 @@ export class AIChatManager {
       parentId,
       siblingGroupId,
       branchIndex,
-      entityRefs?.length ? JSON.stringify(entityRefs) : null
+      persistedEntityRefs?.length ? JSON.stringify(persistedEntityRefs) : null
     )
 
     db.prepare('UPDATE ai_chat SET active_message_id = ?, updated_at = ? WHERE id = ?').run(id, now, aiChatId)
@@ -713,7 +736,7 @@ export class AIChatManager {
       dataMessageCount,
       contentBlocks,
       tokenUsage,
-      entityRefs: entityRefs?.length ? entityRefs : undefined,
+      entityRefs: persistedEntityRefs?.length ? persistedEntityRefs : undefined,
     }
   }
 
@@ -798,7 +821,7 @@ export class AIChatManager {
         row.tokenUsage,
         newParentId,
         newMsgId,
-        row.entityRefs
+        row.role === 'user' || row.role === 'summary' ? row.entityRefs : null
       )
       lastNewId = newMsgId
     }
@@ -863,6 +886,7 @@ export class AIChatManager {
     const db = this.getDb()
     const now = Math.floor(Date.now() / 1000)
     const id = this.generateId('msg')
+    const persistedEntityRefs = role === 'user' ? entityRefs : undefined
 
     const pendingDebug = role === 'assistant' ? this.pendingDebugContextMap.get(aiChatId) : undefined
     if (pendingDebug) {
@@ -890,7 +914,7 @@ export class AIChatManager {
       pendingDebug ?? null,
       afterMessageId,
       id,
-      entityRefs?.length ? JSON.stringify(entityRefs) : null
+      persistedEntityRefs?.length ? JSON.stringify(persistedEntityRefs) : null
     )
 
     if (childRow) {
@@ -909,7 +933,7 @@ export class AIChatManager {
       parentId: afterMessageId,
       contentBlocks,
       tokenUsage,
-      entityRefs: entityRefs?.length ? entityRefs : undefined,
+      entityRefs: persistedEntityRefs?.length ? persistedEntityRefs : undefined,
     }
   }
 
@@ -1000,7 +1024,7 @@ export class AIChatManager {
           role: m.role,
           content: m.content,
           contentBlocks: m.contentBlocks,
-          entityRefs: m.entityRefs,
+          entityRefs: m.role === 'user' ? m.entityRefs : undefined,
         })),
       ]
     } else {
@@ -1008,7 +1032,7 @@ export class AIChatManager {
         role: m.role,
         content: m.content,
         contentBlocks: m.contentBlocks,
-        entityRefs: m.entityRefs,
+        entityRefs: m.role === 'user' ? m.entityRefs : undefined,
       }))
     }
 
@@ -1039,7 +1063,16 @@ export class AIChatManager {
       },
     ]
 
-    return this.addMessage(aiChatId, 'summary', content, undefined, undefined, contentBlocks, undefined, entityRefs)
+    return this.addMessageWithEntityRefs(
+      aiChatId,
+      'summary',
+      content,
+      undefined,
+      undefined,
+      contentBlocks,
+      undefined,
+      entityRefs
+    )
   }
 
   getLatestSummary(aiChatId: string): AIMessage | null {
@@ -1086,7 +1119,7 @@ export class AIChatManager {
       content: row.content,
       timestamp: row.timestamp,
       contentBlocks: row.contentBlocks ? JSON.parse(row.contentBlocks) : undefined,
-      entityRefs: row.entityRefs ? JSON.parse(row.entityRefs) : undefined,
+      entityRefs: row.role === 'user' && row.entityRefs ? JSON.parse(row.entityRefs) : undefined,
     }
   }
 

--- a/packages/node-runtime/src/ai/compression/__tests__/compressor.test.ts
+++ b/packages/node-runtime/src/ai/compression/__tests__/compressor.test.ts
@@ -4,7 +4,7 @@ import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { AIChatManager } from '../../chats'
-import type { ContentBlock } from '../../chats'
+import type { AIEntityRef, ContentBlock } from '../../chats'
 import { checkAndCompress } from '../compressor'
 import type { CompressionConfig, CompressionLlmAdapter } from '../types'
 
@@ -150,6 +150,41 @@ describe('checkAndCompress tool result token accounting', () => {
       assert.ok(captured.prompt!.includes('[PREVIOUS SUMMARY'))
       assert.ok(captured.prompt!.includes('old summary of earlier topics'))
       assert.ok(captured.prompt!.includes('TOOL_DATA_GAMMA'))
+    } finally {
+      manager.close()
+      cleanup(dir)
+    }
+  })
+
+  it('retains stable entity references outside the generated summary text', async () => {
+    const dir = createTempDir()
+    const manager = createManager(dir)
+    const refs: AIEntityRef[] = [
+      { type: 'contact', contactKey: 'qq:10001', displayName: 'Alice' },
+      { type: 'session', sessionId: 'group-1', displayName: 'Project Group', sessionType: 'group' },
+    ]
+    try {
+      const chat = manager.createGlobalAIChat('Global', 'general_cn')
+      manager.addMessage(chat.id, 'user', 'compare Alice', undefined, undefined, undefined, undefined, [refs[0]!])
+      manager.addMessage(chat.id, 'assistant', 'first result', undefined, undefined, [
+        toolBlock('query_a', bigToolResult('ENTITY_DATA_ALPHA')),
+      ])
+      manager.addMessage(chat.id, 'user', 'include the project group', undefined, undefined, undefined, undefined, [
+        refs[1]!,
+      ])
+      manager.addMessage(chat.id, 'assistant', 'second result', undefined, undefined, [
+        toolBlock('query_b', bigToolResult('ENTITY_DATA_BETA')),
+      ])
+      manager.addMessage(chat.id, 'user', 'continue')
+      manager.addMessage(chat.id, 'assistant', 'done')
+
+      const captured: { prompt: string | null } = { prompt: null }
+      const result = await checkAndCompress(chat.id, CONFIG, 'system', createAdapter(captured), manager)
+
+      assert.equal(result.compressed, true)
+      assert.deepEqual(manager.getLatestSummary(chat.id)?.entityRefs, refs)
+      assert.deepEqual(manager.getHistoryForAgent(chat.id)[0]?.entityRefs, refs)
+      assert.ok(captured.prompt!.includes('<chatlab_entity_refs>'))
     } finally {
       manager.close()
       cleanup(dir)

--- a/packages/node-runtime/src/ai/compression/compressor.ts
+++ b/packages/node-runtime/src/ai/compression/compressor.ts
@@ -8,8 +8,8 @@
 import { truncateToolResultText } from '@openchatlab/core'
 
 import { countTokens, countMessagesTokens } from '../tokenizer'
-import { isReplayableToolBlock } from '../agent/history'
-import type { AIChatManager, ContentBlock, AIMessageRole } from '../chats'
+import { appendEntityRefsForModel, isReplayableToolBlock } from '../agent/history'
+import type { AIChatManager, AIEntityRef, ContentBlock, AIMessageRole } from '../chats'
 import type { CompressionConfig, CompressionResult, CompressionLogger, CompressionLlmAdapter } from './types'
 
 interface CompressibleMessage {
@@ -17,6 +17,7 @@ interface CompressibleMessage {
   content: string
   timestamp: number
   contentBlocks?: ContentBlock[]
+  entityRefs?: AIEntityRef[]
 }
 
 const DEFAULT_CONTEXT_WINDOW = 128000
@@ -76,7 +77,13 @@ export async function checkAndCompress(
 
     const summary = convManager.getLatestSummary(aiChatId)
 
-    let messages: Array<{ role: AIMessageRole; content: string; timestamp: number; contentBlocks?: ContentBlock[] }>
+    let messages: Array<{
+      role: AIMessageRole
+      content: string
+      timestamp: number
+      contentBlocks?: ContentBlock[]
+      entityRefs?: AIEntityRef[]
+    }>
     if (summary) {
       const metaBlock = summary.contentBlocks?.find(
         (b): b is Extract<ContentBlock, { type: 'summary_meta' }> => b.type === 'summary_meta'
@@ -89,10 +96,16 @@ export async function checkAndCompress(
 
     const historyForTokenCount: Array<{ role: string; content: string }> = []
     if (summary) {
-      historyForTokenCount.push({ role: 'assistant', content: summary.content })
+      historyForTokenCount.push({
+        role: 'assistant',
+        content: appendEntityRefsForModel(summary.content, summary.entityRefs),
+      })
     }
     for (const msg of messages) {
-      historyForTokenCount.push({ role: msg.role, content: msg.content })
+      historyForTokenCount.push({
+        role: msg.role,
+        content: appendEntityRefsForModel(msg.content, msg.entityRefs),
+      })
       // Persisted tool results are replayed as toolCall/toolResult pairs each
       // turn (see agent/history.ts), so they occupy real context and must be counted.
       for (const toolText of replayedToolResultTexts(msg.contentBlocks)) {
@@ -139,14 +152,25 @@ export async function checkAndCompress(
         ? bufferMessages[0].timestamp
         : messagesToCompress[messagesToCompress.length - 1]!.timestamp + 1
 
-    convManager.addSummaryMessage(aiChatId, summaryText, {
-      bufferBoundaryTimestamp: bufferBoundary,
-      compressedMessageCount: messagesToCompress.length,
-    })
+    const summaryEntityRefs = mergeEntityRefs(
+      summary?.entityRefs,
+      ...messagesToCompress.map((message) => message.entityRefs)
+    )
+    convManager.addSummaryMessage(
+      aiChatId,
+      summaryText,
+      {
+        bufferBoundaryTimestamp: bufferBoundary,
+        compressedMessageCount: messagesToCompress.length,
+      },
+      summaryEntityRefs
+    )
 
-    const afterTokenCount: Array<{ role: string; content: string }> = [{ role: 'assistant', content: summaryText }]
+    const afterTokenCount: Array<{ role: string; content: string }> = [
+      { role: 'assistant', content: appendEntityRefsForModel(summaryText, summaryEntityRefs) },
+    ]
     for (const m of bufferMessages) {
-      afterTokenCount.push({ role: m.role, content: m.content })
+      afterTokenCount.push({ role: m.role, content: appendEntityRefsForModel(m.content, m.entityRefs) })
       for (const toolText of replayedToolResultTexts(m.contentBlocks)) {
         afterTokenCount.push({ role: 'tool', content: toolText })
       }
@@ -207,7 +231,7 @@ function replayedToolResultTexts(blocks?: ContentBlock[]): string[] {
 }
 
 function countMessageTokensWithTools(msg: CompressibleMessage): number {
-  let tokens = countTokens(msg.content) + 4
+  let tokens = countTokens(appendEntityRefsForModel(msg.content, msg.entityRefs)) + 4
   for (const toolText of replayedToolResultTexts(msg.contentBlocks)) {
     tokens += countTokens(toolText) + 4
   }
@@ -243,25 +267,43 @@ function splitMessagesForCompression<T extends CompressibleMessage>(
 }
 
 function buildCompressionInput(
-  messagesToCompress: Array<{ role: string; content: string; contentBlocks?: ContentBlock[] }>,
-  existingSummary: { content: string } | null
+  messagesToCompress: Array<{
+    role: string
+    content: string
+    contentBlocks?: ContentBlock[]
+    entityRefs?: AIEntityRef[]
+  }>,
+  existingSummary: { content: string; entityRefs?: AIEntityRef[] } | null
 ): string {
   const parts: string[] = []
 
   if (existingSummary) {
-    parts.push(`[PREVIOUS SUMMARY — MUST PRESERVE]\n${existingSummary.content}\n`)
+    parts.push(
+      `[PREVIOUS SUMMARY — MUST PRESERVE]\n${appendEntityRefsForModel(existingSummary.content, existingSummary.entityRefs)}\n`
+    )
     parts.push(`[NEW MESSAGES — SUMMARIZE AND MERGE]`)
   }
 
   for (const msg of messagesToCompress) {
     const roleLabel = msg.role === 'user' ? 'User' : 'Assistant'
-    parts.push(`${roleLabel}: ${msg.content}`)
+    parts.push(`${roleLabel}: ${appendEntityRefsForModel(msg.content, msg.entityRefs)}`)
     for (const block of (msg.contentBlocks ?? []).filter(isReplayableToolBlock)) {
       parts.push(`[Tool result: ${block.tool.name}]\n${truncateToolResultText(block.tool.result)}`)
     }
   }
 
   return parts.join('\n\n')
+}
+
+function mergeEntityRefs(...groups: Array<AIEntityRef[] | undefined>): AIEntityRef[] | undefined {
+  const refs = new Map<string, AIEntityRef>()
+  for (const group of groups) {
+    for (const ref of group ?? []) {
+      const key = ref.type === 'contact' ? `contact:${ref.contactKey}` : `session:${ref.sessionId}`
+      refs.set(key, ref)
+    }
+  }
+  return refs.size > 0 ? [...refs.values()] : undefined
 }
 
 function forceTruncate(input: string, targetTokens: number): string {

--- a/packages/node-runtime/src/ai/index.ts
+++ b/packages/node-runtime/src/ai/index.ts
@@ -36,7 +36,17 @@ export type {
 } from './assistant-manager'
 export { parseSkillFile, extractSkillId } from './skill-parser'
 export { AIChatManager } from './chats'
-export type { AIChat, AIMessage, AIMessageRole, ContentBlock, TokenUsageData, AIChatManagerLogger } from './chats'
+export type {
+  AIChat,
+  AIChatKind,
+  AIEntityRef,
+  AIHistoryMessage,
+  AIMessage,
+  AIMessageRole,
+  ContentBlock,
+  TokenUsageData,
+  AIChatManagerLogger,
+} from './chats'
 
 // Tokenizer
 export { countTokens, countMessagesTokens, initTokenizer } from './tokenizer'

--- a/packages/node-runtime/src/index.ts
+++ b/packages/node-runtime/src/index.ts
@@ -292,7 +292,17 @@ export type {
   FormatMessageOptions,
 } from './ai'
 
-export type { AIChat, AIMessage, AIMessageRole, ContentBlock, TokenUsageData, AIChatManagerLogger } from './ai'
+export type {
+  AIChat,
+  AIChatKind,
+  AIEntityRef,
+  AIHistoryMessage,
+  AIMessage,
+  AIMessageRole,
+  ContentBlock,
+  TokenUsageData,
+  AIChatManagerLogger,
+} from './ai'
 
 // Agent Core
 export type { AgentCoreOptions, AgentCoreEvent, AgentCoreResult, AgentTokenUsage, SimpleHistoryMessage } from './ai'

--- a/src/services/ai/fetch.ts
+++ b/src/services/ai/fetch.ts
@@ -10,6 +10,7 @@ import type {
   AIChat,
   AIMessage,
   AIMessageRole,
+  AIEntityRef,
   ContentBlock,
   TokenUsageData,
   ExportFilterParams,
@@ -38,8 +39,16 @@ export class FetchAIAdapter implements AIAdapter {
     return get<AIChat[]>(`/ai/chats?sessionId=${encodeURIComponent(sessionId)}`)
   }
 
+  async getGlobalAIChats(): Promise<AIChat[]> {
+    return get<AIChat[]>('/ai/global-chats')
+  }
+
   async createAIChat(sessionId: string, title: string | undefined, assistantId: string): Promise<AIChat> {
     return post<AIChat>('/ai/chats', { sessionId, title, assistantId })
+  }
+
+  async createGlobalAIChat(title: string | undefined, assistantId: string): Promise<AIChat> {
+    return post<AIChat>('/ai/global-chats', { title, assistantId })
   }
 
   async updateAIChatTitle(aiChatId: string, title: string): Promise<boolean> {
@@ -62,7 +71,8 @@ export class FetchAIAdapter implements AIAdapter {
     dataKeywords?: string[],
     dataMessageCount?: number,
     contentBlocks?: ContentBlock[],
-    tokenUsage?: TokenUsageData
+    tokenUsage?: TokenUsageData,
+    entityRefs?: AIEntityRef[]
   ): Promise<AIMessage> {
     return post<AIMessage>(`/ai/chats/${aiChatId}/messages`, {
       role,
@@ -71,6 +81,7 @@ export class FetchAIAdapter implements AIAdapter {
       dataMessageCount,
       contentBlocks,
       tokenUsage,
+      entityRefs,
     })
   }
 
@@ -96,7 +107,8 @@ export class FetchAIAdapter implements AIAdapter {
     role: AIMessageRole,
     content: string,
     contentBlocks?: ContentBlock[],
-    tokenUsage?: TokenUsageData
+    tokenUsage?: TokenUsageData,
+    entityRefs?: AIEntityRef[]
   ): Promise<AIMessage> {
     return post<AIMessage>(`/ai/chats/${aiChatId}/messages/insert-after`, {
       afterMessageId,
@@ -104,6 +116,7 @@ export class FetchAIAdapter implements AIAdapter {
       content,
       contentBlocks,
       tokenUsage,
+      entityRefs,
     })
   }
 

--- a/src/services/ai/fetch.ts
+++ b/src/services/ai/fetch.ts
@@ -93,8 +93,8 @@ export class FetchAIAdapter implements AIAdapter {
     return post<AIChat>(`/ai/chats/${sourceAIChatId}/fork`, { upToMessageId, title })
   }
 
-  async updateMessageContent(messageId: string, newContent: string): Promise<void> {
-    await put<unknown>(`/ai/messages/${messageId}/content`, { content: newContent })
+  async updateMessageContent(messageId: string, newContent: string, entityRefs?: AIEntityRef[]): Promise<void> {
+    await put<unknown>(`/ai/messages/${messageId}/content`, { content: newContent, entityRefs })
   }
 
   async deleteAndRelinkMessage(aiChatId: string, messageId: string): Promise<void> {

--- a/src/services/ai/types.ts
+++ b/src/services/ai/types.ts
@@ -143,7 +143,8 @@ export interface AIAdapter {
   ): Promise<AIMessage>
   deleteMessagesFrom(aiChatId: string, messageId: string): Promise<void>
   forkAIChat(sourceAIChatId: string, upToMessageId: string, title?: string): Promise<AIChat>
-  updateMessageContent(messageId: string, newContent: string): Promise<void>
+  /** Replace message text and entity references; omitted references clear the previous value. */
+  updateMessageContent(messageId: string, newContent: string, entityRefs?: AIEntityRef[]): Promise<void>
   deleteAndRelinkMessage(aiChatId: string, messageId: string): Promise<void>
   insertMessageAfter(
     aiChatId: string,

--- a/src/services/ai/types.ts
+++ b/src/services/ai/types.ts
@@ -5,12 +5,17 @@ import type { PlanContentBlock } from './planBlocks'
 export interface AIChat {
   id: string
   sessionId: string
+  kind: 'session' | 'global'
   title: string | null
   assistantId: string
   activeMessageId?: string | null
   createdAt: number
   updatedAt: number
 }
+
+export type AIEntityRef =
+  | { type: 'contact'; contactKey: string; displayName: string }
+  | { type: 'session'; sessionId: string; displayName: string; sessionType: 'private' | 'group' }
 
 export type ContentBlock =
   | { type: 'text'; text: string; processDurationMs?: number }
@@ -52,6 +57,7 @@ export interface AIMessage {
   dataMessageCount?: number
   contentBlocks?: ContentBlock[]
   tokenUsage?: TokenUsageData
+  entityRefs?: AIEntityRef[]
 }
 
 export interface DesensitizeRule {
@@ -117,7 +123,9 @@ export interface AIAdapter {
   // ===== 对话管理 =====
   getAIChat(aiChatId: string): Promise<AIChat | null>
   getAIChats(sessionId: string): Promise<AIChat[]>
+  getGlobalAIChats(): Promise<AIChat[]>
   createAIChat(sessionId: string, title: string | undefined, assistantId: string): Promise<AIChat>
+  createGlobalAIChat(title: string | undefined, assistantId: string): Promise<AIChat>
   updateAIChatTitle(aiChatId: string, title: string): Promise<boolean>
   deleteAIChat(aiChatId: string): Promise<boolean>
 
@@ -130,7 +138,8 @@ export interface AIAdapter {
     dataKeywords?: string[],
     dataMessageCount?: number,
     contentBlocks?: ContentBlock[],
-    tokenUsage?: TokenUsageData
+    tokenUsage?: TokenUsageData,
+    entityRefs?: AIEntityRef[]
   ): Promise<AIMessage>
   deleteMessagesFrom(aiChatId: string, messageId: string): Promise<void>
   forkAIChat(sourceAIChatId: string, upToMessageId: string, title?: string): Promise<AIChat>
@@ -142,7 +151,8 @@ export interface AIAdapter {
     role: AIMessageRole,
     content: string,
     contentBlocks?: ContentBlock[],
-    tokenUsage?: TokenUsageData
+    tokenUsage?: TokenUsageData,
+    entityRefs?: AIEntityRef[]
   ): Promise<AIMessage>
   getAIChatTokenUsage(aiChatId: string): Promise<TokenUsageData>
   estimateContextTokens(

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -102,6 +102,7 @@ export type {
   AIAdapter,
   AIChat,
   AIMessage,
+  AIEntityRef,
   AIMessageRole,
   ContentBlock,
   TokenUsageData,


### PR DESCRIPTION
## 变更内容

- 为 AI 对话增加 `session` / `global` 类型，提供全局对话 CRUD，并保持现有会话对话列表和计数隔离。
- 为用户消息持久化结构化 `entity_refs`，支持历史回放、分叉和 Agent 上下文恢复。
- 在上下文压缩后确定性保留实体引用，避免稳定联系人和会话身份只依赖模型摘要。
- Desktop 与 CLI Web 复用同一套持久化契约和 HTTP/前端 service API。

## 本 PR 边界

本 PR 只建立全局 AI 对话的数据模型、迁移和访问接口，不包含跨对话检索工具、Agent 运行时或全局 AI 页面。这些能力将通过后续独立 PR 接入。

## Review 重点

- 加法迁移能否安全覆盖已发布的旧 `conversations.db`。
- `kind='global'` 是否与现有单会话列表、计数和加载路径严格隔离。
- `entity_refs` 是否只附着于原始用户消息，并在历史压缩和分叉后保持稳定。

## 验证

- Web、Node、Desktop 类型检查通过。
- 相关数据库迁移、CRUD、HTTP route、历史和压缩测试：43/43 通过。
- 完整重组分支测试：2179/2179 通过。
