### PR TITLE
feat(ai): add global analysis workspace

### DIFF
--- a/packages/node-runtime/src/ai/chats.ts
+++ b/packages/node-runtime/src/ai/chats.ts
@@ -9,7 +9,11 @@ import Database from 'better-sqlite3'
 import * as fs from 'fs'
 import * as path from 'path'
 import type { ChartPayload, ChatEvidencePayload } from '@openchatlab/core'
-import { DEFAULT_GENERAL_ASSISTANT_ID, type AIEntityRef } from '@openchatlab/shared-types'
+import {
+  DEFAULT_GENERAL_ASSISTANT_ID,
+  type AIEntityRef,
+  type CrossChatEvidencePayload,
+} from '@openchatlab/shared-types'
 import type { PlanContentBlock, PlanDraftContentBlock } from './agent'
 
 const DEFAULT_GENERAL_ID = DEFAULT_GENERAL_ASSISTANT_ID
@@ -36,6 +40,7 @@ export type ContentBlock =
   | { type: 'think'; tag: string; text: string; durationMs?: number }
   | { type: 'chart'; chart: ChartPayload }
   | { type: 'evidence'; evidence: ChatEvidencePayload }
+  | { type: 'cross_chat_evidence'; evidence: CrossChatEvidencePayload }
   | PlanContentBlock
   | PlanDraftContentBlock
   | {

--- a/src/components/AIChat/GlobalTaskBar.vue
+++ b/src/components/AIChat/GlobalTaskBar.vue
@@ -15,6 +15,10 @@ const activeTaskState = computed(() => aiChatStore.getActiveTaskState())
 const shouldShowFloatingBar = computed(() => {
   if (!activeTask.value) return false
 
+  if (activeTask.value.kind === 'global') {
+    return route.name !== 'global-ai' || route.query.aiChatId !== activeTask.value.aiChatId
+  }
+
   const expectedRouteName = activeTask.value.chatType === 'group' ? 'group-chat' : 'private-chat'
   const isOnSameSessionAIPage =
     route.name === expectedRouteName &&
@@ -36,6 +40,11 @@ async function handleOpenTask() {
   // 返回当前任务时，优先把正在流式写入的对话重新切回当前显示缓冲，
   // 避免用户此前查看了别的历史对话，回来后还停留在旧视图。
   aiChatStore.focusActiveTaskAIChat()
+
+  if (activeTask.value.kind === 'global') {
+    await router.push({ name: 'global-ai', query: { aiChatId: activeTask.value.aiChatId ?? undefined } })
+    return
+  }
 
   await router.push({
     name: activeTask.value.chatType === 'group' ? 'group-chat' : 'private-chat',

--- a/src/components/AIChat/chat/ChatMessage.vue
+++ b/src/components/AIChat/chat/ChatMessage.vue
@@ -8,12 +8,13 @@ import CaptureButton from '@/components/common/CaptureButton.vue'
 import ErrorBlock from './ErrorBlock.vue'
 import ChartBlockRenderer from './ChartBlockRenderer.vue'
 import EvidenceBlock from './EvidenceBlock.vue'
+import CrossChatEvidenceBlock from './CrossChatEvidenceBlock.vue'
 import ProcessDisclosure from './ProcessDisclosure.vue'
 import ProcessDisclosureIcon from './ProcessDisclosureIcon.vue'
 import { useToast } from '@/composables/useToast'
 import { stripChartImagePlaceholders } from '@/services/ai/chartMarkdownPlaceholders'
 import { shouldHideRecoverableChartError } from '@/stores/aiChatChartBlocks'
-import type { ToolProgress } from '@openchatlab/shared-types'
+import type { AIEntityRef, ToolProgress } from '@openchatlab/shared-types'
 import LiveFollowText from './LiveFollowText.vue'
 import { getFirstLine, getLatestLine } from './liveFollowText'
 import {
@@ -51,6 +52,7 @@ const props = defineProps<{
     status: 'running' | 'done' | 'error'
     progress?: ToolProgress
   } | null
+  entityRefs?: AIEntityRef[]
 }>()
 
 const emit = defineEmits<{
@@ -722,6 +724,13 @@ const copyMarkdownText = computed(() => {
         return [header, ...groupLines].join('\n')
       }
 
+      if (block.type === 'cross_chat_evidence') {
+        const sourceLines = block.evidence.sources.map(
+          (source) => `> - ${source.sessionName} · ${source.senderName}: ${source.snippet}`
+        )
+        return [`> ${t('ai.chat.crossChatEvidence.title')}`, ...sourceLines].join('\n')
+      }
+
       if (block.type === 'plan') {
         const steps = block.plan.steps
           .map(
@@ -847,6 +856,19 @@ async function handleCopyMarkdown() {
           v-else
           class="ai-user-bubble w-fit max-w-full rounded-3xl bg-gray-100 text-gray-900 dark:bg-gray-800 dark:text-gray-100"
         >
+          <div v-if="entityRefs?.length" class="mb-1.5 flex flex-wrap gap-1.5">
+            <span
+              v-for="entity in entityRefs"
+              :key="entity.type === 'contact' ? `contact:${entity.contactKey}` : `session:${entity.sessionId}`"
+              class="inline-flex items-center gap-1 rounded-full bg-white/70 px-2 py-0.5 text-xs text-primary-600 dark:bg-white/10 dark:text-primary-300"
+            >
+              <UIcon
+                :name="entity.type === 'contact' ? 'i-heroicons-user' : 'i-heroicons-user-group'"
+                class="h-3 w-3"
+              />
+              {{ entity.displayName }}
+            </span>
+          </div>
           <div class="prose prose-sm dark:prose-invert max-w-none" v-html="renderedContent" />
         </div>
       </template>
@@ -1167,6 +1189,11 @@ async function handleCopyMarkdown() {
 
                       <!-- 证据块 -->
                       <EvidenceBlock v-else-if="block.type === 'evidence'" :evidence="block.evidence" />
+
+                      <CrossChatEvidenceBlock
+                        v-else-if="block.type === 'cross_chat_evidence'"
+                        :evidence="block.evidence"
+                      />
 
                       <!-- 工具块：有结果时可展开查看发送给 AI 的安全文本 -->
                       <ProcessDisclosure

--- a/src/components/AIChat/chat/CrossChatEvidenceBlock.vue
+++ b/src/components/AIChat/chat/CrossChatEvidenceBlock.vue
@@ -1,0 +1,138 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import type { CrossChatEvidencePayload, CrossChatEvidenceSource } from '@openchatlab/shared-types'
+import { useLayoutStore } from '@/stores/layout'
+import ProcessDisclosure from './ProcessDisclosure.vue'
+import ProcessDisclosureIcon from './ProcessDisclosureIcon.vue'
+
+const props = defineProps<{
+  evidence: CrossChatEvidencePayload
+}>()
+
+const { t } = useI18n()
+const layoutStore = useLayoutStore()
+
+const sessionGroups = computed(() => {
+  const groups = new Map<string, { sessionName: string; sessionType: string; sources: CrossChatEvidenceSource[] }>()
+  for (const source of props.evidence.sources) {
+    const existing = groups.get(source.sessionId)
+    if (existing) {
+      existing.sources.push(source)
+    } else {
+      groups.set(source.sessionId, {
+        sessionName: source.sessionName,
+        sessionType: source.sessionType,
+        sources: [source],
+      })
+    }
+  }
+  return [...groups.entries()].map(([sessionId, group]) => ({ sessionId, ...group }))
+})
+
+function viewSource(source: CrossChatEvidenceSource): void {
+  layoutStore.openChatRecordDrawer({
+    sessionId: source.sessionId,
+    scrollToMessageId: source.messageId,
+  })
+}
+</script>
+
+<template>
+  <ProcessDisclosure lazy class="w-full text-[13px]">
+    <template #summary="{ open, toggle }">
+      <button
+        type="button"
+        class="group/process-toggle flex h-7 w-full items-center gap-2 rounded-md text-left text-sm leading-7 text-gray-500 transition-colors hover:bg-gray-50/80 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800/30 dark:hover:text-gray-300"
+        :aria-expanded="open"
+        @click="toggle"
+      >
+        <ProcessDisclosureIcon icon="i-heroicons-document-magnifying-glass" :open="open" />
+        <span class="shrink-0 text-gray-600 dark:text-gray-300">{{ t('ai.chat.crossChatEvidence.title') }}</span>
+        <span class="ml-auto shrink-0 text-[11px] text-gray-400 dark:text-gray-500">
+          {{
+            t('ai.chat.crossChatEvidence.summary', {
+              sources: evidence.sources.length,
+              sessions: sessionGroups.length,
+            })
+          }}
+        </span>
+      </button>
+    </template>
+
+    <div
+      class="cross-chat-evidence-details mx-px mt-1 rounded-lg border border-gray-200/60 bg-gray-50/80 px-3 py-2 dark:border-white/5 dark:bg-white/[0.03]"
+    >
+      <div class="mb-2 flex items-start gap-2 text-xs text-gray-500 dark:text-gray-400">
+        <span class="min-w-0 flex-1">
+          <span class="text-gray-600 dark:text-gray-300">{{ t('ai.chat.crossChatEvidence.query') }}:</span>
+          {{ evidence.query }}
+        </span>
+        <span
+          v-if="evidence.coverage.truncated"
+          class="shrink-0 rounded bg-amber-50 px-1.5 py-0.5 text-[11px] text-amber-600 dark:bg-amber-900/20 dark:text-amber-400"
+        >
+          {{ t('ai.chat.crossChatEvidence.partial') }}
+        </span>
+      </div>
+
+      <div v-if="sessionGroups.length === 0" class="py-2 text-center text-xs text-gray-400 dark:text-gray-500">
+        {{ t('ai.chat.crossChatEvidence.empty') }}
+      </div>
+
+      <div v-else class="space-y-2">
+        <section
+          v-for="group in sessionGroups"
+          :key="group.sessionId"
+          class="rounded-md border border-gray-200/80 bg-white px-2.5 py-2 dark:border-gray-700/50 dark:bg-page-dark/30"
+        >
+          <div class="mb-1 flex items-center gap-1.5 text-xs text-gray-600 dark:text-gray-300">
+            <UIcon
+              :name="group.sessionType === 'group' ? 'i-heroicons-user-group' : 'i-heroicons-user'"
+              class="h-3.5 w-3.5 shrink-0 text-gray-400"
+            />
+            <span class="min-w-0 flex-1 truncate">{{ group.sessionName }}</span>
+            <span class="shrink-0 text-[11px] text-gray-400">
+              {{ t('ai.chat.crossChatEvidence.sourceCount', { count: group.sources.length }) }}
+            </span>
+          </div>
+
+          <button
+            v-for="source in group.sources"
+            :key="`${source.sessionId}:${source.messageId}`"
+            type="button"
+            class="group/source flex w-full items-start gap-2 rounded px-1.5 py-1 text-left transition-colors hover:bg-gray-50 dark:hover:bg-gray-800/40"
+            @click="viewSource(source)"
+          >
+            <div class="min-w-0 flex-1 text-xs leading-snug text-gray-600 dark:text-gray-300">
+              <span class="mr-1 text-gray-400 dark:text-gray-500">{{ source.senderName }}:</span>
+              <span class="line-clamp-2 break-words">{{ source.snippet }}</span>
+            </div>
+            <UIcon
+              name="i-heroicons-arrow-top-right-on-square"
+              class="mt-0.5 h-3 w-3 shrink-0 text-gray-400 opacity-0 transition-opacity group-hover/source:opacity-100"
+            />
+          </button>
+        </section>
+      </div>
+
+      <p class="mt-2 text-right text-[11px] text-gray-400 dark:text-gray-500">
+        {{
+          t('ai.chat.crossChatEvidence.coverage', {
+            scanned: evidence.coverage.scannedSessions,
+            candidates: evidence.coverage.candidateSessions,
+          })
+        }}
+      </p>
+    </div>
+  </ProcessDisclosure>
+</template>
+
+<style scoped>
+.cross-chat-evidence-details {
+  max-height: min(32rem, 65vh);
+  overflow: auto;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
+}
+</style>

--- a/src/components/common/Sidebar.vue
+++ b/src/components/common/Sidebar.vue
@@ -65,6 +65,7 @@ const SESSION_LIST_BOTTOM_PADDING = 32
 // 是否在首页
 const isHomePage = computed(() => route.path === '/')
 const isPeoplePage = computed(() => String(route.name ?? '').startsWith('people-'))
+const isGlobalAIPage = computed(() => route.name === 'global-ai')
 const privateSessionCount = computed(() => sessions.value.filter((session) => session.type === 'private').length)
 const groupSessionCount = computed(() => sessions.value.filter((session) => session.type === 'group').length)
 const showContactsEntry = computed(() =>
@@ -189,6 +190,10 @@ function handleImport() {
 
 function openContacts() {
   router.push({ name: 'people-contacts' })
+}
+
+function openGlobalAI() {
+  router.push({ name: 'global-ai' })
 }
 
 function openSession(session: AnalysisSession) {
@@ -548,6 +553,14 @@ function getAvatarColorClass(session: AnalysisSession, isActive: boolean) {
           :title="t('layout.relationships')"
           :active="isPeoplePage"
           @click="openContacts"
+        />
+
+        <SidebarButton
+          v-if="props.backendFeatures"
+          icon="i-heroicons-chat-bubble-left-ellipsis"
+          :title="t('analysis.tabs.aiChat')"
+          :active="isGlobalAIPage"
+          @click="openGlobalAI"
         />
       </div>
     </div>

--- a/src/i18n/locales/en-US/ai.json
+++ b/src/i18n/locales/en-US/ai.json
@@ -258,6 +258,42 @@
         "keyword_unavailable": "Keyword search unavailable",
         "semantic_partial": "Semantic results may be incomplete"
       }
+    },
+    "crossChatEvidence": {
+      "title": "Cross-chat evidence",
+      "query": "Query",
+      "summary": "{sources} sources · {sessions} chats",
+      "sourceCount": "{count} sources",
+      "coverage": "Searched {scanned}/{candidates} candidate chats",
+      "partial": "Results truncated",
+      "empty": "No source messages to display"
+    }
+  },
+  "global": {
+    "title": "AI Analysis",
+    "subtitle": "Query local chats across contacts and groups",
+    "empty": {
+      "title": "Start with a relationship",
+      "description": "Select contacts or groups before asking, or search globally for a topic when you no longer remember who you discussed it with. Only the local data needed for this question is read."
+    },
+    "input": {
+      "placeholder": "Ask a question, optionally selecting contacts or groups first..."
+    },
+    "entityPicker": {
+      "title": "Select contacts or groups",
+      "add": "Select scope",
+      "contacts": "Contacts",
+      "groups": "Groups",
+      "search": "Search names",
+      "loadFailed": "Failed to load contacts",
+      "contactsPreparing": "The contact index is being prepared. Try again later or select a group first.",
+      "empty": "No matching results"
+    },
+    "toast": {
+      "loadFailed": "Failed to load AI conversations",
+      "renameFailed": "Failed to rename conversation",
+      "deleteFailed": "Failed to delete conversation",
+      "busy": "Another AI analysis is already running"
     }
   },
   "sqlLab": {
@@ -426,7 +462,11 @@
       "response_time_analysis": "Response time analysis",
       "keyword_frequency": "Keyword frequency",
       "render_chart": "Generate dynamic chart",
-      "semantic_search_current_chat": "Search chat history"
+      "semantic_search_current_chat": "Search chat history",
+      "resolve_chat_entities": "Resolve contacts and groups",
+      "search_messages_globally": "Search across chats",
+      "get_cross_chat_message_context": "Get cross-chat message context",
+      "get_cross_chat_overview": "Get cross-chat overview"
     }
   },
   "skill": {

--- a/src/i18n/locales/ja-JP/ai.json
+++ b/src/i18n/locales/ja-JP/ai.json
@@ -258,6 +258,42 @@
         "keyword_unavailable": "キーワード検索が利用できません",
         "semantic_partial": "セマンティック検索の結果が不完全な可能性があります"
       }
+    },
+    "crossChatEvidence": {
+      "title": "チャット横断の根拠",
+      "query": "検索語",
+      "summary": "{sources} 件 · {sessions} チャット",
+      "sourceCount": "{count} 件",
+      "coverage": "候補チャット {scanned}/{candidates} 件を検索",
+      "partial": "結果は省略されています",
+      "empty": "表示できる参照メッセージがありません"
+    }
+  },
+  "global": {
+    "title": "AI 分析",
+    "subtitle": "連絡先やグループを横断してローカルのチャットを検索",
+    "empty": {
+      "title": "関係を選んで分析を始める",
+      "description": "連絡先やグループを選んで質問できます。誰と話したか忘れた話題は全体から検索できます。現在の質問に必要なローカルデータだけを読み取ります。"
+    },
+    "input": {
+      "placeholder": "質問を入力。先に連絡先やグループを選択できます..."
+    },
+    "entityPicker": {
+      "title": "連絡先またはグループを選択",
+      "add": "対象を選択",
+      "contacts": "連絡先",
+      "groups": "グループ",
+      "search": "名前を検索",
+      "loadFailed": "連絡先を読み込めませんでした",
+      "contactsPreparing": "連絡先インデックスを準備中です。後で再試行するか、先にグループを選択してください。",
+      "empty": "一致する結果がありません"
+    },
+    "toast": {
+      "loadFailed": "AI 会話を読み込めませんでした",
+      "renameFailed": "名前を変更できませんでした",
+      "deleteFailed": "削除できませんでした",
+      "busy": "別の AI 分析が実行中です"
     }
   },
   "sqlLab": {
@@ -426,7 +462,11 @@
       "response_time_analysis": "応答時間分析",
       "keyword_frequency": "高頻度キーワード統計",
       "render_chart": "動的チャート生成",
-      "semantic_search_current_chat": "チャット履歴を検索"
+      "semantic_search_current_chat": "チャット履歴を検索",
+      "resolve_chat_entities": "連絡先とグループを解決",
+      "search_messages_globally": "チャットを横断して検索",
+      "get_cross_chat_message_context": "チャット横断のメッセージ文脈を取得",
+      "get_cross_chat_overview": "チャット横断の概要を取得"
     }
   },
   "skill": {

--- a/src/i18n/locales/zh-CN/ai.json
+++ b/src/i18n/locales/zh-CN/ai.json
@@ -258,6 +258,42 @@
         "keyword_unavailable": "关键词检索不可用",
         "semantic_partial": "语义检索结果可能不完整"
       }
+    },
+    "crossChatEvidence": {
+      "title": "跨对话证据",
+      "query": "检索词",
+      "summary": "{sources} 条 · {sessions} 个对话",
+      "sourceCount": "{count} 条",
+      "coverage": "已检索 {scanned}/{candidates} 个候选对话",
+      "partial": "结果已截断",
+      "empty": "未找到可展示的来源消息"
+    }
+  },
+  "global": {
+    "title": "AI 分析",
+    "subtitle": "跨联系人和群聊查询本地聊天记录",
+    "empty": {
+      "title": "从一段关系开始分析",
+      "description": "选择联系人或群聊后提问，也可以直接搜索你忘记和谁聊过的话题。只会按当前问题读取必要的本地数据。"
+    },
+    "input": {
+      "placeholder": "输入问题，可先选择联系人或群聊..."
+    },
+    "entityPicker": {
+      "title": "选择联系人或群聊",
+      "add": "选择对象",
+      "contacts": "联系人",
+      "groups": "群聊",
+      "search": "搜索名称",
+      "loadFailed": "联系人加载失败",
+      "contactsPreparing": "联系人索引正在准备，可稍后重试或先选择群聊",
+      "empty": "没有匹配的结果"
+    },
+    "toast": {
+      "loadFailed": "加载 AI 对话失败",
+      "renameFailed": "重命名失败",
+      "deleteFailed": "删除失败",
+      "busy": "已有 AI 分析正在进行"
     }
   },
   "sqlLab": {
@@ -426,7 +462,11 @@
       "response_time_analysis": "响应时间分析",
       "keyword_frequency": "高频词统计",
       "render_chart": "生成动态图表",
-      "semantic_search_current_chat": "检索聊天历史"
+      "semantic_search_current_chat": "检索聊天历史",
+      "resolve_chat_entities": "解析联系人和群聊",
+      "search_messages_globally": "跨对话搜索消息",
+      "get_cross_chat_message_context": "获取跨对话消息上下文",
+      "get_cross_chat_overview": "获取跨对话概览"
     }
   },
   "skill": {

--- a/src/i18n/locales/zh-TW/ai.json
+++ b/src/i18n/locales/zh-TW/ai.json
@@ -258,6 +258,42 @@
         "keyword_unavailable": "關鍵字檢索不可用",
         "semantic_partial": "語意檢索結果可能不完整"
       }
+    },
+    "crossChatEvidence": {
+      "title": "跨對話證據",
+      "query": "搜尋詞",
+      "summary": "{sources} 條 · {sessions} 個對話",
+      "sourceCount": "{count} 條",
+      "coverage": "已搜尋 {scanned}/{candidates} 個候選對話",
+      "partial": "結果已截斷",
+      "empty": "找不到可顯示的來源訊息"
+    }
+  },
+  "global": {
+    "title": "AI 分析",
+    "subtitle": "跨聯絡人與群聊查詢本機聊天記錄",
+    "empty": {
+      "title": "從一段關係開始分析",
+      "description": "選擇聯絡人或群聊後提問，也可以直接搜尋你忘記和誰聊過的話題。只會按目前問題讀取必要的本機資料。"
+    },
+    "input": {
+      "placeholder": "輸入問題，可先選擇聯絡人或群聊..."
+    },
+    "entityPicker": {
+      "title": "選擇聯絡人或群聊",
+      "add": "選擇對象",
+      "contacts": "聯絡人",
+      "groups": "群聊",
+      "search": "搜尋名稱",
+      "loadFailed": "聯絡人載入失敗",
+      "contactsPreparing": "聯絡人索引正在準備，可稍後重試或先選擇群聊",
+      "empty": "沒有符合的結果"
+    },
+    "toast": {
+      "loadFailed": "載入 AI 對話失敗",
+      "renameFailed": "重新命名失敗",
+      "deleteFailed": "刪除失敗",
+      "busy": "已有 AI 分析正在進行"
     }
   },
   "sqlLab": {
@@ -426,7 +462,11 @@
       "response_time_analysis": "回應時間分析",
       "keyword_frequency": "高頻詞統計",
       "render_chart": "生成動態圖表",
-      "semantic_search_current_chat": "檢索聊天歷史"
+      "semantic_search_current_chat": "檢索聊天歷史",
+      "resolve_chat_entities": "解析聯絡人和群聊",
+      "search_messages_globally": "跨對話搜尋訊息",
+      "get_cross_chat_message_context": "取得跨對話訊息上下文",
+      "get_cross_chat_overview": "取得跨對話概覽"
     }
   },
   "skill": {

--- a/src/pages/global-ai/components/GlobalEntityPicker.vue
+++ b/src/pages/global-ai/components/GlobalEntityPicker.vue
@@ -77,6 +77,7 @@ async function loadContacts(): Promise<void> {
   try {
     const options = {
       acceptStale: true,
+      timeRangePreset: 'all',
       page: 1,
       pageSize: 100,
       query: query.value.trim() || undefined,

--- a/src/pages/global-ai/components/GlobalEntityPicker.vue
+++ b/src/pages/global-ai/components/GlobalEntityPicker.vue
@@ -1,0 +1,273 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import type { AIEntityRef, ContactListItem, ContactsResponse } from '@openchatlab/shared-types'
+import { useDataService } from '@/services'
+import { useSessionStore } from '@/stores/session'
+
+const props = defineProps<{
+  modelValue: AIEntityRef[]
+  disabled?: boolean
+}>()
+
+const emit = defineEmits<{
+  'update:modelValue': [value: AIEntityRef[]]
+}>()
+
+const { t } = useI18n()
+const dataService = useDataService()
+const sessionStore = useSessionStore()
+const open = ref(false)
+const activeType = ref<'contacts' | 'groups'>('contacts')
+const query = ref('')
+const contacts = ref<ContactListItem[]>([])
+const contactResponses = ref<ContactsResponse[]>([])
+const loadingContacts = ref(false)
+const contactError = ref('')
+let searchTimer: ReturnType<typeof setTimeout> | null = null
+let requestId = 0
+
+const normalizedQuery = computed(() => query.value.trim().toLocaleLowerCase())
+const groups = computed(() => {
+  const list = sessionStore.sessions.filter((session) => session.type === 'group')
+  if (!normalizedQuery.value) return list
+  return list.filter((session) => session.name.toLocaleLowerCase().includes(normalizedQuery.value))
+})
+const contactsUnavailable = computed(
+  () =>
+    !loadingContacts.value &&
+    !contactError.value &&
+    contacts.value.length === 0 &&
+    contactResponses.value.some(
+      (response) => response.cache.status === 'missing' || response.task?.status === 'running'
+    )
+)
+
+function entityKey(entity: AIEntityRef): string {
+  return entity.type === 'contact' ? `contact:${entity.contactKey}` : `session:${entity.sessionId}`
+}
+
+function isSelected(entity: AIEntityRef): boolean {
+  const key = entityKey(entity)
+  return props.modelValue.some((item) => entityKey(item) === key)
+}
+
+function toggle(entity: AIEntityRef): void {
+  if (props.disabled) return
+  const key = entityKey(entity)
+  const exists = props.modelValue.some((item) => entityKey(item) === key)
+  emit(
+    'update:modelValue',
+    exists ? props.modelValue.filter((item) => entityKey(item) !== key) : [...props.modelValue, entity]
+  )
+}
+
+function remove(entity: AIEntityRef): void {
+  const key = entityKey(entity)
+  emit(
+    'update:modelValue',
+    props.modelValue.filter((item) => entityKey(item) !== key)
+  )
+}
+
+async function loadContacts(): Promise<void> {
+  const currentRequest = ++requestId
+  loadingContacts.value = true
+  contactError.value = ''
+  try {
+    const options = {
+      acceptStale: true,
+      page: 1,
+      pageSize: 100,
+      query: query.value.trim() || undefined,
+    } as const
+    const responses = await Promise.all([
+      dataService.getContacts({ ...options, pool: 'friend' }),
+      dataService.getContacts({ ...options, pool: 'non_friend' }),
+    ])
+    if (currentRequest !== requestId) return
+
+    const byKey = new Map<string, ContactListItem>()
+    responses.flatMap((response) => response.contacts).forEach((contact) => byKey.set(contact.key, contact))
+    contacts.value = [...byKey.values()]
+    contactResponses.value = responses
+  } catch (error) {
+    if (currentRequest !== requestId) return
+    contactError.value = error instanceof Error ? error.message : String(error)
+    contacts.value = []
+    contactResponses.value = []
+  } finally {
+    if (currentRequest === requestId) loadingContacts.value = false
+  }
+}
+
+watch(open, (isOpen) => {
+  if (isOpen) void loadContacts()
+})
+
+watch(query, () => {
+  if (!open.value || activeType.value !== 'contacts') return
+  if (searchTimer) clearTimeout(searchTimer)
+  searchTimer = setTimeout(() => void loadContacts(), 250)
+})
+</script>
+
+<template>
+  <div class="flex min-w-0 flex-wrap items-center gap-1.5">
+    <UPopover v-model:open="open" :ui="{ content: 'z-[80] p-0' }">
+      <button
+        type="button"
+        class="inline-flex h-7 shrink-0 items-center gap-1 rounded-full px-2 text-xs text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700 disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+        :disabled="disabled"
+        :title="t('ai.global.entityPicker.title')"
+      >
+        <span class="text-base leading-none">@</span>
+        <span>{{ t('ai.global.entityPicker.add') }}</span>
+      </button>
+
+      <template #content>
+        <div class="flex h-[390px] w-[340px] flex-col overflow-hidden">
+          <div class="border-b border-gray-200 p-3 dark:border-gray-800">
+            <div class="mb-2 flex rounded-lg bg-gray-100 p-0.5 dark:bg-gray-800">
+              <button
+                v-for="type in ['contacts', 'groups'] as const"
+                :key="type"
+                type="button"
+                class="flex-1 rounded-md px-3 py-1.5 text-xs transition-colors"
+                :class="
+                  activeType === type
+                    ? 'bg-white text-gray-900 shadow-sm dark:bg-gray-700 dark:text-white'
+                    : 'text-gray-500 dark:text-gray-400'
+                "
+                @click="activeType = type"
+              >
+                {{ t(`ai.global.entityPicker.${type}`) }}
+              </button>
+            </div>
+            <UInput
+              v-model="query"
+              icon="i-heroicons-magnifying-glass"
+              size="sm"
+              :placeholder="t('ai.global.entityPicker.search')"
+            />
+          </div>
+
+          <div class="min-h-0 flex-1 overflow-y-auto p-2">
+            <template v-if="activeType === 'contacts'">
+              <div v-if="loadingContacts" class="flex h-full items-center justify-center">
+                <UIcon name="i-lucide-loader-2" class="h-4 w-4 animate-spin text-gray-400" />
+              </div>
+              <div v-else-if="contactError" class="px-3 py-8 text-center text-xs text-red-500">
+                <p>{{ t('ai.global.entityPicker.loadFailed') }}</p>
+                <UButton size="xs" variant="link" class="mt-1" @click="loadContacts">
+                  {{ t('common.retry') }}
+                </UButton>
+              </div>
+              <div v-else-if="contactsUnavailable" class="px-4 py-8 text-center text-xs text-gray-400">
+                {{ t('ai.global.entityPicker.contactsPreparing') }}
+              </div>
+              <div v-else-if="contacts.length === 0" class="px-4 py-8 text-center text-xs text-gray-400">
+                {{ t('ai.global.entityPicker.empty') }}
+              </div>
+              <button
+                v-for="contact in contacts"
+                v-else
+                :key="contact.key"
+                type="button"
+                class="flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left transition-colors hover:bg-gray-100 dark:hover:bg-gray-800"
+                @click="
+                  toggle({
+                    type: 'contact',
+                    contactKey: contact.key,
+                    displayName: contact.displayName,
+                  })
+                "
+              >
+                <div
+                  class="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-primary-50 text-xs text-primary-600 dark:bg-primary-500/10 dark:text-primary-300"
+                >
+                  {{ contact.displayName.slice(0, 1) }}
+                </div>
+                <div class="min-w-0 flex-1">
+                  <p class="truncate text-sm text-gray-700 dark:text-gray-200">{{ contact.displayName }}</p>
+                  <p class="truncate text-[11px] text-gray-400">{{ contact.platform }}</p>
+                </div>
+                <UIcon
+                  v-if="
+                    isSelected({
+                      type: 'contact',
+                      contactKey: contact.key,
+                      displayName: contact.displayName,
+                    })
+                  "
+                  name="i-heroicons-check"
+                  class="h-4 w-4 shrink-0 text-primary-500"
+                />
+              </button>
+            </template>
+
+            <template v-else>
+              <div v-if="groups.length === 0" class="px-4 py-8 text-center text-xs text-gray-400">
+                {{ t('ai.global.entityPicker.empty') }}
+              </div>
+              <button
+                v-for="session in groups"
+                :key="session.id"
+                type="button"
+                class="flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left transition-colors hover:bg-gray-100 dark:hover:bg-gray-800"
+                @click="
+                  toggle({
+                    type: 'session',
+                    sessionId: session.id,
+                    displayName: session.name,
+                    sessionType: 'group',
+                  })
+                "
+              >
+                <div
+                  class="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-300"
+                >
+                  <UIcon name="i-heroicons-user-group" class="h-4 w-4" />
+                </div>
+                <div class="min-w-0 flex-1">
+                  <p class="truncate text-sm text-gray-700 dark:text-gray-200">{{ session.name }}</p>
+                  <p class="text-[11px] text-gray-400">{{ session.platform }}</p>
+                </div>
+                <UIcon
+                  v-if="
+                    isSelected({
+                      type: 'session',
+                      sessionId: session.id,
+                      displayName: session.name,
+                      sessionType: 'group',
+                    })
+                  "
+                  name="i-heroicons-check"
+                  class="h-4 w-4 shrink-0 text-primary-500"
+                />
+              </button>
+            </template>
+          </div>
+        </div>
+      </template>
+    </UPopover>
+
+    <span
+      v-for="entity in modelValue"
+      :key="entityKey(entity)"
+      class="inline-flex h-7 max-w-[180px] items-center gap-1 rounded-full bg-primary-50 px-2 text-xs text-primary-700 dark:bg-primary-500/10 dark:text-primary-300"
+    >
+      <UIcon :name="entity.type === 'contact' ? 'i-heroicons-user' : 'i-heroicons-user-group'" class="h-3 w-3" />
+      <span class="truncate">{{ entity.displayName }}</span>
+      <button
+        type="button"
+        class="ml-0.5 rounded-full text-primary-400 hover:text-primary-700 dark:hover:text-primary-200"
+        :aria-label="t('common.delete')"
+        :disabled="disabled"
+        @click="remove(entity)"
+      >
+        <UIcon name="i-heroicons-x-mark" class="h-3 w-3" />
+      </button>
+    </span>
+  </div>
+</template>

--- a/src/pages/global-ai/components/GlobalEntityPicker.vue
+++ b/src/pages/global-ai/components/GlobalEntityPicker.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
+import { computed, onUnmounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import type { AIEntityRef, ContactListItem, ContactsResponse } from '@openchatlab/shared-types'
 import { useDataService } from '@/services'
@@ -25,7 +25,9 @@ const contactResponses = ref<ContactsResponse[]>([])
 const loadingContacts = ref(false)
 const contactError = ref('')
 let searchTimer: ReturnType<typeof setTimeout> | null = null
+let pollTimer: ReturnType<typeof setTimeout> | null = null
 let requestId = 0
+const CONTACTS_POLL_INTERVAL_MS = 1500
 
 const normalizedQuery = computed(() => query.value.trim().toLocaleLowerCase())
 const groups = computed(() => {
@@ -70,12 +72,39 @@ function remove(entity: AIEntityRef): void {
   )
 }
 
-async function loadContacts(): Promise<void> {
+function stopContactsPolling(): void {
+  if (!pollTimer) return
+  clearTimeout(pollTimer)
+  pollTimer = null
+}
+
+function scheduleContactsPolling(responses: ContactsResponse[]): void {
+  stopContactsPolling()
+  if (!open.value || activeType.value !== 'contacts') return
+  if (!responses.some((response) => response.task?.status === 'running')) return
+
+  pollTimer = setTimeout(() => {
+    pollTimer = null
+    void loadContacts({ silent: true })
+  }, CONTACTS_POLL_INTERVAL_MS)
+}
+
+function stopPendingContactWork(): void {
+  requestId++
+  loadingContacts.value = false
+  if (searchTimer) {
+    clearTimeout(searchTimer)
+    searchTimer = null
+  }
+  stopContactsPolling()
+}
+
+async function loadContacts(loadOptions?: { silent?: boolean }): Promise<void> {
   const currentRequest = ++requestId
-  loadingContacts.value = true
+  if (!loadOptions?.silent) loadingContacts.value = true
   contactError.value = ''
   try {
-    const options = {
+    const requestOptions = {
       acceptStale: true,
       timeRangePreset: 'all',
       page: 1,
@@ -83,8 +112,8 @@ async function loadContacts(): Promise<void> {
       query: query.value.trim() || undefined,
     } as const
     const responses = await Promise.all([
-      dataService.getContacts({ ...options, pool: 'friend' }),
-      dataService.getContacts({ ...options, pool: 'non_friend' }),
+      dataService.getContacts({ ...requestOptions, pool: 'friend' }),
+      dataService.getContacts({ ...requestOptions, pool: 'non_friend' }),
     ])
     if (currentRequest !== requestId) return
 
@@ -92,24 +121,45 @@ async function loadContacts(): Promise<void> {
     responses.flatMap((response) => response.contacts).forEach((contact) => byKey.set(contact.key, contact))
     contacts.value = [...byKey.values()]
     contactResponses.value = responses
+    scheduleContactsPolling(responses)
   } catch (error) {
     if (currentRequest !== requestId) return
+    stopContactsPolling()
     contactError.value = error instanceof Error ? error.message : String(error)
     contacts.value = []
     contactResponses.value = []
   } finally {
-    if (currentRequest === requestId) loadingContacts.value = false
+    if (currentRequest === requestId && !loadOptions?.silent) loadingContacts.value = false
   }
 }
 
 watch(open, (isOpen) => {
-  if (isOpen) void loadContacts()
+  if (isOpen) {
+    void loadContacts()
+  } else {
+    stopPendingContactWork()
+  }
+})
+
+watch(activeType, (type) => {
+  if (!open.value) return
+  stopPendingContactWork()
+  if (type === 'contacts') void loadContacts()
 })
 
 watch(query, () => {
   if (!open.value || activeType.value !== 'contacts') return
+  requestId++
   if (searchTimer) clearTimeout(searchTimer)
-  searchTimer = setTimeout(() => void loadContacts(), 250)
+  stopContactsPolling()
+  searchTimer = setTimeout(() => {
+    searchTimer = null
+    void loadContacts()
+  }, 250)
+})
+
+onUnmounted(() => {
+  stopPendingContactWork()
 })
 </script>
 
@@ -160,7 +210,7 @@ watch(query, () => {
               </div>
               <div v-else-if="contactError" class="px-3 py-8 text-center text-xs text-red-500">
                 <p>{{ t('ai.global.entityPicker.loadFailed') }}</p>
-                <UButton size="xs" variant="link" class="mt-1" @click="loadContacts">
+                <UButton size="xs" variant="link" class="mt-1" @click="loadContacts()">
                   {{ t('common.retry') }}
                 </UButton>
               </div>

--- a/src/pages/global-ai/index.vue
+++ b/src/pages/global-ai/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, nextTick, onMounted, ref, toRef, watch } from 'vue'
+import { computed, nextTick, onMounted, onUnmounted, ref, toRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 import type { AIEntityRef } from '@openchatlab/shared-types'
@@ -37,6 +37,11 @@ const initializing = ref(true)
 const input = ref('')
 const selectedEntities = ref<AIEntityRef[]>([])
 const isComposing = ref(false)
+let isUnmounted = false
+
+function isGlobalPageActive(): boolean {
+  return !isUnmounted && route.name === 'global-ai'
+}
 
 const pairs = computed(() => groupMessagesToQAPairs(messages.value))
 const { messagesContainer, showScrollToBottom, handleScrollToBottom, scrollToBottom } = useChatScroll(
@@ -50,6 +55,8 @@ const { visiblePairs, hasOlderPairs, loadOlderPairs } = useProgressiveChatHistor
 )
 
 async function syncAIChatIdToRoute(aiChatId: string | null): Promise<void> {
+  if (!isGlobalPageActive()) return
+
   const routeAIChatId = typeof route.query.aiChatId === 'string' ? route.query.aiChatId : null
   if (routeAIChatId === aiChatId) return
 
@@ -166,15 +173,29 @@ watch(
 onMounted(async () => {
   aiChatStore.selectAssistantForSession(chatKey, getDefaultGeneralAssistantId(locale.value))
   await loadConversations()
+  if (!isGlobalPageActive()) return
+
   const preferredAIChatId = typeof route.query.aiChatId === 'string' ? route.query.aiChatId : null
-  if (!preferredAIChatId || !(await aiChatStore.loadAIChat(chatKey, preferredAIChatId))) {
+  const restoredPreferredChat = preferredAIChatId ? await aiChatStore.loadAIChat(chatKey, preferredAIChatId) : false
+  if (!isGlobalPageActive()) return
+
+  if (!restoredPreferredChat) {
     aiChatStore.startNewAIChat(chatKey)
     if (preferredAIChatId) await syncAIChatIdToRoute(null)
   }
+  if (!isGlobalPageActive()) return
+
   initializing.value = false
   await syncAIChatIdToRoute(currentAIChatId.value)
+  if (!isGlobalPageActive()) return
+
   await nextTick()
+  if (!isGlobalPageActive()) return
   scrollToBottom(true)
+})
+
+onUnmounted(() => {
+  isUnmounted = true
 })
 </script>
 

--- a/src/pages/global-ai/index.vue
+++ b/src/pages/global-ai/index.vue
@@ -1,0 +1,326 @@
+<script setup lang="ts">
+import { computed, nextTick, onMounted, ref, toRef, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useRoute, useRouter } from 'vue-router'
+import type { AIEntityRef } from '@openchatlab/shared-types'
+import { getDefaultGeneralAssistantId } from '@openchatlab/shared-types'
+import ConversationList from '@/components/AIChat/chat/ConversationList.vue'
+import ChatMessage from '@/components/AIChat/chat/ChatMessage.vue'
+import AIThinkingIndicator from '@/components/AIChat/chat/AIThinkingIndicator.vue'
+import ChatStatusBar from '@/components/AIChat/chat/ChatStatusBar.vue'
+import AIChatComposer from '@/components/AIChat/input/AIChatComposer.vue'
+import { useChatScroll } from '@/components/AIChat/composables/useChatScroll'
+import { useProgressiveChatHistory } from '@/components/AIChat/composables/useProgressiveChatHistory'
+import { groupMessagesToQAPairs } from '@/components/AIChat/utils/chatMessages'
+import PageHeader from '@/components/layout/PageHeader.vue'
+import { useAIService } from '@/services'
+import type { AIChat } from '@/services/ai/types'
+import { useAIChatStore } from '@/stores/aiChat'
+import { useLayoutStore } from '@/stores/layout'
+import { useToast } from '@/composables/useToast'
+import GlobalEntityPicker from './components/GlobalEntityPicker.vue'
+
+const { t, locale } = useI18n()
+const route = useRoute()
+const router = useRouter()
+const toast = useToast()
+const layoutStore = useLayoutStore()
+const aiChatStore = useAIChatStore()
+const aiService = useAIService()
+const { chatKey, state } = aiChatStore.ensureGlobalState(locale.value)
+const messages = toRef(state, 'messages')
+const isAIThinking = toRef(state, 'isAIThinking')
+const currentAIChatId = toRef(state, 'currentAIChatId')
+const conversations = ref<AIChat[]>([])
+const conversationsLoading = ref(false)
+const initializing = ref(true)
+const input = ref('')
+const selectedEntities = ref<AIEntityRef[]>([])
+const isComposing = ref(false)
+
+const pairs = computed(() => groupMessagesToQAPairs(messages.value))
+const { messagesContainer, showScrollToBottom, handleScrollToBottom, scrollToBottom } = useChatScroll(
+  messages,
+  isAIThinking
+)
+const { visiblePairs, hasOlderPairs, loadOlderPairs } = useProgressiveChatHistory(
+  pairs,
+  currentAIChatId,
+  messagesContainer
+)
+
+async function syncAIChatIdToRoute(aiChatId: string | null): Promise<void> {
+  const routeAIChatId = typeof route.query.aiChatId === 'string' ? route.query.aiChatId : null
+  if (routeAIChatId === aiChatId) return
+
+  await router.replace({
+    query: {
+      ...route.query,
+      aiChatId: aiChatId || undefined,
+    },
+  })
+}
+
+async function loadConversations(): Promise<void> {
+  conversationsLoading.value = true
+  try {
+    conversations.value = await aiService.getGlobalAIChats()
+  } catch (error) {
+    toast.fail(t('ai.global.toast.loadFailed'), { description: String(error) })
+  } finally {
+    conversationsLoading.value = false
+  }
+}
+
+async function selectConversation(aiChatId: string): Promise<void> {
+  if (!(await aiChatStore.loadAIChat(chatKey, aiChatId))) {
+    toast.fail(t('ai.global.toast.loadFailed'))
+    return
+  }
+  selectedEntities.value = []
+  await syncAIChatIdToRoute(aiChatId)
+  await nextTick()
+  scrollToBottom(true)
+}
+
+function startNewConversation(): void {
+  if (!aiChatStore.startNewAIChat(chatKey)) return
+  selectedEntities.value = []
+  input.value = ''
+  void syncAIChatIdToRoute(null)
+}
+
+async function renameConversation(payload: { id: string; title: string }): Promise<void> {
+  try {
+    await aiService.updateAIChatTitle(payload.id, payload.title)
+    const conversation = conversations.value.find((item) => item.id === payload.id)
+    if (conversation) conversation.title = payload.title
+  } catch (error) {
+    toast.fail(t('ai.global.toast.renameFailed'), { description: String(error) })
+  }
+}
+
+async function deleteConversation(aiChatId: string): Promise<void> {
+  try {
+    await aiService.deleteAIChat(aiChatId)
+    conversations.value = conversations.value.filter((item) => item.id !== aiChatId)
+    if (currentAIChatId.value === aiChatId) startNewConversation()
+  } catch (error) {
+    toast.fail(t('ai.global.toast.deleteFailed'), { description: String(error) })
+  }
+}
+
+async function submit(): Promise<void> {
+  const content = input.value.trim()
+  if (!content || isAIThinking.value) return
+
+  const refs = selectedEntities.value.map((entity) => ({ ...entity }))
+  input.value = ''
+  selectedEntities.value = []
+  const result = await aiChatStore.sendMessage(chatKey, content, { entityRefs: refs })
+  if (result.success || result.reason === 'aborted') return
+
+  if (result.reason === 'no_config') {
+    input.value = content
+    selectedEntities.value = refs
+    layoutStore.openSettings('ai', 'defaultModel')
+    return
+  }
+  if (result.reason === 'busy') {
+    toast.warn(t('ai.global.toast.busy'))
+    return
+  }
+  input.value = content
+  selectedEntities.value = refs
+}
+
+function handleKeydown(event: KeyboardEvent): void {
+  if (event.key !== 'Enter' || event.shiftKey || isComposing.value) return
+  event.preventDefault()
+  void submit()
+}
+
+watch(locale, (nextLocale) => {
+  aiChatStore.ensureGlobalState(nextLocale)
+})
+
+watch(currentAIChatId, (aiChatId, previousId) => {
+  if (aiChatId === previousId) return
+  if (!initializing.value) void syncAIChatIdToRoute(aiChatId)
+  if (aiChatId) void loadConversations()
+})
+
+watch(
+  () => route.query.aiChatId,
+  (value) => {
+    const aiChatId = typeof value === 'string' ? value : null
+    if (initializing.value || isAIThinking.value) return
+    if (!aiChatId) {
+      if (currentAIChatId.value) aiChatStore.startNewAIChat(chatKey)
+      return
+    }
+    if (aiChatId !== currentAIChatId.value) void selectConversation(aiChatId)
+  }
+)
+
+onMounted(async () => {
+  aiChatStore.selectAssistantForSession(chatKey, getDefaultGeneralAssistantId(locale.value))
+  await loadConversations()
+  const preferredAIChatId = typeof route.query.aiChatId === 'string' ? route.query.aiChatId : null
+  if (!preferredAIChatId || !(await aiChatStore.loadAIChat(chatKey, preferredAIChatId))) {
+    aiChatStore.startNewAIChat(chatKey)
+    if (preferredAIChatId) await syncAIChatIdToRoute(null)
+  }
+  initializing.value = false
+  await syncAIChatIdToRoute(currentAIChatId.value)
+  await nextTick()
+  scrollToBottom(true)
+})
+</script>
+
+<template>
+  <div
+    class="flex h-full min-w-0 flex-col bg-page-bg text-gray-900 dark:bg-page-dark dark:text-gray-100"
+    style="padding-top: var(--titlebar-area-height)"
+  >
+    <PageHeader
+      :title="t('ai.global.title')"
+      :description="t('ai.global.subtitle')"
+      icon="i-heroicons-sparkles"
+      icon-class="bg-primary-600 text-white dark:bg-primary-500 dark:text-white"
+      size="compact"
+    />
+
+    <div class="flex min-h-0 min-w-0 flex-1">
+      <ConversationList
+        session-id=""
+        :active-id="currentAIChatId"
+        :conversations="conversations"
+        :loading="conversationsLoading"
+        :disabled="isAIThinking"
+        embedded
+        @select="selectConversation"
+        @create="startNewConversation"
+        @rename="renameConversation"
+        @delete="deleteConversation"
+      />
+
+      <section class="flex min-w-0 flex-1 flex-col border-l border-gray-200 dark:border-gray-800">
+        <div class="relative min-h-0 flex-1">
+          <div ref="messagesContainer" class="absolute inset-0 overflow-y-auto px-5 py-6">
+            <div v-if="initializing" class="flex h-full items-center justify-center">
+              <UIcon name="i-lucide-loader-2" class="h-5 w-5 animate-spin text-gray-400" />
+            </div>
+
+            <div
+              v-else-if="messages.length === 0"
+              class="mx-auto flex h-full max-w-lg flex-col items-center justify-center pb-16 text-center"
+            >
+              <div
+                class="mb-4 flex h-12 w-12 items-center justify-center rounded-2xl bg-primary-50 text-primary-500 dark:bg-primary-500/10 dark:text-primary-300"
+              >
+                <UIcon name="i-heroicons-chat-bubble-left-right" class="h-6 w-6" />
+              </div>
+              <h2 class="text-base text-gray-800 dark:text-gray-100">{{ t('ai.global.empty.title') }}</h2>
+              <p class="mt-2 text-sm leading-6 text-gray-500 dark:text-gray-400">
+                {{ t('ai.global.empty.description') }}
+              </p>
+            </div>
+
+            <div v-else class="mx-auto max-w-3xl space-y-4">
+              <div v-if="hasOlderPairs" class="flex justify-center pb-2">
+                <button
+                  type="button"
+                  class="flex h-8 items-center gap-1.5 rounded-full px-3 text-xs text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+                  @click="loadOlderPairs"
+                >
+                  <UIcon name="i-heroicons-arrow-up" class="h-3.5 w-3.5" />
+                  {{ t('ai.chat.history.loadEarlier') }}
+                </button>
+              </div>
+
+              <template v-for="pair in visiblePairs" :key="pair.id">
+                <ChatMessage
+                  v-if="pair.standalone"
+                  :role="pair.standalone.role"
+                  :content="pair.standalone.content"
+                  :timestamp="pair.standalone.timestamp"
+                />
+                <div v-else class="qa-pair space-y-6 pb-4">
+                  <ChatMessage
+                    v-if="pair.user"
+                    :role="pair.user.role"
+                    :message-id="pair.user.id"
+                    :content="pair.user.content"
+                    :timestamp="pair.user.timestamp"
+                    :entity-refs="pair.user.entityRefs"
+                  />
+                  <ChatMessage
+                    v-if="
+                      pair.assistant &&
+                      (pair.assistant.content || pair.assistant.contentBlocks?.length || !pair.assistant.isStreaming)
+                    "
+                    :role="pair.assistant.role"
+                    :message-id="pair.assistant.id"
+                    :content="pair.assistant.content"
+                    :timestamp="pair.assistant.timestamp"
+                    :is-streaming="pair.assistant.isStreaming"
+                    :process-duration-ms="pair.assistant.processDurationMs"
+                    :content-blocks="pair.assistant.contentBlocks"
+                    :show-capture-button="!pair.assistant.isStreaming"
+                    :active-tool="pair.assistant.isStreaming ? state.currentToolStatus : null"
+                  />
+                  <AIThinkingIndicator
+                    v-else-if="pair.assistant?.isStreaming"
+                    :current-tool-status="state.currentToolStatus"
+                    :agent-status="state.agentStatus"
+                  />
+                </div>
+              </template>
+            </div>
+          </div>
+
+          <Transition name="fade-up">
+            <button
+              v-if="showScrollToBottom"
+              type="button"
+              class="absolute bottom-4 left-1/2 z-10 flex -translate-x-1/2 items-center gap-1.5 rounded-full bg-gray-800/90 px-3 py-1.5 text-xs text-white shadow-lg backdrop-blur-sm hover:bg-gray-700 dark:bg-gray-700/90"
+              @click="handleScrollToBottom"
+            >
+              <UIcon name="i-heroicons-arrow-down" class="h-3.5 w-3.5" />
+              {{ t('ai.chat.scrollToBottom') }}
+            </button>
+          </Transition>
+        </div>
+
+        <div class="shrink-0 px-4 pb-4">
+          <div
+            class="mx-auto max-w-3xl overflow-visible rounded-2xl bg-white shadow-[0_2px_14px_rgba(0,0,0,0.04)] ring-1 ring-gray-200/60 transition-all focus-within:ring-primary-500/40 focus-within:shadow-[0_4px_20px_rgba(0,0,0,0.08)] dark:bg-page-dark dark:ring-white/5"
+          >
+            <div class="border-b border-gray-100 px-3 py-2 dark:border-gray-800/80">
+              <GlobalEntityPicker v-model="selectedEntities" :disabled="isAIThinking" />
+            </div>
+            <AIChatComposer
+              v-model="input"
+              embedded
+              :disabled="isAIThinking"
+              :status="isAIThinking ? 'streaming' : 'ready'"
+              :placeholder="t('ai.global.input.placeholder')"
+              :send-button-title="t('ai.chat.input.send')"
+              @submit="submit"
+              @stop="aiChatStore.stopGeneration(chatKey)"
+              @keydown="handleKeydown"
+              @composition-start="isComposing = true"
+              @composition-end="isComposing = false"
+            />
+            <ChatStatusBar
+              class="px-2 pb-1.5 pt-0.5"
+              :session-token-usage="state.sessionTokenUsage"
+              :agent-status="state.agentStatus"
+            />
+          </div>
+        </div>
+      </section>
+    </div>
+  </div>
+</template>

--- a/src/pages/global-ai/index.vue
+++ b/src/pages/global-ai/index.vue
@@ -38,6 +38,7 @@ const input = ref('')
 const selectedEntities = ref<AIEntityRef[]>([])
 const isComposing = ref(false)
 let isUnmounted = false
+let conversationSelectionRequestId = 0
 
 function isGlobalPageActive(): boolean {
   return !isUnmounted && route.name === 'global-ai'
@@ -80,18 +81,26 @@ async function loadConversations(): Promise<void> {
 }
 
 async function selectConversation(aiChatId: string): Promise<void> {
-  if (!(await aiChatStore.loadAIChat(chatKey, aiChatId))) {
+  const currentRequest = ++conversationSelectionRequestId
+  const loaded = await aiChatStore.loadAIChat(chatKey, aiChatId)
+  if (currentRequest !== conversationSelectionRequestId || !isGlobalPageActive()) return
+
+  if (!loaded) {
     toast.fail(t('ai.global.toast.loadFailed'))
     return
   }
+  initializing.value = false
   selectedEntities.value = []
   await syncAIChatIdToRoute(aiChatId)
+  if (currentRequest !== conversationSelectionRequestId || !isGlobalPageActive()) return
   await nextTick()
   scrollToBottom(true)
 }
 
 function startNewConversation(): void {
+  conversationSelectionRequestId++
   if (!aiChatStore.startNewAIChat(chatKey)) return
+  initializing.value = false
   selectedEntities.value = []
   input.value = ''
   void syncAIChatIdToRoute(null)
@@ -175,9 +184,10 @@ onMounted(async () => {
   await loadConversations()
   if (!isGlobalPageActive()) return
 
+  const currentSelectionRequest = ++conversationSelectionRequestId
   const preferredAIChatId = typeof route.query.aiChatId === 'string' ? route.query.aiChatId : null
   const restoredPreferredChat = preferredAIChatId ? await aiChatStore.loadAIChat(chatKey, preferredAIChatId) : false
-  if (!isGlobalPageActive()) return
+  if (currentSelectionRequest !== conversationSelectionRequestId || !isGlobalPageActive()) return
 
   if (!restoredPreferredChat) {
     aiChatStore.startNewAIChat(chatKey)
@@ -196,6 +206,7 @@ onMounted(async () => {
 
 onUnmounted(() => {
   isUnmounted = true
+  conversationSelectionRequestId++
 })
 </script>
 

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -36,6 +36,11 @@ export function createAppRoutes(insightRuntime: InsightPluginRuntime = desktopCl
       component: () => import('@/pages/private-chat/index.vue'),
     },
     {
+      path: '/ai-chat',
+      name: 'global-ai',
+      component: () => import('@/pages/global-ai/index.vue'),
+    },
+    {
       path: '/insight',
       component: () => import('@/pages/insight/index.vue'),
       redirect: defaultInsightRoute ? { name: defaultInsightRoute } : undefined,

--- a/src/services/ai/types.ts
+++ b/src/services/ai/types.ts
@@ -1,5 +1,6 @@
 import type { TimeFilter } from '@/types/base'
 import type { ChartPayload, ChatEvidencePayload } from '@openchatlab/core'
+import type { AIEntityRef, CrossChatEvidencePayload } from '@openchatlab/shared-types'
 import type { PlanContentBlock } from './planBlocks'
 
 export interface AIChat {
@@ -13,15 +14,14 @@ export interface AIChat {
   updatedAt: number
 }
 
-export type AIEntityRef =
-  | { type: 'contact'; contactKey: string; displayName: string }
-  | { type: 'session'; sessionId: string; displayName: string; sessionType: 'private' | 'group' }
+export type { AIEntityRef } from '@openchatlab/shared-types'
 
 export type ContentBlock =
   | { type: 'text'; text: string; processDurationMs?: number }
   | { type: 'think'; tag: string; text: string; durationMs?: number }
   | { type: 'chart'; chart: ChartPayload }
   | { type: 'evidence'; evidence: ChatEvidencePayload }
+  | { type: 'cross_chat_evidence'; evidence: CrossChatEvidencePayload }
   | PlanContentBlock
   | {
       type: 'tool'

--- a/src/stores/aiChat.ts
+++ b/src/stores/aiChat.ts
@@ -20,7 +20,11 @@ import { useAgentStreamService } from '@/services/ai-stream/service'
 import { buildSerializablePreprocessConfig, shouldEnsureDesensitizeRulesBeforeSerialize } from './aiPreprocessConfig'
 import type { ChartPayload, ChatEvidencePayload } from '@openchatlab/core'
 import { extractToolResultText, truncateToolResultText } from '@openchatlab/core'
-import { getDefaultGeneralAssistantId } from '@openchatlab/shared-types'
+import {
+  getDefaultGeneralAssistantId,
+  type AIEntityRef,
+  type CrossChatEvidencePayload,
+} from '@openchatlab/shared-types'
 import {
   createRenderOnlyToolPendingBlock,
   extractChartPayloads,
@@ -30,6 +34,7 @@ import {
   toRenderOnlyToolErrorBlock,
 } from './aiChatChartBlocks'
 import { extractEvidencePayload, toEvidenceContentBlock } from './aiChatEvidenceBlocks'
+import { extractCrossChatEvidencePayload, toCrossChatEvidenceContentBlock } from './aiChatCrossChatEvidenceBlocks'
 import {
   appendPlanDraftDelta,
   removePlanDraftBlocks,
@@ -90,6 +95,7 @@ export type ContentBlock =
   | { type: 'think'; tag: string; text: string; durationMs?: number }
   | { type: 'chart'; chart: ChartPayload }
   | { type: 'evidence'; evidence: ChatEvidencePayload }
+  | { type: 'cross_chat_evidence'; evidence: CrossChatEvidencePayload }
   | PlanContentBlock
   | PlanDraftContentBlock
   | {
@@ -122,6 +128,7 @@ export interface ChatMessage {
   isStreaming?: boolean
   /** Runtime wall-clock duration from request start until the final response begins. */
   processDurationMs?: number
+  entityRefs?: AIEntityRef[]
 }
 
 // 搜索结果消息类型（保留用于数据源面板）
@@ -149,6 +156,7 @@ interface AIChatBuffer {
 }
 
 export interface AIChatSessionState {
+  kind: 'session' | 'global'
   sessionId: string
   sessionName: string
   chatType: 'group' | 'private'
@@ -175,6 +183,7 @@ export interface AIChatSessionState {
 
 export interface AIBackgroundTask {
   requestId: string
+  kind: 'session' | 'global'
   chatKey: string
   sessionId: string
   sessionName: string
@@ -185,6 +194,7 @@ export interface AIBackgroundTask {
 }
 
 export interface EnsureAIChatSessionParams {
+  kind?: 'session' | 'global'
   sessionId: string
   sessionName: string
   chatType: 'group' | 'private'
@@ -206,10 +216,12 @@ function buildTimeFilterKey(timeFilter?: { startTs: number; endTs: number }): st
 }
 
 export function buildAIChatKey(params: {
+  kind?: 'session' | 'global'
   sessionId: string
   chatType: 'group' | 'private'
   timeFilter?: { startTs: number; endTs: number }
 }): string {
+  if (params.kind === 'global') return 'global'
   return `${params.sessionId}:${params.chatType}:${buildTimeFilterKey(params.timeFilter)}`
 }
 
@@ -260,6 +272,7 @@ function toRuntimeMessage(msg: PersistedAIMessage): ChatMessage {
     parentId: msg.parentId,
     contentBlocks,
     processDurationMs: getPersistedProcessDurationMs(contentBlocks),
+    entityRefs: msg.entityRefs,
   }
 }
 
@@ -276,6 +289,7 @@ function createAIChatBuffer(assistantId: string | null = null): AIChatBuffer {
 function createSessionState(params: EnsureAIChatSessionParams): AIChatSessionState {
   const draftBuffer = createAIChatBuffer(null)
   return {
+    kind: params.kind ?? 'session',
     sessionId: params.sessionId,
     sessionName: params.sessionName,
     chatType: params.chatType,
@@ -346,6 +360,16 @@ export const useAIChatStore = defineStore('aiChatRuntime', () => {
     return { chatKey, state: reactiveState }
   }
 
+  function ensureGlobalState(locale: string): { chatKey: string; state: AIChatSessionState } {
+    return ensureSessionState({
+      kind: 'global',
+      sessionId: '',
+      sessionName: 'Global AI analysis',
+      chatType: 'group',
+      locale,
+    })
+  }
+
   function getSessionState(chatKey: string): AIChatSessionState | null {
     return sessionStates.value[chatKey] ?? null
   }
@@ -413,7 +437,7 @@ export const useAIChatStore = defineStore('aiChatRuntime', () => {
 
   async function ensureOwnerInfo(chatKey: string): Promise<void> {
     const state = getSessionState(chatKey)
-    if (!state) return
+    if (!state || state.kind === 'global') return
 
     const session = sessionStore.sessions.find((item) => item.id === state.sessionId)
     const ownerId = session?.ownerId
@@ -459,6 +483,7 @@ export const useAIChatStore = defineStore('aiChatRuntime', () => {
 
     activeTask.value = {
       requestId,
+      kind: state.kind,
       chatKey,
       sessionId: state.sessionId,
       sessionName: state.sessionName,
@@ -528,7 +553,9 @@ export const useAIChatStore = defineStore('aiChatRuntime', () => {
 
     try {
       const conversation = await useAIService().getAIChat(aiChatId)
-      if (!conversation || conversation.sessionId !== state.sessionId) return false
+      const belongsToState =
+        conversation?.kind === state.kind && (state.kind === 'global' || conversation.sessionId === state.sessionId)
+      if (!conversation || !belongsToState) return false
 
       const buffer = getOrCreateBuffer(state, aiChatId, conversation.assistantId)
 
@@ -644,6 +671,7 @@ export const useAIChatStore = defineStore('aiChatRuntime', () => {
     appendThinkToBlocks: (text: string, tag?: string, durationMs?: number) => void
     appendChartsToBlocks: (charts: ChartPayload[]) => void
     appendEvidenceToBlocks: (evidence: ChatEvidencePayload) => void
+    appendCrossChatEvidenceToBlocks: (evidence: CrossChatEvidencePayload) => void
     appendPlanDraftToBlocks: (delta: string) => void
     appendPlanToBlocks: (plan: PlanContentBlock) => void
     removePlanDraftsFromBlocks: () => void
@@ -784,6 +812,14 @@ export const useAIChatStore = defineStore('aiChatRuntime', () => {
       updateAIMessage({ contentBlocks: [...blocks] })
     }
 
+    const appendCrossChatEvidenceToBlocks = (evidence: CrossChatEvidencePayload) => {
+      flushPendingText()
+      const idx = getAiMessageIndex()
+      const blocks = targetBuffer.messages[idx].contentBlocks || []
+      blocks.push(toCrossChatEvidenceContentBlock(evidence))
+      updateAIMessage({ contentBlocks: [...blocks] })
+    }
+
     const appendPlanDraftToBlocks = (delta: string) => {
       if (!delta) return
       flushPendingText()
@@ -909,6 +945,7 @@ export const useAIChatStore = defineStore('aiChatRuntime', () => {
       appendThinkToBlocks,
       appendChartsToBlocks,
       appendEvidenceToBlocks,
+      appendCrossChatEvidenceToBlocks,
       appendPlanDraftToBlocks,
       appendPlanToBlocks,
       removePlanDraftsFromBlocks,
@@ -928,7 +965,7 @@ export const useAIChatStore = defineStore('aiChatRuntime', () => {
   async function sendMessage(
     chatKey: string,
     content: string,
-    options?: { mentionedMembers?: MentionedMemberContext[] }
+    options?: { mentionedMembers?: MentionedMemberContext[]; entityRefs?: AIEntityRef[] }
   ): Promise<SendMessageResult> {
     const state = getSessionState(chatKey)
     if (!state) {
@@ -956,10 +993,10 @@ export const useAIChatStore = defineStore('aiChatRuntime', () => {
 
     setActiveTaskMeta(chatKey, content, thisRequestId, resolvedAIChatId)
     applySessionAssistantSelection(chatKey)
-    void ensureOwnerInfo(chatKey)
+    if (state.kind === 'session') void ensureOwnerInfo(chatKey)
 
-    const currentSkillId = skillStore.activeSkillId
-    const currentSkillName = skillStore.activeSkill?.name
+    const currentSkillId = state.kind === 'session' ? skillStore.activeSkillId : null
+    const currentSkillName = state.kind === 'session' ? skillStore.activeSkill?.name : null
     const autoSkillEnabled = aiGlobalSettings.value.enableAutoSkill ?? true
     const chartAutoMode = autoSkillEnabled ? (aiGlobalSettings.value.chartAutoMode ?? 'suggest') : 'explicit'
     const currentMentionedMembers = (options?.mentionedMembers ?? []).map((member) => ({
@@ -969,6 +1006,7 @@ export const useAIChatStore = defineStore('aiChatRuntime', () => {
       aliases: [...member.aliases],
       mentionText: member.mentionText,
     }))
+    const currentEntityRefs = (options?.entityRefs ?? []).map((ref) => ({ ...ref }))
 
     state.isAIThinking = true
     state.isLoadingSource = true
@@ -1008,6 +1046,7 @@ export const useAIChatStore = defineStore('aiChatRuntime', () => {
         content,
         timestamp: Date.now(),
         toolCalls: [],
+        entityRefs: currentEntityRefs,
       }
       currentUserMessage = userMessage
       targetBuffer.messages.push(userMessage)
@@ -1038,6 +1077,7 @@ export const useAIChatStore = defineStore('aiChatRuntime', () => {
         appendThinkToBlocks,
         appendChartsToBlocks,
         appendEvidenceToBlocks,
+        appendCrossChatEvidenceToBlocks,
         appendPlanDraftToBlocks,
         appendPlanToBlocks,
         removePlanDraftsFromBlocks,
@@ -1056,7 +1096,10 @@ export const useAIChatStore = defineStore('aiChatRuntime', () => {
       const currentAssistantId = targetBuffer.assistantId ?? getDefaultGeneralAssistantId(state.locale)
       if (!resolvedAIChatId) {
         const title = content.slice(0, 50) + (content.length > 50 ? '...' : '')
-        const conversation = await useAIService().createAIChat(state.sessionId, title, currentAssistantId)
+        const conversation =
+          state.kind === 'global'
+            ? await useAIService().createGlobalAIChat(title, currentAssistantId)
+            : await useAIService().createAIChat(state.sessionId, title, currentAssistantId)
         if (state.isAborted) {
           settleProcessDuration()
           updateAIMessage({ isStreaming: false })
@@ -1094,19 +1137,21 @@ export const useAIChatStore = defineStore('aiChatRuntime', () => {
       const { requestId: agentReqId, promise: agentPromise } = useAgentStreamService().runStream(
         {
           userMessage: content,
-          sessionId: state.sessionId,
+          chatKind: state.kind,
+          sessionId: state.kind === 'session' ? state.sessionId : undefined,
+          entityRefs: state.kind === 'global' && currentEntityRefs.length > 0 ? currentEntityRefs : undefined,
           aiChatId: resolvedAIChatId,
           timeFilter: context.timeFilter,
           maxMessagesLimit: context.maxMessagesLimit,
-          ownerInfo: context.ownerInfo,
-          mentionedMembers: context.mentionedMembers,
+          ownerInfo: state.kind === 'session' ? context.ownerInfo : undefined,
+          mentionedMembers: state.kind === 'session' ? context.mentionedMembers : undefined,
           preprocessConfig: context.preprocessConfig,
           chatType: state.chatType,
           locale: state.locale,
           assistantId: currentAssistantId,
-          skillId: currentSkillId,
-          enableAutoSkill: !currentSkillId ? autoSkillEnabled : undefined,
-          chartAutoMode: !currentSkillId ? chartAutoMode : undefined,
+          skillId: state.kind === 'session' ? currentSkillId : undefined,
+          enableAutoSkill: state.kind === 'session' && !currentSkillId ? autoSkillEnabled : undefined,
+          chartAutoMode: state.kind === 'session' && !currentSkillId ? chartAutoMode : undefined,
           thinkingLevel: (() => {
             const cfg = llmStore.defaultAssistant
             if (!cfg?.configId || !cfg?.modelId) return undefined
@@ -1173,6 +1218,10 @@ export const useAIChatStore = defineStore('aiChatRuntime', () => {
                 const evidence = extractEvidencePayload(chunk.toolResult)
                 if (evidence) {
                   appendEvidenceToBlocks(evidence)
+                }
+                const crossChatEvidence = extractCrossChatEvidencePayload(chunk.toolResult)
+                if (crossChatEvidence) {
+                  appendCrossChatEvidenceToBlocks(crossChatEvidence)
                 }
                 if (renderOnlyError) {
                   if (!isRenderOnlyTool(chunk.toolName)) {
@@ -1426,7 +1475,16 @@ export const useAIChatStore = defineStore('aiChatRuntime', () => {
         return null
       }
 
-      const savedUserMessage = await useAIService().addMessage(aiChatId, 'user', userMsg.content)
+      const savedUserMessage = await useAIService().addMessage(
+        aiChatId,
+        'user',
+        userMsg.content,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        userMsg.entityRefs
+      )
       const serializableContentBlocks = toSerializableContentBlocks(aiMsg.contentBlocks)
       const savedAssistantMessage = await useAIService().addMessage(
         aiChatId,
@@ -2014,6 +2072,7 @@ export const useAIChatStore = defineStore('aiChatRuntime', () => {
     sessionStates,
     activeTask,
     ensureSessionState,
+    ensureGlobalState,
     getSessionState,
     getActiveTaskState,
     applySessionAssistantSelection,

--- a/src/stores/aiChat.ts
+++ b/src/stores/aiChat.ts
@@ -333,7 +333,7 @@ export const useAIChatStore = defineStore('aiChatRuntime', () => {
   const llmStore = useLLMStore()
   const { aiGlobalSettings } = storeToRefs(promptStore)
 
-  let pendingFocusReturn = false
+  let pendingFocusReturnChatKey: string | null = null
 
   function generateId(prefix: string): string {
     return `${prefix}_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`
@@ -597,18 +597,22 @@ export const useAIChatStore = defineStore('aiChatRuntime', () => {
 
   function focusActiveTaskAIChat(): boolean {
     if (!activeTask.value) return false
-    pendingFocusReturn = true
-    return focusAIChat(activeTask.value.chatKey, activeTask.value.aiChatId)
+
+    const task = activeTask.value
+    const focused = focusAIChat(task.chatKey, task.aiChatId)
+    pendingFocusReturnChatKey = focused && task.kind === 'session' ? task.chatKey : null
+    return focused
   }
 
   /**
    * 每次 ChatExplorer 挂载时调用。
    * 如果存在有效的记忆助手则直接进入对应助手，否则回到助手选择页。
-   * 从浮动任务条返回（pendingFocusReturn）时跳过重置以保留对话状态。
+   * 从浮动任务条返回当前会话时跳过重置，以保留正在运行的对话状态。
    */
   async function resetToSelectorOnEnter(chatKey: string, preferredAIChatId?: string | null): Promise<void> {
-    if (pendingFocusReturn) {
-      pendingFocusReturn = false
+    const shouldPreserveFocusedTask = pendingFocusReturnChatKey === chatKey
+    pendingFocusReturnChatKey = null
+    if (shouldPreserveFocusedTask) {
       return
     }
     const state = getSessionState(chatKey)

--- a/src/stores/aiChat.ts
+++ b/src/stores/aiChat.ts
@@ -334,6 +334,17 @@ export const useAIChatStore = defineStore('aiChatRuntime', () => {
   const { aiGlobalSettings } = storeToRefs(promptStore)
 
   let pendingFocusReturnChatKey: string | null = null
+  const aiChatSelectionGenerations = new Map<string, number>()
+
+  function advanceAIChatSelection(chatKey: string): number {
+    const generation = (aiChatSelectionGenerations.get(chatKey) ?? 0) + 1
+    aiChatSelectionGenerations.set(chatKey, generation)
+    return generation
+  }
+
+  function isLatestAIChatSelection(chatKey: string, generation: number): boolean {
+    return aiChatSelectionGenerations.get(chatKey) === generation
+  }
 
   function generateId(prefix: string): string {
     return `${prefix}_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`
@@ -550,9 +561,12 @@ export const useAIChatStore = defineStore('aiChatRuntime', () => {
   async function loadAIChat(chatKey: string, aiChatId: string): Promise<boolean> {
     const state = getSessionState(chatKey)
     if (!state) return false
+    const selectionGeneration = advanceAIChatSelection(chatKey)
 
     try {
       const conversation = await useAIService().getAIChat(aiChatId)
+      if (!isLatestAIChatSelection(chatKey, selectionGeneration)) return false
+
       const belongsToState =
         conversation?.kind === state.kind && (state.kind === 'global' || conversation.sessionId === state.sessionId)
       if (!conversation || !belongsToState) return false
@@ -564,6 +578,8 @@ export const useAIChatStore = defineStore('aiChatRuntime', () => {
           useAIService().getMessages(aiChatId),
           useAIService().getAIChatTokenUsage(aiChatId),
         ])
+        if (!isLatestAIChatSelection(chatKey, selectionGeneration)) return false
+
         buffer.messages.splice(0, buffer.messages.length, ...history.map((msg) => toRuntimeMessage(msg)))
         buffer.sourceMessages.splice(0, buffer.sourceMessages.length)
         buffer.currentKeywords.splice(0, buffer.currentKeywords.length)
@@ -571,11 +587,13 @@ export const useAIChatStore = defineStore('aiChatRuntime', () => {
         buffer.loaded = true
       }
 
+      if (!isLatestAIChatSelection(chatKey, selectionGeneration)) return false
       buffer.assistantId = conversation.assistantId
       bindDisplayedBuffer(state, aiChatId)
       applySessionAssistantSelection(chatKey)
       return true
     } catch (error) {
+      if (!isLatestAIChatSelection(chatKey, selectionGeneration)) return false
       console.error('[AI] 加载对话历史失败：', error)
       return false
     }
@@ -590,6 +608,7 @@ export const useAIChatStore = defineStore('aiChatRuntime', () => {
       return false
     }
 
+    advanceAIChatSelection(chatKey)
     bindDisplayedBuffer(state, bufferKey)
     applySessionAssistantSelection(chatKey)
     return true
@@ -637,6 +656,7 @@ export const useAIChatStore = defineStore('aiChatRuntime', () => {
     const state = getSessionState(chatKey)
     if (!state || state.isAIThinking) return false
 
+    advanceAIChatSelection(chatKey)
     const draftBuffer = createAIChatBuffer(state.selectedAssistantId)
     state.aiChatBuffers[DRAFT_AI_CHAT_KEY] = draftBuffer
     bindDisplayedBuffer(state, DRAFT_AI_CHAT_KEY)

--- a/src/stores/aiChatCrossChatEvidenceBlocks.test.ts
+++ b/src/stores/aiChatCrossChatEvidenceBlocks.test.ts
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { ChatType, type CrossChatEvidencePayload } from '@openchatlab/shared-types'
+import { extractCrossChatEvidencePayload, toCrossChatEvidenceContentBlock } from './aiChatCrossChatEvidenceBlocks'
+
+const evidence: CrossChatEvidencePayload = {
+  version: 1 as const,
+  query: 'project',
+  sources: [
+    {
+      sessionId: 'session-a',
+      sessionName: 'Project group',
+      sessionType: ChatType.GROUP,
+      platform: 'qq',
+      messageId: 42,
+      senderName: 'Alice',
+      timestamp: 1_700_000_000,
+      snippet: 'project update',
+    },
+  ],
+  coverage: {
+    candidateSessions: 2,
+    scannedSessions: 1,
+    matchedSessions: 1,
+    failedSessions: 0,
+    truncated: true,
+    truncatedReasons: ['session_budget' as const],
+  },
+}
+
+test('extracts cross-chat evidence from a tool result and keeps compound source identity', () => {
+  const extracted = extractCrossChatEvidencePayload({ data: { crossChatEvidence: evidence } })
+
+  assert.deepEqual(extracted, evidence)
+  assert.equal(extracted?.sources[0]?.sessionId, 'session-a')
+  assert.equal(extracted?.sources[0]?.messageId, 42)
+  assert.deepEqual(toCrossChatEvidenceContentBlock(evidence), {
+    type: 'cross_chat_evidence',
+    evidence,
+  })
+})
+
+test('extracts cross-chat evidence from agent adapter details', () => {
+  assert.deepEqual(extractCrossChatEvidencePayload({ details: { crossChatEvidence: evidence } }), evidence)
+})
+
+test('rejects unrelated or malformed tool results', () => {
+  assert.equal(extractCrossChatEvidencePayload(null), null)
+  assert.equal(extractCrossChatEvidencePayload({ data: {} }), null)
+  assert.equal(extractCrossChatEvidencePayload({ data: { crossChatEvidence: { version: 1, query: 'x' } } }), null)
+})

--- a/src/stores/aiChatCrossChatEvidenceBlocks.ts
+++ b/src/stores/aiChatCrossChatEvidenceBlocks.ts
@@ -1,0 +1,28 @@
+import type { CrossChatEvidencePayload } from '@openchatlab/shared-types'
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function isCrossChatEvidencePayload(value: unknown): value is CrossChatEvidencePayload {
+  if (!isRecord(value)) return false
+  return (
+    value.version === 1 && typeof value.query === 'string' && Array.isArray(value.sources) && isRecord(value.coverage)
+  )
+}
+
+export function extractCrossChatEvidencePayload(result: unknown): CrossChatEvidencePayload | null {
+  if (!isRecord(result)) return null
+
+  const details = isRecord(result.details) ? result.details : null
+  if (details && isCrossChatEvidencePayload(details.crossChatEvidence)) return details.crossChatEvidence
+
+  const data = isRecord(result.data) ? result.data : null
+  if (data && isCrossChatEvidencePayload(data.crossChatEvidence)) return data.crossChatEvidence
+
+  return isCrossChatEvidencePayload(result.crossChatEvidence) ? result.crossChatEvidence : null
+}
+
+export function toCrossChatEvidenceContentBlock(evidence: CrossChatEvidencePayload) {
+  return { type: 'cross_chat_evidence' as const, evidence }
+}

--- a/src/stores/aiChatNavigation.test.ts
+++ b/src/stores/aiChatNavigation.test.ts
@@ -3,7 +3,7 @@ import test from 'node:test'
 import { createPinia, setActivePinia } from 'pinia'
 import { ref } from 'vue'
 
-test('restores the requested AI chat only when it belongs to the current session', async (t) => {
+test('restores requested AI chats without leaking global task navigation state', async (t) => {
   const aiService = {
     getAIChat: async (id: string) =>
       id === 'chat-one'
@@ -92,4 +92,24 @@ test('restores the requested AI chat only when it belongs to the current session
 
   assert.equal(second.state.currentAIChatId, null)
   assert.equal(second.state.messages.length, 0)
+
+  const global = store.ensureGlobalState('zh-CN')
+  store.activeTask = {
+    requestId: 'global-request',
+    kind: 'global',
+    chatKey: global.chatKey,
+    sessionId: '',
+    sessionName: 'Global AI analysis',
+    chatType: 'group',
+    aiChatId: null,
+    questionPreview: 'Global question',
+    startedAt: 1,
+  }
+
+  assert.equal(store.focusActiveTaskAIChat(), true)
+  assert.equal(store.startNewAIChat(first.chatKey), true)
+  await store.resetToSelectorOnEnter(first.chatKey, 'chat-one')
+
+  assert.equal(first.state.currentAIChatId, 'chat-one')
+  assert.equal(first.state.messages[0]?.content, 'Saved answer')
 })

--- a/src/stores/aiChatNavigation.test.ts
+++ b/src/stores/aiChatNavigation.test.ts
@@ -10,6 +10,7 @@ test('restores the requested AI chat only when it belongs to the current session
         ? {
             id,
             sessionId: 'session-one',
+            kind: 'session' as const,
             title: 'Saved chat',
             assistantId: 'assistant-one',
             createdAt: 1,

--- a/src/stores/aiChatNavigation.test.ts
+++ b/src/stores/aiChatNavigation.test.ts
@@ -3,26 +3,31 @@ import test from 'node:test'
 import { createPinia, setActivePinia } from 'pinia'
 import { ref } from 'vue'
 
-test('restores requested AI chats without leaking global task navigation state', async (t) => {
+test('restores only the latest requested AI chat without leaking navigation state', async (t) => {
+  const makeConversation = (id: string) => ({
+    id,
+    sessionId: 'session-one',
+    kind: 'session' as const,
+    title: 'Saved chat',
+    assistantId: 'assistant-one',
+    createdAt: 1,
+    updatedAt: 1,
+  })
+  let resolveSlowConversation!: (conversation: ReturnType<typeof makeConversation>) => void
+  const slowConversation = new Promise<ReturnType<typeof makeConversation>>((resolve) => {
+    resolveSlowConversation = resolve
+  })
   const aiService = {
-    getAIChat: async (id: string) =>
-      id === 'chat-one'
-        ? {
-            id,
-            sessionId: 'session-one',
-            kind: 'session' as const,
-            title: 'Saved chat',
-            assistantId: 'assistant-one',
-            createdAt: 1,
-            updatedAt: 1,
-          }
-        : null,
-    getMessages: async () => [
+    getAIChat: async (id: string) => {
+      if (id === 'chat-slow') return slowConversation
+      return id === 'chat-one' || id === 'chat-latest' ? makeConversation(id) : null
+    },
+    getMessages: async (aiChatId: string) => [
       {
-        id: 'message-one',
-        aiChatId: 'chat-one',
+        id: `message-${aiChatId}`,
+        aiChatId,
         role: 'assistant' as const,
-        content: 'Saved answer',
+        content: `Saved answer for ${aiChatId}`,
         timestamp: 1,
       },
     ],
@@ -80,7 +85,7 @@ test('restores requested AI chats without leaking global task navigation state',
   await store.resetToSelectorOnEnter(first.chatKey, 'chat-one')
 
   assert.equal(first.state.currentAIChatId, 'chat-one')
-  assert.equal(first.state.messages[0]?.content, 'Saved answer')
+  assert.equal(first.state.messages[0]?.content, 'Saved answer for chat-one')
 
   const second = store.ensureSessionState({
     sessionId: 'session-two',
@@ -92,6 +97,14 @@ test('restores requested AI chats without leaking global task navigation state',
 
   assert.equal(second.state.currentAIChatId, null)
   assert.equal(second.state.messages.length, 0)
+
+  const staleLoad = store.loadAIChat(first.chatKey, 'chat-slow')
+  assert.equal(await store.loadAIChat(first.chatKey, 'chat-latest'), true)
+  resolveSlowConversation(makeConversation('chat-slow'))
+
+  assert.equal(await staleLoad, false)
+  assert.equal(first.state.currentAIChatId, 'chat-latest')
+  assert.equal(first.state.messages[0]?.content, 'Saved answer for chat-latest')
 
   const global = store.ensureGlobalState('zh-CN')
   store.activeTask = {
@@ -111,5 +124,5 @@ test('restores requested AI chats without leaking global task navigation state',
   await store.resetToSelectorOnEnter(first.chatKey, 'chat-one')
 
   assert.equal(first.state.currentAIChatId, 'chat-one')
-  assert.equal(first.state.messages[0]?.content, 'Saved answer')
+  assert.equal(first.state.messages[0]?.content, 'Saved answer for chat-one')
 })

--- a/vite.cli-web.config.mts
+++ b/vite.cli-web.config.mts
@@ -43,10 +43,14 @@ function isPortInUse(port: number): Promise<boolean> {
 
 async function isChatlabBackendResponsive(port: number, timeoutMs = 800): Promise<boolean> {
   try {
-    const response = await fetch(`http://127.0.0.1:${port}/_web/sessions`, {
-      signal: AbortSignal.timeout(timeoutMs),
-    })
-    return response.status === 200 || response.status === 401 || response.status === 403
+    const responses = await Promise.all(
+      ['/_web/sessions', '/_web/ai/global-chats'].map((path) =>
+        fetch(`http://127.0.0.1:${port}${path}`, {
+          signal: AbortSignal.timeout(timeoutMs),
+        })
+      )
+    )
+    return responses.every((response) => [200, 401, 403].includes(response.status))
   } catch {
     return false
   }
@@ -106,7 +110,7 @@ function chatlabServePlugin(): Plugin {
           return
         }
         throw new Error(
-          `[clb web] Port ${BACKEND_PORT} is in use, but ChatLab API did not respond. Stop the stale process and restart dev:cli-web.`
+          `[clb web] Port ${BACKEND_PORT} is in use, but the ChatLab API is stale or incomplete. Stop the stale process and restart dev:cli-web.`
         )
       }
 
@@ -133,11 +137,9 @@ function chatlabServePlugin(): Plugin {
         unregisterProcessCleanup()
       })
       registerProcessCleanup()
-      server.httpServer?.once('close', stopServerProcess)
     },
-    buildEnd() {
-      stopServerProcess()
-    },
+    // Vite closes and rebuilds its HTTP server during config hot reloads.
+    // Cleanup stays bound to the Vite process lifecycle so a reload cannot stop the CLI backend.
   }
 }
 


### PR DESCRIPTION
## 变更内容

- 新增一级全局 AI 工作区、独立全局对话列表和页面路由。
- 支持联系人/群聊稳定引用、历史对话恢复及跨会话证据展示。
- 跨会话证据可以通过 `sessionId + messageId` 打开聊天记录抽屉并定位原消息。
- 入口只在 Desktop 与 CLI Web 的 backend 模式展示，Web WASM 不暴露该能力。

## 本 PR 边界

本 PR 只接入已有跨对话 Agent，不新增检索算法或关系判断逻辑。输入框和导航的进一步统一由后续独立 PR 完成。

## Review 重点

- 全局与单会话 AI 状态是否隔离。
- 跨会话证据来源、截断状态和回跳定位是否正确。
- Desktop、CLI Web 与 Web WASM 的入口边界是否成立。

## 验证

- Web、Node、Desktop 类型检查通过。
- 完整重组分支测试：2179/2179 通过。

依赖上一层独立跨对话 Agent PR。
