### PR TITLE
feat(electron): add UI scale setting

### DIFF
--- a/apps/desktop/main/ipc/window.ts
+++ b/apps/desktop/main/ipc/window.ts
@@ -2,7 +2,7 @@
  * 窗口和文件系统操作 IPC 处理器
  */
 
-import { ipcMain, app, dialog, clipboard, shell, nativeTheme } from 'electron'
+import { ipcMain, app, dialog, clipboard, shell, nativeTheme, BrowserWindow } from 'electron'
 import * as fs from 'fs/promises'
 import { loadConfig, setConfigField } from '@openchatlab/config'
 import type { DesktopCloseBehavior } from '@openchatlab/shared-types'
@@ -237,6 +237,25 @@ export function registerWindowHandlers(ctx: IpcContext): void {
     try {
       setConfigField('desktop.close_behavior', behavior)
       if (behavior !== 'background') destroyWindowsTray()
+      return { success: true }
+    } catch (error) {
+      return { success: false, error: error instanceof Error ? error.message : String(error) }
+    }
+  })
+
+  // ==================== 界面缩放 ====================
+  ipcMain.handle('app:getUiScale', () => {
+    return loadConfig().desktop.ui_scale
+  })
+
+  ipcMain.handle('app:setUiScale', (event, scale: number) => {
+    if (typeof scale !== 'number' || !Number.isFinite(scale) || scale < 0.8 || scale > 2) {
+      return { success: false, error: 'Unsupported UI scale' }
+    }
+
+    try {
+      setConfigField('desktop.ui_scale', String(scale))
+      BrowserWindow.fromWebContents(event.sender)?.webContents.setZoomFactor(scale)
       return { success: true }
     } catch (error) {
       return { success: false, error: error instanceof Error ? error.message : String(error) }

--- a/apps/desktop/main/window/main-window.ts
+++ b/apps/desktop/main/window/main-window.ts
@@ -17,6 +17,7 @@ export interface MainWindowPaths {
 }
 
 export async function createMainWindow(paths: MainWindowPaths): Promise<BrowserWindow> {
+  const uiScale = loadConfig().desktop.ui_scale
   const windowOptions: Electron.BrowserWindowConstructorOptions = {
     width: 1180,
     height: 752,
@@ -28,6 +29,7 @@ export async function createMainWindow(paths: MainWindowPaths): Promise<BrowserW
       preload: paths.preloadPath,
       sandbox: false,
       devTools: true,
+      zoomFactor: uiScale,
     },
   }
 
@@ -44,6 +46,11 @@ export async function createMainWindow(paths: MainWindowPaths): Promise<BrowserW
 
   const win = new BrowserWindow(windowOptions)
   currentMainWindow = win
+
+  // Chromium may restore a persisted per-origin zoom level, which overrides zoomFactor.
+  win.webContents.on('did-finish-load', () => {
+    win.webContents.setZoomFactor(uiScale)
+  })
 
   win.once('ready-to-show', () => {
     currentMainWindow?.show()

--- a/apps/desktop/main/window/main-window.ts
+++ b/apps/desktop/main/window/main-window.ts
@@ -48,8 +48,10 @@ export async function createMainWindow(paths: MainWindowPaths): Promise<BrowserW
   currentMainWindow = win
 
   // Chromium may restore a persisted per-origin zoom level, which overrides zoomFactor.
+  // Read the config again here: the renderer is reloaded after a crash, and the
+  // setting may have changed since the window was created.
   win.webContents.on('did-finish-load', () => {
-    win.webContents.setZoomFactor(uiScale)
+    win.webContents.setZoomFactor(loadConfig().desktop.ui_scale)
   })
 
   win.once('ready-to-show', () => {

--- a/apps/desktop/preload/apis/core.ts
+++ b/apps/desktop/preload/apis/core.ts
@@ -123,5 +123,11 @@ export const extendedApi = {
     setDesktopCloseBehavior: (behavior: DesktopCloseBehavior): Promise<{ success: boolean; error?: string }> => {
       return ipcRenderer.invoke('app:setDesktopCloseBehavior', behavior)
     },
+    getUiScale: (): Promise<number> => {
+      return ipcRenderer.invoke('app:getUiScale')
+    },
+    setUiScale: (scale: number): Promise<{ success: boolean; error?: string }> => {
+      return ipcRenderer.invoke('app:setUiScale', scale)
+    },
   },
 }

--- a/apps/desktop/preload/index.d.ts
+++ b/apps/desktop/preload/index.d.ts
@@ -194,6 +194,8 @@ interface Api {
     setOpenAtLogin: (enabled: boolean) => Promise<{ success: boolean; error?: string }>
     getDesktopCloseBehavior: () => Promise<DesktopCloseBehavior>
     setDesktopCloseBehavior: (behavior: DesktopCloseBehavior) => Promise<{ success: boolean; error?: string }>
+    getUiScale: () => Promise<number>
+    setUiScale: (scale: number) => Promise<{ success: boolean; error?: string }>
   }
 }
 

--- a/packages/config/src/schema.test.ts
+++ b/packages/config/src/schema.test.ts
@@ -35,3 +35,19 @@ test('accepts supported Windows close behaviors and rejects invalid values', () 
   assert.throws(() => configSchema.parse({ desktop: { close_behavior: 'ask' } }))
   assert.throws(() => configSchema.parse({ desktop: { close_behavior: 'hide-forever' } }))
 })
+
+test('defaults the desktop UI scale to 1', () => {
+  const config = configSchema.parse({})
+
+  assert.equal(config.desktop.ui_scale, 1)
+})
+
+test('accepts supported desktop UI scales and rejects out-of-range or non-numeric values', () => {
+  for (const uiScale of [0.8, 1.25, 2]) {
+    assert.equal(configSchema.parse({ desktop: { ui_scale: uiScale } }).desktop.ui_scale, uiScale)
+  }
+
+  for (const uiScale of [0.5, 3, '1']) {
+    assert.throws(() => configSchema.parse({ desktop: { ui_scale: uiScale } }))
+  }
+})

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -48,6 +48,7 @@ export const cliConfigSchema = z.object({
 
 export const desktopConfigSchema = z.object({
   close_behavior: z.enum(['background', 'quit']).default('background'),
+  ui_scale: z.number().min(0.8).max(2).default(1),
 })
 
 export const configSchema = z.object({

--- a/src/components/common/Settings/BasicSettingsTab.vue
+++ b/src/components/common/Settings/BasicSettingsTab.vue
@@ -40,6 +40,12 @@ const isWindowsDesktop =
 const desktopCloseBehavior = ref<DesktopCloseBehavior>('background')
 let savedDesktopCloseBehavior: DesktopCloseBehavior = 'background'
 
+// UI Scale
+const UI_SCALE_PRESETS = [0.9, 1, 1.1, 1.25, 1.5]
+const uiScale = ref('1')
+let savedUiScale = '1'
+const uiScaleOptions = UI_SCALE_PRESETS.map((scale) => ({ label: `${Math.round(scale * 100)}%`, value: String(scale) }))
+
 onMounted(async () => {
   if (!IS_ELECTRON) {
     isPackaged.value = false
@@ -59,6 +65,13 @@ onMounted(async () => {
     } catch {
       desktopCloseBehavior.value = 'background'
     }
+  }
+
+  try {
+    savedUiScale = String(await usePlatformService().getUiScale())
+    uiScale.value = savedUiScale
+  } catch {
+    uiScale.value = '1'
   }
 })
 
@@ -81,6 +94,17 @@ async function handleDesktopCloseBehaviorChange(value: string | number) {
     savedDesktopCloseBehavior = nextBehavior
   } else {
     desktopCloseBehavior.value = savedDesktopCloseBehavior
+  }
+}
+
+async function handleUiScaleChange(value: string | number) {
+  const nextScale = String(value)
+  uiScale.value = nextScale
+  const result = await usePlatformService().setUiScale(Number(nextScale))
+  if (result.success) {
+    savedUiScale = nextScale
+  } else {
+    uiScale.value = savedUiScale
   }
 }
 
@@ -215,6 +239,28 @@ const desktopCloseBehaviorOptions = computed(() => [
             <UTabs v-model="colorMode" size="sm" class="gap-0" :items="colorModeOptions"></UTabs>
           </div>
         </div>
+        <template v-if="IS_ELECTRON">
+          <div class="border-t border-gray-200 dark:border-gray-700"></div>
+          <div class="flex items-center justify-between p-4">
+            <div class="flex-1 pr-4">
+              <p class="text-sm font-medium text-gray-900 dark:text-white">
+                {{ t('settings.basic.appearance.uiScale') }}
+              </p>
+              <p class="text-xs text-gray-500 dark:text-gray-400">
+                {{ t('settings.basic.appearance.uiScaleDesc') }}
+              </p>
+            </div>
+            <div class="w-64">
+              <UTabs
+                :model-value="uiScale"
+                size="sm"
+                class="gap-0"
+                :items="uiScaleOptions"
+                @update:model-value="handleUiScaleChange"
+              ></UTabs>
+            </div>
+          </div>
+        </template>
         <div class="border-t border-gray-200 dark:border-gray-700"></div>
         <div class="flex items-center justify-between p-4">
           <div class="flex-1 pr-4">

--- a/src/i18n/locales/en-US/settings.json
+++ b/src/i18n/locales/en-US/settings.json
@@ -34,6 +34,8 @@
     "appearance": {
       "title": "Appearance",
       "themeMode": "Theme Mode",
+      "uiScale": "UI scale",
+      "uiScaleDesc": "Adjust the size of the whole interface and text",
       "insightCardTheme": "Insight card colors",
       "insightCardThemeOption": "Color scheme {index}",
       "auto": "System",

--- a/src/i18n/locales/ja-JP/settings.json
+++ b/src/i18n/locales/ja-JP/settings.json
@@ -34,6 +34,8 @@
     "appearance": {
       "title": "外観設定",
       "themeMode": "テーマモード",
+      "uiScale": "画面の拡大率",
+      "uiScaleDesc": "画面全体と文字の大きさを調整します",
       "insightCardTheme": "インサイトカードの配色",
       "insightCardThemeOption": "配色 {index}",
       "auto": "システムに従う",

--- a/src/i18n/locales/zh-CN/settings.json
+++ b/src/i18n/locales/zh-CN/settings.json
@@ -34,6 +34,8 @@
     "appearance": {
       "title": "外观设置",
       "themeMode": "主题模式",
+      "uiScale": "界面缩放",
+      "uiScaleDesc": "调整整体界面和文字的大小",
       "insightCardTheme": "洞察卡片配色",
       "insightCardThemeOption": "配色 {index}",
       "auto": "跟随系统",

--- a/src/i18n/locales/zh-TW/settings.json
+++ b/src/i18n/locales/zh-TW/settings.json
@@ -34,6 +34,8 @@
     "appearance": {
       "title": "外觀設定",
       "themeMode": "主題模式",
+      "uiScale": "介面縮放",
+      "uiScaleDesc": "調整整體介面和文字的大小",
       "insightCardTheme": "洞察卡片配色",
       "insightCardThemeOption": "配色 {index}",
       "auto": "依系統設定",

--- a/src/services/platform/browser.ts
+++ b/src/services/platform/browser.ts
@@ -49,6 +49,14 @@ export class BrowserPlatformAdapter implements PlatformAdapter {
     return { success: false, error: 'Desktop close behavior is not available in Web WASM' }
   }
 
+  async getUiScale(): Promise<number> {
+    return 1
+  }
+
+  async setUiScale(_scale: number): Promise<{ success: boolean; error?: string }> {
+    return { success: false, error: 'UI scale is only available on desktop' }
+  }
+
   async getAnalyticsEnabled(): Promise<boolean> {
     return false
   }

--- a/src/services/platform/cli-web.ts
+++ b/src/services/platform/cli-web.ts
@@ -56,6 +56,14 @@ export class CliWebPlatformAdapter implements PlatformAdapter {
     return { success: false, error: 'Not available in CLI Web' }
   }
 
+  async getUiScale(): Promise<number> {
+    return 1
+  }
+
+  async setUiScale(_scale: number): Promise<{ success: boolean; error?: string }> {
+    return { success: false, error: 'UI scale is only available on desktop' }
+  }
+
   async getAnalyticsEnabled(): Promise<boolean> {
     try {
       const resp = await fetchWithAuth('/_web/telemetry/enabled')

--- a/src/services/platform/electron.ts
+++ b/src/services/platform/electron.ts
@@ -34,6 +34,14 @@ export class ElectronPlatformAdapter implements PlatformAdapter {
     return window.api.app.setDesktopCloseBehavior(behavior)
   }
 
+  getUiScale(): Promise<number> {
+    return window.api.app.getUiScale()
+  }
+
+  setUiScale(scale: number): Promise<{ success: boolean; error?: string }> {
+    return window.api.app.setUiScale(scale)
+  }
+
   getAnalyticsEnabled(): Promise<boolean> {
     return window.api.app.getAnalyticsEnabled()
   }

--- a/src/services/platform/types.ts
+++ b/src/services/platform/types.ts
@@ -48,6 +48,8 @@ export interface PlatformAdapter {
   setOpenAtLogin(enabled: boolean): Promise<{ success: boolean; error?: string }>
   getDesktopCloseBehavior(): Promise<DesktopCloseBehavior>
   setDesktopCloseBehavior(behavior: DesktopCloseBehavior): Promise<{ success: boolean; error?: string }>
+  getUiScale(): Promise<number>
+  setUiScale(scale: number): Promise<{ success: boolean; error?: string }>
 
   getAnalyticsEnabled(): Promise<boolean>
   setAnalyticsEnabled(enabled: boolean): Promise<{ success: boolean }>


### PR DESCRIPTION
Closes #445

## 改动

- 设置 › 外观设置新增「界面缩放」，五档 90% / 100% / 110% / 125% / 150%，仅桌面端显示。
- 持久化到 `~/.chatlab/config.toml` 的 `desktop.ui_scale`（范围 0.8–2，默认 1），沿用 `desktop.close_behavior` 的 schema / IPC / preload / 平台适配器模式。
- 主进程建窗时 `webPreferences.zoomFactor` 直接取配置值，`did-finish-load` 后再 `setZoomFactor` 一次，压过 Chromium 可能持久化的站点缩放级别，避免首帧先 100% 再跳变。

## 为什么是页面缩放而不是字号

- 缩放让文字、图标和 ECharts 画布一起放大且保持清晰（DPR 随之变化）；只改根字号的话 rem 单位跟着变、px 图标和图表字号不变，比例失调。#445 的截图正是图表页。
- Web WASM / CLI Web 的浏览器自带 Ctrl + / - 并按站点持久化，所以只做桌面端。

## 已知限制

- Electron 默认菜单的 Zoom In / Out / Actual Size 快捷键仍可临时缩放，不写回配置（Electron 的 zoom 菜单角色没有可拦截的事件）。

## 验证

- `pnpm run type-check:all`、`eslint`、`prettier --check`、`pnpm test -- packages/config/src/schema.test.ts` 全绿；新增 2 个表驱动测试（默认值；范围与类型校验）。
- 未在 Windows 上验证自定义标题栏 overlay 与缩放的组合，麻烦维护者看一眼。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
