### PR TITLE
docs(contributing): build chatlab-mcp before running pnpm test

### DIFF
--- a/docs/cn/contributing/development.md
+++ b/docs/cn/contributing/development.md
@@ -150,7 +150,7 @@ CHATLAB_ALLOW_INCOMPATIBLE_DATA_DIR=1
 - 修复会影响用户数据、业务逻辑、异步任务、缓存状态、跨端共享 service、公开 API 契约、导入解析、去重逻辑、权限认证、AI 工具 allowlist、配置/API key 迁移或数据库 schema/迁移的行为 bug 时，必须优先补能失败的回归测试。
 - 只改 UI 文案、i18n key/翻译、样式、类型声明、日志、注释、无行为变化的小重构，或修复低风险展示细节时，可以不新增测试，但仍需运行相关类型检查、lint 和 format；不要为了低价值页面文案或源码字符串扫描新增脆弱测试。
 - 日常默认运行 `pnpm test`；需要优先验证相关文件时运行 `pnpm test -- path/to/file.test.ts`。
-- 首次运行 `pnpm test` 前先执行 `pnpm --filter chatlab-mcp build`：`apps/cli` 通过 workspace 依赖导入 `chatlab-mcp` 的构建产物，未构建时相关测试会以 `ERR_MODULE_NOT_FOUND` 失败。CI 的测试工作流已包含这一步。
+- 运行 `pnpm test` 前先执行 `pnpm --filter chatlab-mcp build`，修改 `packages/mcp-server/src` 后也要重新构建：`apps/cli` 通过 workspace 依赖导入 `chatlab-mcp` 的构建产物，未构建时相关测试会以 `ERR_MODULE_NOT_FOUND` 失败，产物过期时测试跑的是旧代码。CI 的测试工作流已包含这一步。
 - `pnpm test` 默认只包含单元/集成测试，不应依赖真实 LLM、真实 Electron、真实浏览器、真实网络或长时间 E2E。
 - 与单个业务模块强相关的单元测试就近放在被测文件同目录，命名为 `*.test.ts` 或 `*.test.js`。
 - 跨模块、集成、E2E、测试工具或归属不明显的测试放在根目录 `tests/`。

--- a/docs/cn/contributing/development.md
+++ b/docs/cn/contributing/development.md
@@ -150,6 +150,7 @@ CHATLAB_ALLOW_INCOMPATIBLE_DATA_DIR=1
 - 修复会影响用户数据、业务逻辑、异步任务、缓存状态、跨端共享 service、公开 API 契约、导入解析、去重逻辑、权限认证、AI 工具 allowlist、配置/API key 迁移或数据库 schema/迁移的行为 bug 时，必须优先补能失败的回归测试。
 - 只改 UI 文案、i18n key/翻译、样式、类型声明、日志、注释、无行为变化的小重构，或修复低风险展示细节时，可以不新增测试，但仍需运行相关类型检查、lint 和 format；不要为了低价值页面文案或源码字符串扫描新增脆弱测试。
 - 日常默认运行 `pnpm test`；需要优先验证相关文件时运行 `pnpm test -- path/to/file.test.ts`。
+- 首次运行 `pnpm test` 前先执行 `pnpm --filter chatlab-mcp build`：`apps/cli` 通过 workspace 依赖导入 `chatlab-mcp` 的构建产物，未构建时相关测试会以 `ERR_MODULE_NOT_FOUND` 失败。CI 的测试工作流已包含这一步。
 - `pnpm test` 默认只包含单元/集成测试，不应依赖真实 LLM、真实 Electron、真实浏览器、真实网络或长时间 E2E。
 - 与单个业务模块强相关的单元测试就近放在被测文件同目录，命名为 `*.test.ts` 或 `*.test.js`。
 - 跨模块、集成、E2E、测试工具或归属不明显的测试放在根目录 `tests/`。

--- a/docs/en/contributing/development.md
+++ b/docs/en/contributing/development.md
@@ -148,6 +148,7 @@ Compatibility-related changes should cover:
 - After changing public docs, run `pnpm docs:build` or targeted formatting checks for the changed Markdown/config files.
 - After changing shared cross-platform logic, confirm Electron and CLI Web entry points do not diverge in behavior.
 - Daily default test command is `pnpm test`; to prioritize related tests, run `pnpm test -- path/to/file.test.ts`.
+- Run `pnpm --filter chatlab-mcp build` before the first `pnpm test`: `apps/cli` imports the built output of `chatlab-mcp` through the workspace dependency, so the related tests fail with `ERR_MODULE_NOT_FOUND` until it is built. The CI test workflow already includes this step.
 - `pnpm test` should include only unit/integration tests and must not depend on real LLMs, real Electron, real browsers, real network, or long-running E2E.
 - Unit tests tightly coupled to one business module should live next to the tested file and use `*.test.ts` or `*.test.js`.
 - Cross-module, integration, E2E, test utility, or unclear-ownership tests should live in the root `tests/` directory.

--- a/docs/en/contributing/development.md
+++ b/docs/en/contributing/development.md
@@ -148,7 +148,7 @@ Compatibility-related changes should cover:
 - After changing public docs, run `pnpm docs:build` or targeted formatting checks for the changed Markdown/config files.
 - After changing shared cross-platform logic, confirm Electron and CLI Web entry points do not diverge in behavior.
 - Daily default test command is `pnpm test`; to prioritize related tests, run `pnpm test -- path/to/file.test.ts`.
-- Run `pnpm --filter chatlab-mcp build` before the first `pnpm test`: `apps/cli` imports the built output of `chatlab-mcp` through the workspace dependency, so the related tests fail with `ERR_MODULE_NOT_FOUND` until it is built. The CI test workflow already includes this step.
+- Run `pnpm --filter chatlab-mcp build` before `pnpm test`, and again after changing `packages/mcp-server/src`: `apps/cli` imports the built output of `chatlab-mcp` through the workspace dependency, so the related tests fail with `ERR_MODULE_NOT_FOUND` until it is built and run against stale code when the build is outdated. The CI test workflow already includes this step.
 - `pnpm test` should include only unit/integration tests and must not depend on real LLMs, real Electron, real browsers, real network, or long-running E2E.
 - Unit tests tightly coupled to one business module should live next to the tested file and use `*.test.ts` or `*.test.js`.
 - Cross-module, integration, E2E, test utility, or unclear-ownership tests should live in the root `tests/` directory.


### PR DESCRIPTION
## 问题

新 clone 后直接 `pnpm test`，`apps/cli/src/runtime-compat-startup.test.ts` 会崩：

```
Error: Cannot find package '.../apps/cli/node_modules/chatlab-mcp/dist/index.mjs' imported from .../apps/cli/src/mcp.ts
```

`apps/cli` 通过 workspace 依赖导入 `chatlab-mcp` 的构建产物；CI 的测试工作流已有 `pnpm --filter chatlab-mcp build` 这一步（`.github/workflows/test.yml`），但开发指南没写。

## 改动

中英文开发指南「测试与检查」各加一条：首次 `pnpm test` 前先 `pnpm --filter chatlab-mcp build`。各 1 行，无其他格式改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
