### PR TITLE
fix(ai): preserve stream errors through completion

### DIFF
--- a/src/components/AIChat/ChatExplorer.vue
+++ b/src/components/AIChat/ChatExplorer.vue
@@ -363,6 +363,7 @@ async function handleSend(payload: {
     onAccepted: payload.onAccepted,
   })
   if (!result.success) {
+    if (result.reason === 'error') conversationListRef.value?.refresh()
     if (result.reason === 'busy') {
       showRunningTaskToast()
     }

--- a/src/stores/aiChat.ts
+++ b/src/stores/aiChat.ts
@@ -1370,7 +1370,11 @@ export const useAIChatStore = defineStore('aiChatRuntime', () => {
                   cacheWriteTokens: state.sessionTokenUsage.cacheWriteTokens + chunk.usage.cacheWriteTokens,
                 }
               }
-              setAgentPhase(state, 'completed', chunk.usage ? { totalUsage: chunk.usage } : undefined)
+              setAgentPhase(
+                state,
+                hasStreamError ? 'error' : 'completed',
+                chunk.usage ? { totalUsage: chunk.usage } : undefined
+              )
               break
 
             case 'error':
@@ -1484,7 +1488,7 @@ export const useAIChatStore = defineStore('aiChatRuntime', () => {
         }
       }
 
-      return { success: true }
+      return result.success ? { success: true } : { success: false, reason: 'error' }
     } catch (error) {
       console.error('[AI] 处理失败：', error)
       state.agentStatus = null
@@ -1960,7 +1964,11 @@ export const useAIChatStore = defineStore('aiChatRuntime', () => {
               state.currentToolStatus = null
               if (!hasStreamError) updatePlanBlockStatus('done')
               if (chunk.usage) lastDoneUsage = { ...chunk.usage }
-              setAgentPhase(state, 'completed', chunk.usage ? { totalUsage: chunk.usage } : undefined)
+              setAgentPhase(
+                state,
+                hasStreamError ? 'error' : 'completed',
+                chunk.usage ? { totalUsage: chunk.usage } : undefined
+              )
               break
             case 'error': {
               settleProcessDuration()

--- a/src/stores/aiChatNavigation.test.ts
+++ b/src/stores/aiChatNavigation.test.ts
@@ -1,10 +1,15 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
+import type { AgentStreamChunk, AgentStreamResult } from '@/services/ai-stream/types'
 import { createPinia, setActivePinia } from 'pinia'
 import { ref } from 'vue'
 
 test('restores the latest valid AI chat without leaking stale navigation state', async (t) => {
   let hasLLMConfig = false
+  let agentStreamRun:
+    | ((onChunk?: (chunk: AgentStreamChunk) => void) => { requestId: string; promise: Promise<AgentStreamResult> })
+    | null = null
+  let savedMessageId = 0
   const makeConversation = (id: string, sessionId = 'session-one') => ({
     id,
     sessionId,
@@ -56,6 +61,24 @@ test('restores the latest valid AI chat without leaking stale navigation state',
     createAIChat: async () => {
       throw new Error('create failed')
     },
+    addMessage: async (
+      aiChatId: string,
+      role: 'user' | 'assistant',
+      content: string,
+      _dataKeywords?: string[],
+      _dataMessageCount?: number,
+      contentBlocks?: unknown,
+      _tokenUsage?: unknown,
+      entityRefs?: unknown
+    ) => ({
+      id: `saved-${++savedMessageId}`,
+      aiChatId,
+      role,
+      content,
+      timestamp: 1,
+      contentBlocks,
+      entityRefs,
+    }),
   }
   const assistantStore = {
     isLoaded: true,
@@ -69,7 +92,20 @@ test('restores the latest valid AI chat without leaking stale navigation state',
       namedExports: { useSessionStore: () => ({ sessions: [] }) },
     }),
     t.mock.module('@/stores/settings', {
-      namedExports: { useSettingsStore: () => ({ aiPreprocessConfig: {} }) },
+      namedExports: {
+        useSettingsStore: () => ({
+          aiPreprocessConfig: {
+            dataCleaning: false,
+            mergeConsecutive: false,
+            mergeWindowSeconds: 180,
+            blacklistKeywords: [],
+            denoise: false,
+            desensitize: false,
+            desensitizeRules: [],
+            anonymizeNames: false,
+          },
+        }),
+      },
     }),
     t.mock.module('@/stores/assistant', {
       namedExports: { useAssistantStore: () => assistantStore },
@@ -88,7 +124,14 @@ test('restores the latest valid AI chat without leaking stale navigation state',
       },
     }),
     t.mock.module('@/services/ai-stream/service', {
-      namedExports: { useAgentStreamService: () => ({}) },
+      namedExports: {
+        useAgentStreamService: () => ({
+          runStream: (_params: unknown, onChunk?: (chunk: AgentStreamChunk) => void) => {
+            if (!agentStreamRun) throw new Error('agent stream is not configured')
+            return agentStreamRun(onChunk)
+          },
+        }),
+      },
     }),
   ])
 
@@ -181,6 +224,35 @@ test('restores the latest valid AI chat without leaking stale navigation state',
   assert.equal(
     fifth.state.messages.some((message) => message.role === 'user' && message.content === 'Accepted draft'),
     true
+  )
+
+  const streamError = { name: 'ProviderError', message: 'provider unavailable', stack: null }
+  agentStreamRun = (onChunk) => {
+    onChunk?.({ type: 'error', error: streamError })
+    onChunk?.({
+      type: 'done',
+      isFinished: true,
+      usage: { promptTokens: 1, completionTokens: 2, totalTokens: 3, cacheReadTokens: 0, cacheWriteTokens: 0 },
+    })
+    return {
+      requestId: 'stream-error',
+      promise: Promise.resolve({ success: false, error: streamError }),
+    }
+  }
+  const streamFailureResult = await store.sendMessage(first.chatKey, 'Trigger provider failure')
+  const failedAssistant = first.state.messages.findLast((message) => message.role === 'assistant')
+
+  assert.deepEqual(
+    {
+      result: streamFailureResult,
+      phase: first.state.agentStatus?.phase,
+      errorBlocks: failedAssistant?.contentBlocks?.filter((block) => block.type === 'error').length,
+    },
+    {
+      result: { success: false, reason: 'error' },
+      phase: 'error',
+      errorBlocks: 1,
+    }
   )
 
   const global = store.ensureGlobalState('zh-CN')


### PR DESCRIPTION
## Summary / 摘要

- Keep the agent phase in `error` when the terminal `done` frame follows an error.
- Map a failed `AgentStreamResult` to `{ success: false, reason: 'error' }` after preserving the partial response.
- Preserve terminal usage, duration settlement, tool cleanup, and successful/aborted behavior.
- 保持错误流的终态与失败返回，同时保留 partial response、usage 和现有清理语义。

## Why / 原因

The shared SSE route intentionally uses `done` as a transport terminator, including after an `error` frame. The store treated every `done` as business success and also returned success after the service had resolved with `success:false`, hiding real provider failures from the UI and callers.

共享 SSE 的 `done` 是传输终止标记，并不代表错误流恢复成功；store 原先会把 `error → done` 覆盖为 completed，并误报发送成功。

## Verification / 验证

- Regression failed before with `{ success:true, phase:'completed' }` and passes after with `{ success:false, reason:'error', phase:'error' }`
- All `src/stores` tests: 50/50 passed
- `pnpm run type-check:node`
- Targeted ESLint and Prettier
- `git diff --check`
- Two independent store/service probes verified error, success, abort, partial content, and usage behavior before and after

`type-check:web` was attempted; its only failure is an existing `MockModuleOptions` error in the unchanged `memory-optional-jieba.test.ts` on the current base.