### PR TITLE
fix(ai): isolate credentials for colliding config names / 隔离同名配置凭据

### DIFF
--- a/packages/node-runtime/src/ai/auth-profile-llm-config-store.test.ts
+++ b/packages/node-runtime/src/ai/auth-profile-llm-config-store.test.ts
@@ -17,6 +17,7 @@ test('createAuthProfileLlmConfigStore shares auth-profile creation, resolution, 
   const profiles = new Map<string, string>()
   const deleted: string[] = []
   const store = createAuthProfileLlmConfigStore(storage, {
+    loadAuthProfiles: () => ({ version: 1, profiles: {} }),
     resolveApiKey: (_provider, profileName) => (profileName ? profiles.get(profileName) : undefined),
     writeAuthProfile: (name, profile) => profiles.set(name, profile.type === 'api_key' ? profile.key : ''),
     deleteAuthProfile: (name) => {
@@ -33,12 +34,44 @@ test('createAuthProfileLlmConfigStore shares auth-profile creation, resolution, 
   })
 
   assert.equal(added.success, true)
-  assert.equal(profiles.get('team-openai'), 'secret-key')
   const persisted = storage.data.get('llm-config') as { configs: Array<Record<string, unknown>> }
+  const profileName = String(persisted.configs[0].authProfile)
+  assert.equal(profiles.get(profileName), 'secret-key')
   assert.equal(persisted.configs[0].apiKey, '')
-  assert.equal(persisted.configs[0].authProfile, 'team-openai')
   assert.equal(store.getAllConfigs()[0].apiKey, 'secret-key')
 
   assert.equal(store.deleteConfig(added.config!.id).success, true)
-  assert.deepEqual(deleted, ['team-openai'])
+  assert.deepEqual(deleted, [profileName])
+})
+
+test('createAuthProfileLlmConfigStore keeps API keys isolated when config names collide', () => {
+  const storage = createMemoryStorage()
+  const profiles = new Map<string, { type: 'api_key'; provider: string; key: string }>()
+  const ids = ['config-a', 'config-b']
+  const store = createAuthProfileLlmConfigStore(storage, {
+    generateId: () => ids.shift()!,
+    loadAuthProfiles: () => ({ version: 1, profiles: Object.fromEntries(profiles) }),
+    resolveApiKey: (_provider, profileName) => (profileName ? profiles.get(profileName)?.key : undefined),
+    writeAuthProfile: (name, profile) => profiles.set(name, profile),
+  })
+
+  const first = store.addConfig({
+    name: 'Same Name',
+    provider: 'openai-compatible',
+    apiKey: 'KEY_A',
+    model: 'model-a',
+  })
+  const second = store.addConfig({
+    name: 'Same Name',
+    provider: 'openai-compatible',
+    apiKey: 'KEY_B',
+    model: 'model-b',
+  })
+
+  assert.equal(first.success, true)
+  assert.equal(second.success, true)
+  assert.deepEqual(
+    store.getAllConfigs().map((config) => config.apiKey),
+    ['KEY_A', 'KEY_B']
+  )
 })

--- a/packages/node-runtime/src/ai/auth-profile-llm-config-store.ts
+++ b/packages/node-runtime/src/ai/auth-profile-llm-config-store.ts
@@ -31,6 +31,10 @@ function getNamedAuthProfile(config: Pick<AIServiceConfig, 'name' | 'provider'>)
   return config.name?.toLowerCase().replace(/\s+/g, '-') || config.provider
 }
 
+function getConfigAuthProfile(config: AIServiceConfig): string {
+  return `${getNamedAuthProfile(config)}-${config.id}`
+}
+
 function restoreLegacyAuthProfileReferences(configs: AIServiceConfig[], authProfiles: AuthProfilesData): void {
   const usedProfiles = new Set(configs.map(getAuthProfile).filter((name): name is string => Boolean(name)))
 
@@ -71,7 +75,7 @@ export function createAuthProfileLlmConfigStore(
     },
     resolveApiKey: resolvedDeps.resolveApiKey,
     onApiKeyCreated: (config, apiKey) => {
-      const profileName = getNamedAuthProfile(config)
+      const profileName = getConfigAuthProfile(config)
       resolvedDeps.writeAuthProfile(profileName, { type: 'api_key', provider: config.provider, key: apiKey })
       return profileName
     },

--- a/packages/node-runtime/src/ai/llm-runtime-stores.test.ts
+++ b/packages/node-runtime/src/ai/llm-runtime-stores.test.ts
@@ -133,10 +133,11 @@ test('createLlmRuntimeStores shares configs and catalogs without persisting API 
   const persisted = storage.readJson<{ configs: Array<Record<string, unknown>> }>('llm-config')
   const persistedSecondConfig = persisted?.configs.find((config) => config.id === 'second-config')
   assert.equal(persistedSecondConfig?.apiKey, '')
-  assert.equal(persistedSecondConfig?.authProfile, 'second-openai')
+  const secondProfile = String(persistedSecondConfig?.authProfile)
+  assert.equal(profiles.get(secondProfile)?.key, 'new-secret')
 
   assert.equal(secondRuntime.llmConfigStore.deleteConfig('second-config').success, true)
-  assert.deepEqual(deletedProfiles, ['second-openai'])
+  assert.deepEqual(deletedProfiles, [secondProfile])
   assert.equal(firstRuntime.llmConfigStore.getConfigById('second-config'), null)
 })
 


### PR DESCRIPTION
## Summary / 摘要

- Scope each new LLM auth profile by stable config ID so configs with the same display name cannot overwrite each other's API keys.
- 使用稳定 config ID 隔离新建 LLM 配置的 auth profile，避免同名配置互相覆盖 API Key。
- Preserve existing profile references and legacy profile restoration.
- 保留已有 profile 引用和旧配置恢复行为。

## Reproduction / 复现

Before / 修复前: `Same Name + KEY_A`, then `Same Name + KEY_B` resolved as `KEY_B / KEY_B`.

After / 修复后: the two configs resolve independently as `KEY_A / KEY_B`.

## Verification / 验证

- 31 related tests passed / 31 项相关测试通过
- Local OpenAI-compatible fake endpoint observed `FAKE_KEY_A`, then `FAKE_KEY_B`
- `pnpm run type-check:node`
- ESLint, Prettier, and `git diff --check`