### PR TITLE
fix(analysis): omit members without repeated catchphrases

### DIFF
--- a/packages/core/src/query/advanced/repeat.test.ts
+++ b/packages/core/src/query/advanced/repeat.test.ts
@@ -203,6 +203,20 @@ describe('getCatchphraseAnalysis', () => {
     db.close()
   })
 
+  it('omits members whose normalized voice phrases never repeat', (t) => {
+    const db = createCatchphraseDb([
+      { memberId: 1, content: '[语音 3秒] 只转写一次', count: 1 },
+      { memberId: 2, content: '收到', count: 3 },
+    ])
+    t.after(() => db.close())
+
+    assert.deepEqual(
+      getCatchphraseAnalysis(db).members.map((member) => member.memberId),
+      [2]
+    )
+    assert.deepEqual(getCatchphraseAnalysis(db, { memberId: 1 }), { members: [] })
+  })
+
   it('filters explicit system notifications but keeps emoji labels', () => {
     const db = createCatchphraseDb([
       { memberId: 1, content: '[系统] 对方赞了你分享的 图文', count: 4 },

--- a/packages/core/src/query/advanced/repeat.ts
+++ b/packages/core/src/query/advanced/repeat.ts
@@ -109,5 +109,5 @@ export function getCatchphraseAnalysis(db: DatabaseAdapter, filter?: TimeFilter)
     return countDifference || a.memberId - b.memberId
   })
 
-  return { members }
+  return { members: members.filter((member) => member.catchphrases.length > 0) }
 }


### PR DESCRIPTION
Voice transcription normalization can remove every phrase for a member while leaving an empty member entry. Filter those entries from the result so overview and selected-member views retain their empty states.

Add a regression test for single-use transcriptions alongside another member with valid catchphrases.