### PR TITLE
fix(ai): harden Pi agent loop contracts

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -48,8 +48,8 @@
   "dependencies": {
     "@fastify/multipart": "^10.0.0",
     "@fastify/static": "^9.1.3",
-    "@earendil-works/pi-agent-core": "0.83.0",
-    "@earendil-works/pi-ai": "0.83.0",
+    "@earendil-works/pi-agent-core": "0.84.2",
+    "@earendil-works/pi-ai": "0.84.2",
     "@modelcontextprotocol/sdk": "^1.12.1",
     "better-sqlite3": "^12.4.6",
     "commander": "^13.1.0",

--- a/packages/node-runtime/package.json
+++ b/packages/node-runtime/package.json
@@ -15,8 +15,8 @@
     "./src/*": "./src/*.ts"
   },
   "dependencies": {
-    "@earendil-works/pi-agent-core": "0.83.0",
-    "@earendil-works/pi-ai": "0.83.0",
+    "@earendil-works/pi-agent-core": "0.84.2",
+    "@earendil-works/pi-ai": "0.84.2",
     "@huggingface/transformers": "^4.2.0",
     "@openchatlab/config": "workspace:*",
     "@openchatlab/core": "workspace:*",

--- a/packages/node-runtime/src/ai/agent/__tests__/core.test.ts
+++ b/packages/node-runtime/src/ai/agent/__tests__/core.test.ts
@@ -309,13 +309,21 @@ describe('runAgentCore runtime contract', () => {
     assert.equal(result.toolRounds, 1)
     assert.deepEqual(finalContext?.tools, [])
     assert.equal(
-      finalContext?.messages.some(
+      finalContext?.messages.filter(
         (message) =>
           message.role === 'user' &&
           Array.isArray(message.content) &&
           message.content.some((block) => block.type === 'text' && block.text === 'Finish now.')
-      ),
-      true
+      ).length,
+      1
+    )
+    assert.equal(
+      result.finalMessages.filter(
+        (message) =>
+          message.role === 'assistant' &&
+          message.content.some((block) => block.type === 'text' && block.text === 'Done')
+      ).length,
+      1
     )
   })
 

--- a/packages/node-runtime/src/ai/agent/__tests__/core.test.ts
+++ b/packages/node-runtime/src/ai/agent/__tests__/core.test.ts
@@ -282,6 +282,38 @@ describe('runAgentCore runtime contract', () => {
     )
   })
 
+  it('preserves explicit error flags returned by tools', async () => {
+    const events: AgentCoreEvent[] = []
+    const tool = createTool('failed_lookup', async () => ({
+      content: [{ type: 'text', text: 'lookup failed' }],
+      details: null,
+      isError: true,
+    }))
+
+    const result = await runAgentCore(
+      createOptions({
+        tools: [tool],
+        streamFn: createScriptedStream([
+          assistantMessage([{ type: 'toolCall', id: 'failed-lookup', name: 'failed_lookup', arguments: {} }], {
+            stopReason: 'toolUse',
+          }),
+          assistantMessage([{ type: 'text', text: 'Recovered' }]),
+        ]),
+        onEvent: (event) => events.push(event),
+      })
+    )
+    const toolEnd = events.find((event) => event.type === 'tool_end')
+    const toolResult = result.finalMessages.find((message) => message.role === 'toolResult')
+
+    assert.deepEqual(
+      {
+        event: toolEnd?.type === 'tool_end' ? toolEnd.isError : undefined,
+        transcript: toolResult?.role === 'toolResult' ? toolResult.isError : undefined,
+      },
+      { event: true, transcript: true }
+    )
+  })
+
   it('disables tools and injects the final-answer steer message at the tool round limit', async () => {
     let finalContext: Context | undefined
     const tool = createTool('lookup', async () => ({

--- a/packages/node-runtime/src/ai/agent/__tests__/core.test.ts
+++ b/packages/node-runtime/src/ai/agent/__tests__/core.test.ts
@@ -359,6 +359,93 @@ describe('runAgentCore runtime contract', () => {
     )
   })
 
+  it('stops after one final-answer turn when the tool round limit is reached', async () => {
+    let providerCalls = 0
+    let handlerCalls = 0
+    const tool = createTool('lookup', async () => {
+      handlerCalls += 1
+      return { content: [{ type: 'text', text: 'tool result' }], details: null }
+    })
+    const toolCall = () =>
+      assistantMessage([{ type: 'toolCall', id: `tool-${providerCalls}`, name: 'lookup', arguments: {} }], {
+        stopReason: 'toolUse',
+      })
+
+    const result = await runAgentCore(
+      createOptions({
+        tools: [tool],
+        maxToolRounds: 1,
+        steerMessage: 'Finish now.',
+        streamFn: createScriptedStream([
+          () => {
+            providerCalls += 1
+            return toolCall()
+          },
+          (context) => {
+            providerCalls += 1
+            assert.deepEqual(context.tools, [])
+            return toolCall()
+          },
+          () => {
+            providerCalls += 1
+            return toolCall()
+          },
+          () => {
+            providerCalls += 1
+            return assistantMessage([{ type: 'text', text: 'Too late' }])
+          },
+        ]),
+      })
+    )
+
+    assert.deepEqual(
+      { providerCalls, handlerCalls, toolRounds: result.toolRounds },
+      { providerCalls: 2, handlerCalls: 1, toolRounds: 1 }
+    )
+  })
+
+  it('stops after the first turn when the tool round limit is zero', async () => {
+    let providerCalls = 0
+    let handlerCalls = 0
+    const tool = createTool('lookup', async () => {
+      handlerCalls += 1
+      return { content: [{ type: 'text', text: 'tool result' }], details: null }
+    })
+    const toolCall = () =>
+      assistantMessage([{ type: 'toolCall', id: `tool-${providerCalls}`, name: 'lookup', arguments: {} }], {
+        stopReason: 'toolUse',
+      })
+
+    const result = await runAgentCore(
+      createOptions({
+        tools: [tool],
+        maxToolRounds: 0,
+        streamFn: createScriptedStream([
+          (context) => {
+            providerCalls += 1
+            assert.deepEqual(context.tools, [])
+            return toolCall()
+          },
+          () => {
+            providerCalls += 1
+            return toolCall()
+          },
+        ]),
+      })
+    )
+
+    assert.deepEqual(
+      { providerCalls, handlerCalls, toolRounds: result.toolRounds },
+      { providerCalls: 1, handlerCalls: 0, toolRounds: 0 }
+    )
+    assert.deepEqual(
+      result.finalMessages.map((message) => message.role),
+      ['user', 'assistant', 'toolResult']
+    )
+    const finalMessage = result.finalMessages.at(-1)
+    assert.equal(finalMessage?.role === 'toolResult' && finalMessage.isError, true)
+  })
+
   it('forwards the stable AI conversation id as the provider session id', async () => {
     let capturedOptions: SimpleStreamOptions | undefined
 

--- a/packages/node-runtime/src/ai/agent/core.ts
+++ b/packages/node-runtime/src/ai/agent/core.ts
@@ -96,7 +96,8 @@ export async function runAgentCore(options: AgentCoreOptions): Promise<AgentCore
   })()
 
   const finalThinkingLevel = resolvedThinkingLevel ?? (piModel.reasoning ? undefined : 'off')
-  let hasReachedToolRoundLimit = false
+  let hasReachedToolRoundLimit = maxToolRounds <= 0
+  let hasCompletedFinalAnswerTurn = false
 
   // DeepSeek-format APIs require reasoning_content on assistant messages that
   // precede tool results; build replay options so toPiHistoryMessages includes
@@ -129,6 +130,7 @@ export async function runAgentCore(options: AgentCoreOptions): Promise<AgentCore
     },
     afterToolCall: async ({ result }) =>
       (result as { isError?: boolean }).isError === true ? { isError: true } : undefined,
+    shouldStopAfterTurn: async () => hasCompletedFinalAnswerTurn,
     prepareNextTurnWithContext: ({ context }) =>
       hasReachedToolRoundLimit
         ? {
@@ -219,9 +221,10 @@ export async function runAgentCore(options: AgentCoreOptions): Promise<AgentCore
       })
     } else if (event.type === 'turn_end') {
       const hadToolCalls = event.toolResults.length > 0
-      if (hadToolCalls) {
+      const isFinalAnswerTurn = hasReachedToolRoundLimit
+      if (hadToolCalls && !hasReachedToolRoundLimit) {
         toolRounds += 1
-        if (!hasReachedToolRoundLimit && maxToolRounds > 0 && toolRounds >= maxToolRounds) {
+        if (maxToolRounds > 0 && toolRounds >= maxToolRounds) {
           hasReachedToolRoundLimit = true
           coreAgent.state.tools = []
           coreAgent.steer({
@@ -231,6 +234,7 @@ export async function runAgentCore(options: AgentCoreOptions): Promise<AgentCore
           } as PiMessage)
         }
       }
+      if (isFinalAnswerTurn) hasCompletedFinalAnswerTurn = true
       onEvent({ type: 'turn_end', round: toolRounds, hadToolCalls })
     } else if (event.type === 'message_end') {
       if (event.message.role === 'assistant') {

--- a/packages/node-runtime/src/ai/agent/core.ts
+++ b/packages/node-runtime/src/ai/agent/core.ts
@@ -127,12 +127,11 @@ export async function runAgentCore(options: AgentCoreOptions): Promise<AgentCore
       onConvertToLlm?.(filtered)
       return filtered
     },
-    prepareNextTurn: () =>
+    prepareNextTurnWithContext: ({ context }) =>
       hasReachedToolRoundLimit
         ? {
             context: {
-              systemPrompt,
-              messages: coreAgent.state.messages,
+              ...context,
               tools: [],
             },
           }

--- a/packages/node-runtime/src/ai/agent/core.ts
+++ b/packages/node-runtime/src/ai/agent/core.ts
@@ -127,6 +127,8 @@ export async function runAgentCore(options: AgentCoreOptions): Promise<AgentCore
       onConvertToLlm?.(filtered)
       return filtered
     },
+    afterToolCall: async ({ result }) =>
+      (result as { isError?: boolean }).isError === true ? { isError: true } : undefined,
     prepareNextTurnWithContext: ({ context }) =>
       hasReachedToolRoundLimit
         ? {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,11 +136,11 @@ importers:
   apps/cli:
     dependencies:
       '@earendil-works/pi-agent-core':
-        specifier: 0.83.0
-        version: 0.83.0(@modelcontextprotocol/sdk@1.29.0(supports-color@7.2.0)(zod@3.25.76))(supports-color@7.2.0)(ws@8.19.0)(zod@3.25.76)
+        specifier: 0.84.2
+        version: 0.84.2(@modelcontextprotocol/sdk@1.29.0(supports-color@7.2.0)(zod@3.25.76))(supports-color@7.2.0)(ws@8.19.0)(zod@3.25.76)
       '@earendil-works/pi-ai':
-        specifier: 0.83.0
-        version: 0.83.0(@modelcontextprotocol/sdk@1.29.0(supports-color@7.2.0)(zod@3.25.76))(supports-color@7.2.0)(ws@8.19.0)(zod@3.25.76)
+        specifier: 0.84.2
+        version: 0.84.2(@modelcontextprotocol/sdk@1.29.0(supports-color@7.2.0)(zod@3.25.76))(supports-color@7.2.0)(ws@8.19.0)(zod@3.25.76)
       '@fastify/multipart':
         specifier: ^10.0.0
         version: 10.0.0
@@ -390,11 +390,11 @@ importers:
   packages/node-runtime:
     dependencies:
       '@earendil-works/pi-agent-core':
-        specifier: 0.83.0
-        version: 0.83.0(@modelcontextprotocol/sdk@1.29.0(supports-color@7.2.0)(zod@3.25.76))(supports-color@7.2.0)(ws@8.19.0)(zod@3.25.76)
+        specifier: 0.84.2
+        version: 0.84.2(@modelcontextprotocol/sdk@1.29.0(supports-color@7.2.0)(zod@3.25.76))(supports-color@7.2.0)(ws@8.19.0)(zod@3.25.76)
       '@earendil-works/pi-ai':
-        specifier: 0.83.0
-        version: 0.83.0(@modelcontextprotocol/sdk@1.29.0(supports-color@7.2.0)(zod@3.25.76))(supports-color@7.2.0)(ws@8.19.0)(zod@3.25.76)
+        specifier: 0.84.2
+        version: 0.84.2(@modelcontextprotocol/sdk@1.29.0(supports-color@7.2.0)(zod@3.25.76))(supports-color@7.2.0)(ws@8.19.0)(zod@3.25.76)
       '@huggingface/transformers':
         specifier: ^4.2.0
         version: 4.2.0
@@ -808,14 +808,18 @@ packages:
       search-insights:
         optional: true
 
-  '@earendil-works/pi-agent-core@0.83.0':
-    resolution: {integrity: sha512-RorGp9OH5l3ElpuC5a5ZQ2eWcchZGXflXRzVGkV99y3y6tT+LLNyxoYIdVKvTKWEObwhExeQbTH0fI2tE4iX4g==}
+  '@earendil-works/pi-agent-core@0.84.2':
+    resolution: {integrity: sha512-8Pn3wSCxj0cfo5I6jxQYVB/3uuQRmHhAlEclyjqpOuMEdQMIODHizRogv56FLdbU+dTiGnybeHQ2N+sV1/L2YA==}
     engines: {node: '>=22.19.0'}
 
-  '@earendil-works/pi-ai@0.83.0':
-    resolution: {integrity: sha512-m3IZD4g3er0V8TC9+Vpgw/sjTKqcJlkcIBy/JvsgRubuuik3tAVzyugUg4rVrShIkkOT69mEd34NEqKUIsl6JQ==}
+  '@earendil-works/pi-ai@0.84.2':
+    resolution: {integrity: sha512-6MzsrYIYNVlE7SfpbL2yYb67Qo58p/7Q+xWG1RZvoX1P80aRCHSod2/13aFpxkow1lPO2LEh3c495J0Gwmyjig==}
     engines: {node: '>=22.19.0'}
     hasBin: true
+
+  '@earendil-works/pi-telemetry@0.84.3':
+    resolution: {integrity: sha512-sgEkWoKrvSGaKn+YfLLFZmn+/A7B/w62eLwTD57nI+C9to8ITlFFVbgC2OtwvPnT3NFGHdCd53qhBEMIlptD1g==}
+    engines: {node: '>=22.19.0'}
 
   '@electron-toolkit/preload@3.0.2':
     resolution: {integrity: sha512-TWWPToXd8qPRfSXwzf5KVhpXMfONaUuRAZJHsKthKgZR/+LqX1dZVSSClQ8OTAEduvLGdecljCsoT2jSshfoUg==}
@@ -1825,14 +1829,6 @@ packages:
     resolution: {integrity: sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q==}
     engines: {node: '>= 10.0.0'}
 
-  '@mistralai/mistralai@2.2.6':
-    resolution: {integrity: sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==}
-    peerDependencies:
-      '@opentelemetry/api': ^1.9.0
-    peerDependenciesMeta:
-      '@opentelemetry/api':
-        optional: true
-
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
     engines: {node: '>=18'}
@@ -2446,10 +2442,6 @@ packages:
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
-
-  '@opentelemetry/semantic-conventions@1.43.0':
-    resolution: {integrity: sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==}
-    engines: {node: '>=14'}
 
   '@peculiar/asn1-schema@2.9.0':
     resolution: {integrity: sha512-AKvPMOM7LfK0uFe1m7o7+veOa8xQGPqsqOrKi3QKgCElzwjGp39mbhr2g7mt/v/mXQHiIvJmDj5cJS173x8Q9Q==}
@@ -5692,9 +5684,8 @@ packages:
   onnxruntime-web@1.26.0-dev.20260416-b7804b056c:
     resolution: {integrity: sha512-MD6Ss4GSpQBo6zqoJzyT9LRbKYs7x/JVN23FT24EcEvlqF4VuzPOeH6X38orZPKHQDbprn7K+SBpu0/mj2CQiw==}
 
-  openai@6.26.0:
-    resolution: {integrity: sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==}
-    hasBin: true
+  openai@6.40.0:
+    resolution: {integrity: sha512-MWtTjd/gQt4jpbji61NTgFWJLoY/PdRJ6wG9/ZDRMYNMlBKrCrSlkLI+KgHP1vR1qT6LKSAyAqIxno6lcK9JiA==}
     peerDependencies:
       ws: ^8.18.0
       zod: ^3.25 || ^4.0
@@ -7677,9 +7668,10 @@ snapshots:
     transitivePeerDependencies:
       - '@algolia/client-search'
 
-  '@earendil-works/pi-agent-core@0.83.0(@modelcontextprotocol/sdk@1.29.0(supports-color@7.2.0)(zod@3.25.76))(supports-color@7.2.0)(ws@8.19.0)(zod@3.25.76)':
+  '@earendil-works/pi-agent-core@0.84.2(@modelcontextprotocol/sdk@1.29.0(supports-color@7.2.0)(zod@3.25.76))(supports-color@7.2.0)(ws@8.19.0)(zod@3.25.76)':
     dependencies:
-      '@earendil-works/pi-ai': 0.83.0(@modelcontextprotocol/sdk@1.29.0(supports-color@7.2.0)(zod@3.25.76))(supports-color@7.2.0)(ws@8.19.0)(zod@3.25.76)
+      '@earendil-works/pi-ai': 0.84.2(@modelcontextprotocol/sdk@1.29.0(supports-color@7.2.0)(zod@3.25.76))(supports-color@7.2.0)(ws@8.19.0)(zod@3.25.76)
+      '@earendil-works/pi-telemetry': 0.84.3
       diff: 8.0.4
       ignore: 7.0.5
       typebox: 1.3.7
@@ -7692,17 +7684,17 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-ai@0.83.0(@modelcontextprotocol/sdk@1.29.0(supports-color@7.2.0)(zod@3.25.76))(supports-color@7.2.0)(ws@8.19.0)(zod@3.25.76)':
+  '@earendil-works/pi-ai@0.84.2(@modelcontextprotocol/sdk@1.29.0(supports-color@7.2.0)(zod@3.25.76))(supports-color@7.2.0)(ws@8.19.0)(zod@3.25.76)':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@3.25.76)
       '@aws-sdk/client-bedrock-runtime': 3.1048.0
+      '@earendil-works/pi-telemetry': 0.84.3
       '@google/genai': 1.52.0(@modelcontextprotocol/sdk@1.29.0(supports-color@7.2.0)(zod@3.25.76))(supports-color@7.2.0)
-      '@mistralai/mistralai': 2.2.6(@opentelemetry/api@1.9.0)
       '@opentelemetry/api': 1.9.0
       '@smithy/node-http-handler': 4.7.3
       http-proxy-agent: 7.0.2(supports-color@7.2.0)
       https-proxy-agent: 7.0.6(supports-color@7.2.0)
-      openai: 6.26.0(ws@8.19.0)(zod@3.25.76)
+      openai: 6.40.0(ws@8.19.0)(zod@3.25.76)
       partial-json: 0.1.7
       typebox: 1.3.7
     transitivePeerDependencies:
@@ -7712,6 +7704,8 @@ snapshots:
       - utf-8-validate
       - ws
       - zod
+
+  '@earendil-works/pi-telemetry@0.84.3': {}
 
   '@electron-toolkit/preload@3.0.2(electron@35.7.5(supports-color@7.2.0))':
     dependencies:
@@ -8532,18 +8526,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@mistralai/mistralai@2.2.6(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/semantic-conventions': 1.43.0
-      ws: 8.19.0
-      zod: 3.25.76
-      zod-to-json-schema: 3.25.1(zod@3.25.76)
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.0
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-
   '@modelcontextprotocol/sdk@1.29.0(supports-color@7.2.0)(zod@3.25.76)':
     dependencies:
       '@hono/node-server': 1.19.14(hono@4.12.18)
@@ -9220,8 +9202,6 @@ snapshots:
       '@octokit/openapi-types': 27.0.0
 
   '@opentelemetry/api@1.9.0': {}
-
-  '@opentelemetry/semantic-conventions@1.43.0': {}
 
   '@peculiar/asn1-schema@2.9.0':
     dependencies:
@@ -12563,7 +12543,7 @@ snapshots:
       platform: 1.3.6
       protobufjs: 7.5.4
 
-  openai@6.26.0(ws@8.19.0)(zod@3.25.76):
+  openai@6.40.0(ws@8.19.0)(zod@3.25.76):
     optionalDependencies:
       ws: 8.19.0
       zod: 3.25.76


### PR DESCRIPTION
## Summary

- preserve Pi's ownership of the active turn context so steer and final messages are not appended twice
- promote resolved tool `isError` flags through Pi's formal tool-result contract
- enforce `maxToolRounds` with exactly one final-answer turn, including the zero-round boundary
- pin `pi-agent-core` and `pi-ai` to 0.84.2 for the public `shouldStopAfterTurn` hook

中文摘要：修复 Agent 循环中的消息重复、工具错误被记为成功，以及工具轮次上限失效；每个问题保留为独立小提交。

## Reproduction and result

| Contract | Before | After |
| --- | --- | --- |
| active-turn ownership | steer/final messages appeared twice | each appears exactly once |
| resolved tool error | event and transcript both reported success | both preserve `isError: true` |
| `maxToolRounds: 1` | provider 4 / handler 1 / rounds 3 | provider 2 / handler 1 / rounds 1 |
| `maxToolRounds: 0` | requested another provider turn and rounds advanced | provider 1 / handler 0 / rounds 0 |

The regressions use a deterministic scripted provider. A separate opt-in smoke with Command Code, `deepseek/deepseek-v4-flash`, and `thinking=high` completed with provider 2 / handler 1 / rounds 1, one expected marker, and no core or tool error. No credentials are included.

## Checks

- Agent/runtime focused tests: 80 passed
- `tsc --noEmit -p tsconfig.node.json`
- `tsc --noEmit -p apps/desktop/tsconfig.node.json`
- ESLint on the changed TypeScript files
- Prettier on all changed files
- `git diff --check`

The repository-wide `pnpm test` could not complete in this Windows checkout because unrelated pre-existing native/built artifacts were unavailable; the affected runtime suites were run directly with `scripts/run-tests.mjs`.
