### PR TITLE
feat(analysis): use voice transcription text and keep system notifications out of text analysis

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -298,6 +298,7 @@ export {
   getStopwords,
   isStopword,
   cleanText,
+  isSystemMessageContent,
   isValidWord,
 } from './nlp'
 export type {

--- a/packages/core/src/nlp/index.ts
+++ b/packages/core/src/nlp/index.ts
@@ -24,4 +24,10 @@ export { POS_TAG_DEFINITIONS, MEANINGFUL_POS_TAGS } from './pos-tags'
 
 export { CHINESE_STOPWORDS, ENGLISH_STOPWORDS, JAPANESE_STOPWORDS, getStopwords, isStopword } from './stopwords'
 
-export { cleanText, isValidWord } from './text-utils'
+export {
+  cleanText,
+  isMediaPlaceholderContent,
+  isValidWord,
+  stripMediaPlaceholders,
+  stripVoiceTranscriptionPrefix,
+} from './text-utils'

--- a/packages/core/src/nlp/index.ts
+++ b/packages/core/src/nlp/index.ts
@@ -27,6 +27,7 @@ export { CHINESE_STOPWORDS, ENGLISH_STOPWORDS, JAPANESE_STOPWORDS, getStopwords,
 export {
   cleanText,
   isMediaPlaceholderContent,
+  isSystemMessageContent,
   isValidWord,
   stripMediaPlaceholders,
   stripVoiceTranscriptionPrefix,

--- a/packages/core/src/nlp/text-utils.test.ts
+++ b/packages/core/src/nlp/text-utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { cleanText } from './text-utils'
+import { cleanText, isMediaPlaceholderContent, stripVoiceTranscriptionPrefix } from './text-utils'
 
 describe('cleanText', () => {
   const cases = [
@@ -22,4 +22,14 @@ describe('cleanText', () => {
       assert.equal(cleanText(input), expected)
     })
   }
+
+  it('removes duration-bearing voice labels while retaining the transcription', () => {
+    assert.equal(cleanText('[语音 3秒] 这是测试语音内容。'), '这是测试语音内容')
+    assert.equal(stripVoiceTranscriptionPrefix('[语音 3秒] 这是测试语音内容。'), '这是测试语音内容。')
+  })
+
+  it('recognizes duration-bearing media-only content as a placeholder', () => {
+    assert.equal(isMediaPlaceholderContent('[语音 3秒]'), true)
+    assert.equal(isMediaPlaceholderContent('[语音 3秒] 有转写内容'), false)
+  })
 })

--- a/packages/core/src/nlp/text-utils.test.ts
+++ b/packages/core/src/nlp/text-utils.test.ts
@@ -1,6 +1,11 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { cleanText, isMediaPlaceholderContent, stripVoiceTranscriptionPrefix } from './text-utils'
+import {
+  cleanText,
+  isMediaPlaceholderContent,
+  isSystemMessageContent,
+  stripVoiceTranscriptionPrefix,
+} from './text-utils'
 
 describe('cleanText', () => {
   const cases = [
@@ -31,5 +36,23 @@ describe('cleanText', () => {
   it('recognizes duration-bearing media-only content as a placeholder', () => {
     assert.equal(isMediaPlaceholderContent('[语音 3秒]'), true)
     assert.equal(isMediaPlaceholderContent('[语音 3秒] 有转写内容'), false)
+  })
+
+  it('recognizes explicit system markers without treating bracketed emoji labels as system text', () => {
+    const cases = [
+      ['[系统] 对方赞了你分享的 图文', true],
+      ['【系统消息】你赞了对方分享的视频', true],
+      ['[System Message] shared a post', true],
+      ['[分享内容]', true],
+      ['【分享内容】', true],
+      ['[强壮]', false],
+      ['[躺平]', false],
+      ['[分享]', false],
+      ['我说“[系统]”这个词', false],
+    ] as const
+
+    for (const [input, expected] of cases) {
+      assert.equal(isSystemMessageContent(input), expected, input)
+    }
   })
 })

--- a/packages/core/src/nlp/text-utils.ts
+++ b/packages/core/src/nlp/text-utils.ts
@@ -23,6 +23,8 @@ const VOICE_TRANSCRIPTION_PREFIX_REGEX = new RegExp(
   `^\\s*\\[(?:语音|Voice|Audio)${MEDIA_PLACEHOLDER_DURATION_PATTERN}\\]\\s*`,
   'i'
 )
+const SYSTEM_MESSAGE_PREFIX_REGEX =
+  /^\s*(?:\[(?:系统(?:消息)?|分享内容|system(?:\s+message)?)\]|【(?:系统(?:消息)?|分享内容|system(?:\s+message)?)】)\s*/iu
 const BRACKET_EMOJI_PLACEHOLDER_REGEX =
   /(?:\[|【)([\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Letter}\p{Number}_-]{1,16})(?:\]|】)/gu
 const CJK_TEXT_REGEX = /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}]/u
@@ -139,6 +141,11 @@ export function stripMediaPlaceholders(text: string): string {
 /** Return the transcribed text after a leading voice-message label. */
 export function stripVoiceTranscriptionPrefix(text: string): string {
   return text.replace(VOICE_TRANSCRIPTION_PREFIX_REGEX, '').trim()
+}
+
+/** Identify an explicit system/share marker without classifying bracketed emoji labels as system text. */
+export function isSystemMessageContent(text: string): boolean {
+  return SYSTEM_MESSAGE_PREFIX_REGEX.test(text)
 }
 
 /** Whether the complete value is a media placeholder rather than message text. */

--- a/packages/core/src/nlp/text-utils.ts
+++ b/packages/core/src/nlp/text-utils.ts
@@ -8,8 +8,21 @@ const PUNCTUATION_REGEX = /[!"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~，。！？、�
 const URL_REGEX = /https?:\/\/[^\s]+/g
 const MENTION_REGEX = /@[^\s@]+/g
 const PURE_NUMBER_REGEX = /^\d+$/
-const SYSTEM_PLACEHOLDER_REGEX =
-  /\[(?:图片|视频|语音|文件|动画表情|表情|链接|位置|名片|红包|转账|音乐|Image|Video|Voice|File|Sticker|Link)\]/gi
+const MEDIA_PLACEHOLDER_NAME_PATTERN =
+  '(?:图片|视频|语音|文件|动画表情|表情|链接|位置|地理位置|名片|红包|转账|音乐|Image|Photo|Video|Voice|Audio|File|Sticker|Link|Location)'
+const MEDIA_PLACEHOLDER_DURATION_PATTERN = '(?:\\s+\\d+(?:\\.\\d+)?\\s*(?:秒|s))?'
+const SYSTEM_PLACEHOLDER_REGEX = new RegExp(
+  `\\[${MEDIA_PLACEHOLDER_NAME_PATTERN}${MEDIA_PLACEHOLDER_DURATION_PATTERN}\\]`,
+  'gi'
+)
+const MEDIA_PLACEHOLDER_ONLY_REGEX = new RegExp(
+  `^\\[${MEDIA_PLACEHOLDER_NAME_PATTERN}${MEDIA_PLACEHOLDER_DURATION_PATTERN}\\]$`,
+  'i'
+)
+const VOICE_TRANSCRIPTION_PREFIX_REGEX = new RegExp(
+  `^\\s*\\[(?:语音|Voice|Audio)${MEDIA_PLACEHOLDER_DURATION_PATTERN}\\]\\s*`,
+  'i'
+)
 const BRACKET_EMOJI_PLACEHOLDER_REGEX =
   /(?:\[|【)([\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Letter}\p{Number}_-]{1,16})(?:\]|】)/gu
 const CJK_TEXT_REGEX = /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}]/u
@@ -116,6 +129,21 @@ export function cleanText(text: string): string {
     .replace(PUNCTUATION_REGEX, ' ')
     .replace(/\s+/g, ' ')
     .trim()
+}
+
+/** Remove media placeholders, including duration-bearing labels such as `[语音 3秒]`. */
+export function stripMediaPlaceholders(text: string): string {
+  return text.replace(SYSTEM_PLACEHOLDER_REGEX, ' ')
+}
+
+/** Return the transcribed text after a leading voice-message label. */
+export function stripVoiceTranscriptionPrefix(text: string): string {
+  return text.replace(VOICE_TRANSCRIPTION_PREFIX_REGEX, '').trim()
+}
+
+/** Whether the complete value is a media placeholder rather than message text. */
+export function isMediaPlaceholderContent(text: string): boolean {
+  return MEDIA_PLACEHOLDER_ONLY_REGEX.test(text.trim())
 }
 
 /**

--- a/packages/core/src/query/__tests__/browser-word-frequency.test.ts
+++ b/packages/core/src/query/__tests__/browser-word-frequency.test.ts
@@ -119,6 +119,25 @@ describe('getBrowserWordFrequency', () => {
     assert.equal(result.uniqueWords, 2)
   })
 
+  it('keeps voice transcription words but removes the duration label', () => {
+    const insert = raw.prepare('INSERT INTO message (id, sender_id, ts, type, content) VALUES (?, ?, ?, ?, ?)')
+    insert.run(6, 1, 600, 0, '[Voice 3s] sample transcript')
+    insert.run(7, 1, 700, 0, '[Voice 3s] sample transcript')
+
+    const result = getBrowserWordFrequency(database, {
+      sessionId: 'session-one',
+      locale: 'en-US',
+      topN: 20,
+      minCount: 2,
+      posFilterMode: 'all',
+      enableStopwords: false,
+    })
+
+    const words = result.words.map((word) => word.word)
+    assert.ok(words.includes('sample'))
+    assert.ok(!words.includes('voice'))
+  })
+
   it('applies member, time, excluded-word, and excluded-message filters', () => {
     const result = getBrowserWordFrequency(database, {
       sessionId: 'session-one',

--- a/packages/core/src/query/__tests__/browser-word-frequency.test.ts
+++ b/packages/core/src/query/__tests__/browser-word-frequency.test.ts
@@ -138,6 +138,29 @@ describe('getBrowserWordFrequency', () => {
     assert.ok(!words.includes('voice'))
   })
 
+  it('excludes explicit system notifications from word frequency', () => {
+    const insert = raw.prepare('INSERT INTO message (id, sender_id, ts, type, content) VALUES (?, ?, ?, ?, ?)')
+    insert.run(8, 1, 800, 0, '[系统] 对方赞了你分享的 systemnoise')
+    insert.run(9, 1, 900, 0, '[系统] 对方赞了你分享的 systemnoise')
+    insert.run(10, 1, 1000, 5, '[强壮]')
+    insert.run(11, 1, 1100, 0, '[分享内容] share_noise')
+    insert.run(12, 1, 1200, 0, '[分享内容] share_noise')
+
+    const result = getBrowserWordFrequency(database, {
+      sessionId: 'session-one',
+      locale: 'en-US',
+      topN: 20,
+      minCount: 1,
+      posFilterMode: 'all',
+      enableStopwords: false,
+    })
+
+    const words = result.words.map((word) => word.word)
+    assert.ok(!words.includes('systemnoise'))
+    assert.ok(!words.includes('share_noise'))
+    assert.equal(result.totalMessages, 4)
+  })
+
   it('applies member, time, excluded-word, and excluded-message filters', () => {
     const result = getBrowserWordFrequency(database, {
       sessionId: 'session-one',

--- a/packages/core/src/query/advanced/languagePreference.ts
+++ b/packages/core/src/query/advanced/languagePreference.ts
@@ -5,9 +5,9 @@
  * 调用方负责提供对应平台的实现（Electron / Server 用 jieba，浏览器可降级）。
  */
 
-import type { TimeFilter } from '@openchatlab/shared-types'
+import { MessageType, type TimeFilter } from '@openchatlab/shared-types'
 import type { DatabaseAdapter } from '../../interfaces'
-import { stripMediaPlaceholders, stripVoiceTranscriptionPrefix } from '../../nlp'
+import { isSystemMessageContent, stripMediaPlaceholders, stripVoiceTranscriptionPrefix } from '../../nlp'
 import { buildTimeFilter } from '../filters'
 import { isSystemPlaceholderContent } from './text-filters'
 
@@ -45,6 +45,7 @@ const RE_EMOJI =
   /[\u{1F600}-\u{1F64F}\u{1F300}-\u{1F5FF}\u{1F680}-\u{1F6FF}\u{1F1E0}-\u{1F1FF}\u{2600}-\u{26FF}\u{2700}-\u{27BF}]/gu
 const RE_PUNCTUATION = /[!"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~，。！？、；：""''（）【】《》…—～·\s]/g
 const RE_PURE_NUMBER = /^\d+$/
+const LANGUAGE_ANALYSIS_MESSAGE_TYPES = [MessageType.TEXT, MessageType.EMOJI].join(', ')
 
 function cleanTextForNlp(text: string): string {
   return stripMediaPlaceholders(text)
@@ -88,8 +89,7 @@ export function getLanguagePreferenceAnalysis(db: DatabaseAdapter, params: Langu
 
   const { clause, params: filterParams } = buildTimeFilter(timeFilter)
   let whereClause = clause
-  const textFilter =
-    " COALESCE(m.account_name, '') != '系统消息' AND msg.type = 0 AND msg.content IS NOT NULL AND LENGTH(TRIM(msg.content)) >= 2"
+  const textFilter = ` COALESCE(m.account_name, '') != '系统消息' AND msg.type IN (${LANGUAGE_ANALYSIS_MESSAGE_TYPES}) AND msg.content IS NOT NULL AND LENGTH(TRIM(msg.content)) >= 2`
   if (whereClause.includes('WHERE')) {
     whereClause += ' AND ' + textFilter
   } else {
@@ -108,7 +108,7 @@ export function getLanguagePreferenceAnalysis(db: DatabaseAdapter, params: Langu
   const memberMessages = new Map<number, { name: string; messages: string[] }>()
   for (const row of rows) {
     const content = stripVoiceTranscriptionPrefix(row.content)
-    if (!content || isSystemPlaceholderContent(content)) continue
+    if (!content || isSystemMessageContent(content) || isSystemPlaceholderContent(content)) continue
 
     let entry = memberMessages.get(row.memberId)
     if (!entry) {

--- a/packages/core/src/query/advanced/languagePreference.ts
+++ b/packages/core/src/query/advanced/languagePreference.ts
@@ -7,6 +7,7 @@
 
 import type { TimeFilter } from '@openchatlab/shared-types'
 import type { DatabaseAdapter } from '../../interfaces'
+import { stripMediaPlaceholders, stripVoiceTranscriptionPrefix } from '../../nlp'
 import { buildTimeFilter } from '../filters'
 import { isSystemPlaceholderContent } from './text-filters'
 
@@ -46,7 +47,7 @@ const RE_PUNCTUATION = /[!"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~，。！？、；�
 const RE_PURE_NUMBER = /^\d+$/
 
 function cleanTextForNlp(text: string): string {
-  return text
+  return stripMediaPlaceholders(text)
     .replace(RE_URL, ' ')
     .replace(RE_MENTION, ' ')
     .replace(RE_EMOJI, ' ')
@@ -106,14 +107,15 @@ export function getLanguagePreferenceAnalysis(db: DatabaseAdapter, params: Langu
 
   const memberMessages = new Map<number, { name: string; messages: string[] }>()
   for (const row of rows) {
-    if (isSystemPlaceholderContent(row.content)) continue
+    const content = stripVoiceTranscriptionPrefix(row.content)
+    if (!content || isSystemPlaceholderContent(content)) continue
 
     let entry = memberMessages.get(row.memberId)
     if (!entry) {
       entry = { name: row.name, messages: [] }
       memberMessages.set(row.memberId, entry)
     }
-    entry.messages.push(row.content)
+    entry.messages.push(content)
   }
 
   const isChinese = locale.startsWith('zh')

--- a/packages/core/src/query/advanced/repeat.test.ts
+++ b/packages/core/src/query/advanced/repeat.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import Database from 'better-sqlite3'
+import { MessageType } from '@openchatlab/shared-types'
 import type { DatabaseAdapter, PreparedStatement, RunResult } from '../../interfaces'
 import { getLanguagePreferenceAnalysis } from './languagePreference'
 import { getCatchphraseAnalysis } from './repeat'
@@ -91,6 +92,7 @@ interface CatchphraseFixture {
   memberId: number
   content: string
   count: number
+  type?: number
 }
 
 function createCatchphraseDb(fixtures: CatchphraseFixture[]): DatabaseAdapter {
@@ -114,11 +116,17 @@ function createCatchphraseDb(fixtures: CatchphraseFixture[]): DatabaseAdapter {
       (2, 'bob', 'Bob', NULL);
   `)
 
-  const insert = database.prepare('INSERT INTO message (id, sender_id, ts, type, content) VALUES (?, ?, ?, 0, ?)')
+  const insert = database.prepare('INSERT INTO message (id, sender_id, ts, type, content) VALUES (?, ?, ?, ?, ?)')
   let messageId = 1
   for (const fixture of fixtures) {
     for (let index = 0; index < fixture.count; index += 1) {
-      insert.run(messageId, fixture.memberId, 1_700_000_000 + messageId, fixture.content)
+      insert.run(
+        messageId,
+        fixture.memberId,
+        1_700_000_000 + messageId,
+        fixture.type ?? MessageType.TEXT,
+        fixture.content
+      )
       messageId += 1
     }
   }
@@ -194,6 +202,24 @@ describe('getCatchphraseAnalysis', () => {
     assert.deepEqual(result.members[0]?.catchphrases, [{ content: '同一句测试转写', count: 2 }])
     db.close()
   })
+
+  it('filters explicit system notifications but keeps emoji labels', () => {
+    const db = createCatchphraseDb([
+      { memberId: 1, content: '[系统] 对方赞了你分享的 图文', count: 4 },
+      { memberId: 1, content: '[系统] 你赞了对方分享的 视频', count: 3 },
+      { memberId: 1, content: '[分享内容]', count: 5 },
+      { memberId: 1, content: '[强壮]', count: 4, type: MessageType.EMOJI },
+      { memberId: 1, content: '[躺平]', count: 3, type: MessageType.TEXT },
+    ])
+
+    const result = getCatchphraseAnalysis(db)
+
+    assert.deepEqual(result.members[0]?.catchphrases, [
+      { content: '[强壮]', count: 4 },
+      { content: '[躺平]', count: 3 },
+    ])
+    db.close()
+  })
 })
 
 describe('getLanguagePreferenceAnalysis', () => {
@@ -235,5 +261,27 @@ describe('getLanguagePreferenceAnalysis', () => {
       alice?.topWords.some((word: { word: string }) => word.word === 'sample'),
       true
     )
+  })
+
+  it('filters system notifications while retaining bracketed emoji phrases', () => {
+    const db = createRowsDb([
+      { memberId: 1, name: 'Alice', content: '[系统] 对方赞了你分享的 图文' },
+      { memberId: 1, name: 'Alice', content: '[系统] 对方赞了你分享的 图文' },
+      { memberId: 1, name: 'Alice', content: '[分享内容] share_noise' },
+      { memberId: 1, name: 'Alice', content: '[分享内容] share_noise' },
+      { memberId: 1, name: 'Alice', content: '[强壮]' },
+      { memberId: 1, name: 'Alice', content: '[强壮]' },
+      { memberId: 1, name: 'Alice', content: '[躺平]' },
+      { memberId: 1, name: 'Alice', content: '[躺平]' },
+    ])
+
+    const result = getLanguagePreferenceAnalysis(db, { locale: 'zh-CN' })
+    const alice = result.members.find((member: { name: string }) => member.name === 'Alice')
+
+    assert.equal(alice?.totalMessages, 4)
+    assert.deepEqual(alice?.catchphrases, [
+      { content: '[强壮]', count: 2 },
+      { content: '[躺平]', count: 2 },
+    ])
   })
 })

--- a/packages/core/src/query/advanced/repeat.test.ts
+++ b/packages/core/src/query/advanced/repeat.test.ts
@@ -170,6 +170,30 @@ describe('getCatchphraseAnalysis', () => {
     )
     db.close()
   })
+
+  it('shows voice transcriptions without the duration label', () => {
+    const db = createCatchphraseDb([
+      { memberId: 1, content: '[语音 3秒] 测试转写内容', count: 3 },
+      { memberId: 1, content: '[语音 2秒]', count: 5 },
+    ])
+
+    const result = getCatchphraseAnalysis(db)
+
+    assert.deepEqual(result.members[0]?.catchphrases, [{ content: '测试转写内容', count: 3 }])
+    db.close()
+  })
+
+  it('aggregates the same transcription when voice durations differ', () => {
+    const db = createCatchphraseDb([
+      { memberId: 1, content: '[语音 2秒] 同一句测试转写', count: 1 },
+      { memberId: 1, content: '[语音 3秒] 同一句测试转写', count: 1 },
+    ])
+
+    const result = getCatchphraseAnalysis(db)
+
+    assert.deepEqual(result.members[0]?.catchphrases, [{ content: '同一句测试转写', count: 2 }])
+    db.close()
+  })
 })
 
 describe('getLanguagePreferenceAnalysis', () => {
@@ -187,5 +211,29 @@ describe('getLanguagePreferenceAnalysis', () => {
     assert.equal(result.members[0]?.name, 'Bob')
     assert.equal(result.members[0]?.totalMessages, 2)
     assert.deepEqual(result.members[0]?.catchphrases, [{ content: 'noted', count: 2 }])
+  })
+
+  it('uses voice transcription text for language analysis instead of the duration label', () => {
+    const db = createRowsDb([
+      { memberId: 1, name: 'Alice', content: '[Voice 3s] sample transcript' },
+      { memberId: 1, name: 'Alice', content: '[Voice 3s] sample transcript' },
+      { memberId: 1, name: 'Alice', content: '[语音 2秒]' },
+      { memberId: 2, name: 'Bob', content: '普通文本' },
+      { memberId: 2, name: 'Bob', content: '普通文本' },
+    ])
+
+    const result = getLanguagePreferenceAnalysis(db, { locale: 'en-US' })
+    const alice = result.members.find((member: { name: string }) => member.name === 'Alice')
+
+    assert.equal(alice?.totalMessages, 2)
+    assert.deepEqual(alice?.catchphrases, [{ content: 'sample transcript', count: 2 }])
+    assert.equal(
+      alice?.topWords.some((word: { word: string }) => word.word === 'voice'),
+      false
+    )
+    assert.equal(
+      alice?.topWords.some((word: { word: string }) => word.word === 'sample'),
+      true
+    )
   })
 })

--- a/packages/core/src/query/advanced/repeat.ts
+++ b/packages/core/src/query/advanced/repeat.ts
@@ -2,9 +2,9 @@
  * 口头禅分析模块（平台无关）
  */
 
-import type { TimeFilter } from '@openchatlab/shared-types'
+import { MessageType, type TimeFilter } from '@openchatlab/shared-types'
 import type { DatabaseAdapter } from '../../interfaces'
-import { stripVoiceTranscriptionPrefix } from '../../nlp'
+import { isSystemMessageContent, stripVoiceTranscriptionPrefix } from '../../nlp'
 import { buildTimeFilter } from '../filters'
 import { isSystemPlaceholderContent } from './text-filters'
 
@@ -18,6 +18,7 @@ const VOICE_TRANSCRIPTION_SQL = `
         TRIM(msg.content) LIKE '[Audio] %' OR
         TRIM(msg.content) LIKE '[Audio %] %'
       `
+const CATCHPHRASE_MESSAGE_TYPES = [MessageType.TEXT, MessageType.EMOJI].join(', ')
 
 export interface CatchphraseItem {
   content: string
@@ -40,11 +41,9 @@ export function getCatchphraseAnalysis(db: DatabaseAdapter, filter?: TimeFilter)
 
   let whereClause = clause
   if (whereClause.includes('WHERE')) {
-    whereClause +=
-      " AND COALESCE(m.account_name, '') != '系统消息' AND msg.type = 0 AND msg.content IS NOT NULL AND LENGTH(TRIM(msg.content)) >= 2"
+    whereClause += ` AND COALESCE(m.account_name, '') != '系统消息' AND msg.type IN (${CATCHPHRASE_MESSAGE_TYPES}) AND msg.content IS NOT NULL AND LENGTH(TRIM(msg.content)) >= 2`
   } else {
-    whereClause =
-      " WHERE COALESCE(m.account_name, '') != '系统消息' AND msg.type = 0 AND msg.content IS NOT NULL AND LENGTH(TRIM(msg.content)) >= 2"
+    whereClause = ` WHERE COALESCE(m.account_name, '') != '系统消息' AND msg.type IN (${CATCHPHRASE_MESSAGE_TYPES}) AND msg.content IS NOT NULL AND LENGTH(TRIM(msg.content)) >= 2`
   }
 
   const rows = db
@@ -77,7 +76,7 @@ export function getCatchphraseAnalysis(db: DatabaseAdapter, filter?: TimeFilter)
 
   for (const row of rows) {
     const content = stripVoiceTranscriptionPrefix(row.content)
-    if (!content || isSystemPlaceholderContent(content)) continue
+    if (!content || isSystemMessageContent(content) || isSystemPlaceholderContent(content)) continue
 
     if (!memberMap.has(row.memberId)) {
       memberMap.set(row.memberId, {

--- a/packages/core/src/query/advanced/repeat.ts
+++ b/packages/core/src/query/advanced/repeat.ts
@@ -4,8 +4,20 @@
 
 import type { TimeFilter } from '@openchatlab/shared-types'
 import type { DatabaseAdapter } from '../../interfaces'
+import { stripVoiceTranscriptionPrefix } from '../../nlp'
 import { buildTimeFilter } from '../filters'
 import { isSystemPlaceholderContent } from './text-filters'
+
+// Keep one-off voice transcription rows in the grouped query so JavaScript can
+// normalize away duration labels before applying the repeated-phrase threshold.
+const VOICE_TRANSCRIPTION_SQL = `
+        TRIM(msg.content) LIKE '[语音] %' OR
+        TRIM(msg.content) LIKE '[语音 %] %' OR
+        TRIM(msg.content) LIKE '[Voice] %' OR
+        TRIM(msg.content) LIKE '[Voice %] %' OR
+        TRIM(msg.content) LIKE '[Audio] %' OR
+        TRIM(msg.content) LIKE '[Audio %] %'
+      `
 
 export interface CatchphraseItem {
   content: string
@@ -48,7 +60,7 @@ export function getCatchphraseAnalysis(db: DatabaseAdapter, filter?: TimeFilter)
       JOIN member m ON msg.sender_id = m.id
       ${whereClause}
       GROUP BY m.id, TRIM(msg.content)
-      HAVING COUNT(*) >= 2
+      HAVING COUNT(*) >= 2 OR (${VOICE_TRANSCRIPTION_SQL})
       ORDER BY m.id, count DESC
       `
     )
@@ -61,9 +73,11 @@ export function getCatchphraseAnalysis(db: DatabaseAdapter, filter?: TimeFilter)
   }>
 
   const memberMap = new Map<number, MemberCatchphrase>()
+  const phraseMaps = new Map<number, Map<string, CatchphraseItem>>()
 
   for (const row of rows) {
-    if (isSystemPlaceholderContent(row.content)) continue
+    const content = stripVoiceTranscriptionPrefix(row.content)
+    if (!content || isSystemPlaceholderContent(content)) continue
 
     if (!memberMap.has(row.memberId)) {
       memberMap.set(row.memberId, {
@@ -74,13 +88,23 @@ export function getCatchphraseAnalysis(db: DatabaseAdapter, filter?: TimeFilter)
       })
     }
 
-    const member = memberMap.get(row.memberId)!
-    if (member.catchphrases.length < 100) {
-      member.catchphrases.push({ content: row.content, count: row.count })
+    let phrases = phraseMaps.get(row.memberId)
+    if (!phrases) {
+      phrases = new Map<string, CatchphraseItem>()
+      phraseMaps.set(row.memberId, phrases)
     }
+    const existing = phrases.get(content)
+    if (existing) existing.count += Number(row.count)
+    else phrases.set(content, { content, count: Number(row.count) })
   }
 
   const members = Array.from(memberMap.values())
+  for (const member of members) {
+    member.catchphrases = [...(phraseMaps.get(member.memberId)?.values() ?? [])]
+      .filter((item) => item.count >= 2)
+      .sort((a, b) => b.count - a.count || a.content.localeCompare(b.content))
+      .slice(0, 100)
+  }
   members.sort((a, b) => {
     const countDifference = (b.catchphrases[0]?.count ?? 0) - (a.catchphrases[0]?.count ?? 0)
     return countDifference || a.memberId - b.memberId

--- a/packages/core/src/query/advanced/text-filters.ts
+++ b/packages/core/src/query/advanced/text-filters.ts
@@ -1,3 +1,5 @@
+import { isMediaPlaceholderContent } from '../../nlp'
+
 const SYSTEM_PLACEHOLDER_CONTENTS = new Set([
   '[图片]',
   '[视频]',
@@ -24,5 +26,6 @@ const SYSTEM_PLACEHOLDER_CONTENTS = new Set([
 ])
 
 export function isSystemPlaceholderContent(content: string): boolean {
-  return SYSTEM_PLACEHOLDER_CONTENTS.has(content.trim())
+  const trimmed = content.trim()
+  return SYSTEM_PLACEHOLDER_CONTENTS.has(trimmed) || isMediaPlaceholderContent(trimmed)
 }

--- a/packages/core/src/query/browser-word-frequency.ts
+++ b/packages/core/src/query/browser-word-frequency.ts
@@ -1,5 +1,13 @@
 import type { DatabaseAdapter } from '../interfaces'
-import { cleanText, isStopword, isValidWord, type WordFrequencyParams, type WordFrequencyResult } from '../nlp'
+import { MessageType } from '@openchatlab/shared-types'
+import {
+  cleanText,
+  isStopword,
+  isSystemMessageContent,
+  isValidWord,
+  type WordFrequencyParams,
+  type WordFrequencyResult,
+} from '../nlp'
 import { buildExcludeKeywordsConditions } from './message-sql'
 
 function tokenize(text: string, locale: string): string[] {
@@ -34,7 +42,7 @@ export function getBrowserWordFrequency(db: DatabaseAdapter, params: WordFrequen
   } = params
   const conditions = [
     "COALESCE(m.account_name, '') != '系统消息'",
-    'msg.type = 0',
+    `msg.type IN (${MessageType.TEXT}, ${MessageType.EMOJI})`,
     'msg.content IS NOT NULL',
     "TRIM(msg.content) != ''",
   ]
@@ -66,10 +74,11 @@ export function getBrowserWordFrequency(db: DatabaseAdapter, params: WordFrequen
        WHERE ${conditions.join(' AND ')}`
     )
     .all(...queryParams) as Array<{ content: string }>
+  const analyzableMessages = messages.filter((message) => !isSystemMessageContent(message.content))
   const excludedWords = new Set(excludeWords.map((word) => word.trim().toLocaleLowerCase(locale)).filter(Boolean))
   const frequencies = new Map<string, number>()
 
-  for (const message of messages) {
+  for (const message of analyzableMessages) {
     for (const rawWord of tokenize(message.content, locale)) {
       const word = rawWord.toLocaleLowerCase(locale)
       if (excludedWords.has(word)) continue
@@ -92,7 +101,7 @@ export function getBrowserWordFrequency(db: DatabaseAdapter, params: WordFrequen
       percentage: rankedTotal > 0 ? Math.round((count / rankedTotal) * 10_000) / 100 : 0,
     })),
     totalWords,
-    totalMessages: messages.length,
+    totalMessages: analyzableMessages.length,
     uniqueWords: filteredFrequencies.length,
   }
 }

--- a/packages/node-runtime/src/nlp/word-frequency.test.ts
+++ b/packages/node-runtime/src/nlp/word-frequency.test.ts
@@ -112,4 +112,26 @@ describe('computeWordFrequency excludeKeywords pushdown', () => {
     })
     assert.equal(wildcard.totalMessages, 3)
   })
+
+  it('excludes explicit system notifications while keeping emoji messages eligible', () => {
+    const insert = raw.prepare('INSERT INTO message (id, sender_id, ts, type, content) VALUES (?, ?, ?, ?, ?)')
+    insert.run(4, 1, 4000, 0, '[系统] 你赞了对方分享的 systemnoise')
+    insert.run(5, 1, 5000, 0, '[系统] 你赞了对方分享的 systemnoise')
+    insert.run(6, 1, 6000, 5, '[强壮]')
+    insert.run(7, 1, 7000, 0, '[分享内容] share_noise')
+    insert.run(8, 1, 8000, 0, '[分享内容] share_noise')
+
+    const result = computeWordFrequency(db, {
+      sessionId: 's1',
+      locale: 'en-US',
+      minCount: 1,
+      posFilterMode: 'all',
+      enableStopwords: false,
+    })
+
+    const words = result.words.map((word) => word.word)
+    assert.ok(!words.includes('systemnoise'))
+    assert.ok(!words.includes('share_noise'))
+    assert.equal(result.totalMessages, 4)
+  })
 })

--- a/packages/node-runtime/src/nlp/word-frequency.ts
+++ b/packages/node-runtime/src/nlp/word-frequency.ts
@@ -5,7 +5,8 @@
  * 供 Electron worker 和 Server HTTP 路由共用。
  */
 
-import { buildExcludeKeywordsConditions, type DatabaseAdapter } from '@openchatlab/core'
+import { buildExcludeKeywordsConditions, isSystemMessageContent, type DatabaseAdapter } from '@openchatlab/core'
+import { MessageType } from '@openchatlab/shared-types'
 import type {
   SupportedLocale,
   DictType,
@@ -44,7 +45,7 @@ function buildMessageQuery(
   }
 
   conditions.push("COALESCE(m.account_name, '') != '系统消息'")
-  conditions.push('msg.type = 0')
+  conditions.push(`msg.type IN (${MessageType.TEXT}, ${MessageType.EMOJI})`)
   conditions.push('msg.content IS NOT NULL')
   conditions.push("TRIM(msg.content) != ''")
 
@@ -83,7 +84,12 @@ export function computeWordFrequency(db: DatabaseAdapter, params: WordFrequencyP
     return { words: [], totalWords: 0, totalMessages: 0, uniqueWords: 0 }
   }
 
-  const texts = messages.map((m) => m.content)
+  const analyzableMessages = messages.filter((message) => !isSystemMessageContent(message.content))
+  if (analyzableMessages.length === 0) {
+    return { words: [], totalWords: 0, totalMessages: 0, uniqueWords: 0 }
+  }
+
+  const texts = analyzableMessages.map((m) => m.content)
 
   const segmentOptions = {
     minLength: minWordLength,
@@ -124,7 +130,7 @@ export function computeWordFrequency(db: DatabaseAdapter, params: WordFrequencyP
   return {
     words,
     totalWords: result.totalWords,
-    totalMessages: messages.length,
+    totalMessages: analyzableMessages.length,
     uniqueWords: result.uniqueWords,
     posTagStats,
   }

--- a/packages/parser/src/formats/chatlab-jsonl.test.ts
+++ b/packages/parser/src/formats/chatlab-jsonl.test.ts
@@ -84,6 +84,45 @@ test('ChatLab JSONL emits message batches and progress while reading', async () 
   }
 })
 
+test('preserves a duration-bearing voice transcription in the parsed message content', async () => {
+  const root = makeTempDir()
+  const filePath = path.join(root, 'voice-transcription.jsonl')
+  const transcription = '[语音 3秒] 这是测试语音内容。'
+  fs.writeFileSync(
+    filePath,
+    [
+      JSON.stringify({
+        _type: 'header',
+        chatlab: { version: '0.0.2', exportedAt: 1711468800 },
+        meta: { name: 'Voice transcription', platform: 'douyin', type: 'private' },
+      }),
+      JSON.stringify({ _type: 'member', platformId: 'member-1', accountName: 'Alice' }),
+      JSON.stringify({
+        _type: 'message',
+        sender: 'member-1',
+        accountName: 'Alice',
+        timestamp: 1711468800,
+        type: MessageType.TEXT,
+        content: transcription,
+        platformMessageId: 'voice-1',
+      }),
+    ].join('\n') + '\n',
+    'utf-8'
+  )
+
+  try {
+    const messages: Array<{ type: number; content: string | null }> = []
+    for await (const event of parseFileWithFormat('chatlab-jsonl', { filePath })) {
+      if (event.type === 'messages') {
+        messages.push(...event.data.map(({ type, content }) => ({ type, content })))
+      }
+    }
+    assert.deepEqual(messages, [{ type: MessageType.TEXT, content: transcription }])
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
 test('directory entry detection accepts a top-level ChatLab JSONL file', () => {
   const root = makeTempDir()
   const filePath = path.join(root, 'chat.jsonl')


### PR DESCRIPTION
- 您好，这个pr是我在个人使用中发现了一些小问题，前些日子使用[TeamBreakerr/douyin-chat-export](https://github.com/TeamBreakerr/douyin-chat-export)导出抖音聊天记录后，导入ChatLab想要进行分析，发现出来了很多还带着 `[语音 x秒]` 这样的前缀，同一句转写因为时长不同被算成好几句。还有类似于`对方赞了你分享的 图文`这类互动通知——它们是文本消息，而且一天重复几十次。如图所示，比较影响使用体验。
<img width="2543" height="1528" alt="image" src="https://github.com/user-attachments/assets/4d2cdef4-7d58-4cb3-b748-88442e792a14" />
- 所以本次改动将`[语音 x秒]`等官方提示在口头禅列表显示真实转写句子，同一句不同时长的合并计数；`[语音 2秒]` 这类纯占位不再出现；"对方赞了你分享的 图文"从口头禅、词频、语言偏好里全部消失；并且原始聊天记录不做任何改写，只动分析层。
- 测试用脱敏合成数据补了一轮回归（jsonl 导入、词频、语言偏好、口头禅），把这批边界都锁住了。